### PR TITLE
fix: decode mermaid entities in flowchart subgraph titles

### DIFF
--- a/crates/merman-core/src/diagrams/flowchart.rs
+++ b/crates/merman-core/src/diagrams/flowchart.rs
@@ -405,10 +405,11 @@ pub fn parse_flowchart_model_for_render(
 }
 
 fn flow_subgraph_to_json(sg: FlowSubGraph) -> Value {
+    let title = crate::entities::decode_mermaid_entities_to_unicode(&sg.title).into_owned();
     json!({
         "id": sg.id,
         "nodes": sg.nodes,
-        "title": sg.title,
+        "title": title,
         "classes": sg.classes,
         "styles": sg.styles,
         "dir": sg.dir,
@@ -420,7 +421,7 @@ fn flow_subgraph_to_model(sg: FlowSubGraph) -> FlowSubgraph {
     FlowSubgraph {
         id: sg.id,
         nodes: sg.nodes,
-        title: sg.title,
+        title: crate::entities::decode_mermaid_entities_to_unicode(&sg.title).into_owned(),
         classes: sg.classes,
         styles: sg.styles,
         dir: sg.dir,


### PR DESCRIPTION
## Summary

- Flowchart subgraph titles are not passed through `decode_mermaid_entities_to_unicode()`, causing encoded placeholders (e.g. `ﬂ°°40¶ß` for `(`) to appear in the rendered SVG output
- Node labels and edge labels already have this decoding applied, but `flow_subgraph_to_json()` and `flow_subgraph_to_model()` emit `sg.title` raw
- This PR applies the same entity decoding to subgraph titles in both output paths

## Reproduction

```mermaid
flowchart TD
    subgraph sg1["useCollaboration#40;#40;#41; => noteId#41;"]
        A["node#40;test#41;"]
    end
```

**Before:** Subgraph title renders as `useCollaborationﬂ°°40¶ßﬂ°°40¶ßﬂ°°41¶ß => noteIdﬂ°°41¶ß`
**After:** Subgraph title renders as `useCollaboration(() => noteId)`

Node label `A` already decodes correctly in both cases.

## Test plan

- [x] All 88 existing `merman-core` flowchart tests pass
- [x] Verified fix with a standalone test rendering the above diagram