### PR TITLE
fix(render): fix journey diagram rendering bugs in resvg pipeline

### DIFF
--- a/crates/merman-render/src/svg/fallback.rs
+++ b/crates/merman-render/src/svg/fallback.rs
@@ -98,9 +98,13 @@ pub fn foreign_object_label_fallback_svg_text(svg: &str) -> String {
 
             out.push_str(&svg[lt..i_next]);
 
+            // Skip generating overlay fallbacks for foreignObjects inside <switch> elements,
+            // as those already contain their own <text> fallback siblings.
+            let inside_switch = svg[..lt].trim_end().ends_with("<switch>");
+
             let width = parse_attr_f64(tag, "width").unwrap_or(0.0);
             let height = parse_attr_f64(tag, "height").unwrap_or(0.0);
-            if width > 0.0 && height > 0.0 {
+            if width > 0.0 && height > 0.0 && !inside_switch {
                 let x = parse_attr_f64(tag, "x").unwrap_or(0.0);
                 let y = parse_attr_f64(tag, "y").unwrap_or(0.0);
                 let base = sum_translate(&g_stack);
@@ -231,6 +235,21 @@ pub fn foreign_object_label_fallback_svg_text(svg: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::foreign_object_label_fallback_svg_text;
+
+    #[test]
+    fn foreign_object_inside_switch_does_not_generate_overlay() {
+        let svg = r##"<svg xmlns="http://www.w3.org/2000/svg"><switch><foreignObject x="150" y="50" width="550" height="50"><div class="journey-section" xmlns="http://www.w3.org/1999/xhtml" style="display: table; height: 100%; width: 100%;"><div class="label" style="display: table-cell; text-align: center; vertical-align: middle;">Go to work</div></div></foreignObject><text x="425" y="75" fill="#333"><tspan x="425" dy="0">Go to work</tspan></text></switch></svg>"##;
+        let out = foreign_object_label_fallback_svg_text(svg);
+        assert_eq!(
+            out.matches("Go to work").count(),
+            2,
+            "should keep exactly 2 occurrences (foreignObject + text fallback), no overlay added: {out}"
+        );
+        assert!(
+            !out.contains(r#"data-merman-foreignobject="fallback""#),
+            "should not generate fallback overlay for switch-wrapped foreignObject: {out}"
+        );
+    }
 
     #[test]
     fn foreign_object_overlay_accounts_for_parent_translate() {

--- a/crates/merman-render/src/svg/fallback.rs
+++ b/crates/merman-render/src/svg/fallback.rs
@@ -98,13 +98,11 @@ pub fn foreign_object_label_fallback_svg_text(svg: &str) -> String {
 
             out.push_str(&svg[lt..i_next]);
 
-            // Skip generating overlay fallbacks for foreignObjects inside <switch> elements,
-            // as those already contain their own <text> fallback siblings.
-            let inside_switch = svg[..lt].trim_end().ends_with("<switch>");
+            let from_switch = tag.contains(r#"data-merman-switch="true""#);
 
             let width = parse_attr_f64(tag, "width").unwrap_or(0.0);
             let height = parse_attr_f64(tag, "height").unwrap_or(0.0);
-            if width > 0.0 && height > 0.0 && !inside_switch {
+            if width > 0.0 && height > 0.0 {
                 let x = parse_attr_f64(tag, "x").unwrap_or(0.0);
                 let y = parse_attr_f64(tag, "y").unwrap_or(0.0);
                 let base = sum_translate(&g_stack);
@@ -120,9 +118,15 @@ pub fn foreign_object_label_fallback_svg_text(svg: &str) -> String {
 
                 let raw_lines = htmlish_to_text_lines(inner);
                 if !raw_lines.is_empty() {
+                    let source_attr = if from_switch {
+                        r#" data-merman-foreignobject-source="switch-native-fallback""#
+                    } else {
+                        ""
+                    };
                     overlays.push_str(&format!(
-                        r#"<g data-merman-foreignobject="fallback" class="{}">"#,
-                        class_attr_tokens(&g_stack, inner, "merman-foreignobject-fallback")
+                        r#"<g data-merman-foreignobject="fallback"{source} class="{cls}">"#,
+                        source = source_attr,
+                        cls = class_attr_tokens(&g_stack, inner, "merman-foreignobject-fallback")
                     ));
 
                     let wants_label_bkg = inner.contains("labelBkg");
@@ -237,17 +241,16 @@ mod tests {
     use super::foreign_object_label_fallback_svg_text;
 
     #[test]
-    fn foreign_object_inside_switch_does_not_generate_overlay() {
-        let svg = r##"<svg xmlns="http://www.w3.org/2000/svg"><switch><foreignObject x="150" y="50" width="550" height="50"><div class="journey-section" xmlns="http://www.w3.org/1999/xhtml" style="display: table; height: 100%; width: 100%;"><div class="label" style="display: table-cell; text-align: center; vertical-align: middle;">Go to work</div></div></foreignObject><text x="425" y="75" fill="#333"><tspan x="425" dy="0">Go to work</tspan></text></switch></svg>"##;
+    fn foreign_object_with_switch_tag_generates_tagged_fallback() {
+        let svg = r##"<svg xmlns="http://www.w3.org/2000/svg"><switch><foreignObject x="150" y="50" width="550" height="50" data-merman-switch="true"><div class="journey-section" xmlns="http://www.w3.org/1999/xhtml" style="display: table; height: 100%; width: 100%;"><div class="label" style="display: table-cell; text-align: center; vertical-align: middle;">Go to work</div></div></foreignObject><text x="425" y="75" fill="#333"><tspan x="425" dy="0">Go to work</tspan></text></switch></svg>"##;
         let out = foreign_object_label_fallback_svg_text(svg);
-        assert_eq!(
-            out.matches("Go to work").count(),
-            2,
-            "should keep exactly 2 occurrences (foreignObject + text fallback), no overlay added: {out}"
+        assert!(
+            out.contains(r#"data-merman-foreignobject="fallback""#),
+            "should generate fallback overlay: {out}"
         );
         assert!(
-            !out.contains(r#"data-merman-foreignobject="fallback""#),
-            "should not generate fallback overlay for switch-wrapped foreignObject: {out}"
+            out.contains(r#"data-merman-foreignobject-source="switch-native-fallback""#),
+            "fallback should be tagged with switch source: {out}"
         );
     }
 

--- a/crates/merman-render/src/svg/parity/journey/render.rs
+++ b/crates/merman-render/src/svg/parity/journey/render.rs
@@ -286,7 +286,7 @@ pub(crate) fn render_journey_diagram_svg_model(
         out.push_str("<switch>");
         let _ = write!(
             out,
-            r#"<foreignObject x="{x}" y="{y}" width="{w}" height="{h}">"#,
+            r#"<foreignObject x="{x}" y="{y}" width="{w}" height="{h}" data-merman-switch="true">"#,
             x = fmt(x),
             y = fmt(y),
             w = fmt(width),

--- a/crates/merman-render/src/svg/parity/journey/render.rs
+++ b/crates/merman-render/src/svg/parity/journey/render.rs
@@ -264,6 +264,7 @@ pub(crate) fn render_journey_diagram_svg_model(
         class: &str,
         text_box: JourneyTextBox,
         style: JourneyTextStyle<'_>,
+        text_fill: &str,
     ) {
         let JourneyTextBox {
             x,
@@ -278,6 +279,7 @@ pub(crate) fn render_journey_diagram_svg_model(
         let content_esc = escape_xml(content);
         let class_esc = escape_attr(class);
         let font_family_esc = escape_attr(task_font_family);
+        let fill_esc = escape_attr(text_fill);
         let cx = x + width / 2.0;
         let cy = y + height / 2.0;
 
@@ -304,9 +306,10 @@ pub(crate) fn render_journey_diagram_svg_model(
             let dy = (i as f64) * task_font_size - (task_font_size * (n - 1.0)) / 2.0;
             let _ = write!(
                 out,
-                r#"<text x="{x}" y="{y}" dominant-baseline="central" alignment-baseline="central" class="{class}" style="text-anchor: middle; font-size: {fs}px; font-family: {ff};"><tspan x="{x}" dy="{dy}">{text}</tspan></text>"#,
+                r#"<text x="{x}" y="{y}" dominant-baseline="central" alignment-baseline="central" class="{class}" style="text-anchor: middle; font-size: {fs}px; font-family: {ff}; fill: {fill};"><tspan x="{x}" dy="{dy}">{text}</tspan></text>"#,
                 x = fmt(cx),
                 y = fmt(cy),
+                fill = fill_esc,
                 class = class_esc,
                 fs = fmt(task_font_size),
                 ff = font_family_esc,
@@ -443,12 +446,17 @@ pub(crate) fn render_journey_diagram_svg_model(
                 break;
             };
             let section_class = format!("journey-section section-type-{}", section.num);
+            let section_themed_fill = theme
+                .fill_types
+                .get(section.num as usize)
+                .map(|s| s.as_str())
+                .unwrap_or(&section.fill);
             let _ = write!(
                 &mut out,
                 r##"<g><rect x="{x}" y="{y}" fill="{fill}" stroke="#666" width="{w}" height="{h}" rx="3" ry="3" class="{class}"/>"##,
                 x = fmt(section.x),
                 y = fmt(section.y),
-                fill = escape_attr(&section.fill),
+                fill = escape_attr(section_themed_fill),
                 w = fmt(section.width),
                 h = fmt(section.height),
                 class = escape_attr(&section_class),
@@ -467,6 +475,7 @@ pub(crate) fn render_journey_diagram_svg_model(
                     task_font_size,
                     task_font_family,
                 },
+                &theme.text_color,
             );
             out.push_str("</g>");
         }
@@ -539,12 +548,17 @@ pub(crate) fn render_journey_diagram_svg_model(
 
         out.push_str("</g>");
 
+        let task_themed_fill = theme
+            .fill_types
+            .get(task.num as usize)
+            .map(|s| s.as_str())
+            .unwrap_or(&task.fill);
         let _ = write!(
             &mut out,
             r##"<rect x="{x}" y="{y}" fill="{fill}" stroke="#666" width="{w}" height="{h}" rx="3" ry="3" class="task task-type-{num}"/>"##,
             x = fmt(task.x),
             y = fmt(task.y),
-            fill = escape_attr(&task.fill),
+            fill = escape_attr(task_themed_fill),
             w = fmt(task.width),
             h = fmt(task.height),
             num = task.num,
@@ -577,6 +591,7 @@ pub(crate) fn render_journey_diagram_svg_model(
                 task_font_size,
                 task_font_family,
             },
+            &theme.text_color,
         );
 
         out.push_str("</g>");

--- a/crates/merman-render/src/svg/parity/sequence/actor_shapes.rs
+++ b/crates/merman-render/src/svg/parity/sequence/actor_shapes.rs
@@ -287,7 +287,7 @@ fn write_actor_label(
             out.push_str("<switch>");
             let _ = write!(
                 out,
-                r#"<foreignObject x="{x}" y="{y}" width="{w}" height="{h}"><div class="actor actor-box" xmlns="http://www.w3.org/1999/xhtml" style="height: 100%; width: 100%;"><div style="text-align: center; vertical-align: middle;">{html}</div></div></foreignObject>"#,
+                r#"<foreignObject x="{x}" y="{y}" width="{w}" height="{h}" data-merman-switch="true"><div class="actor actor-box" xmlns="http://www.w3.org/1999/xhtml" style="height: 100%; width: 100%;"><div style="text-align: center; vertical-align: middle;">{html}</div></div></foreignObject>"#,
                 x = fmt(x),
                 y = fmt(y),
                 w = fmt(katex.width),

--- a/crates/merman-render/src/svg/pipeline/builtin/foreign_object.rs
+++ b/crates/merman-render/src/svg/pipeline/builtin/foreign_object.rs
@@ -67,6 +67,39 @@ impl SvgPostprocessor for DropNativeDuplicateFallbacksPostprocessor {
     }
 }
 
+pub(crate) fn drop_switch_native_fallbacks(svg: &str) -> String {
+    if !svg.contains(r#"data-merman-foreignobject-source="switch-native-fallback""#) {
+        return svg.to_string();
+    }
+    let marker = r#"data-merman-foreignobject-source="switch-native-fallback""#;
+    let mut out = String::with_capacity(svg.len());
+    let mut cursor = 0;
+
+    while let Some(rel_start) = svg[cursor..].find(marker) {
+        let attr_start = cursor + rel_start;
+        let Some(group_start) = svg[..attr_start].rfind("<g") else {
+            out.push_str(&svg[cursor..attr_start]);
+            cursor = attr_start + marker.len();
+            continue;
+        };
+        if group_start < cursor {
+            out.push_str(&svg[cursor..attr_start]);
+            cursor = attr_start + marker.len();
+            continue;
+        }
+        let Some((_, group_end)) = find_matching_g_end(svg, group_start) else {
+            out.push_str(&svg[cursor..attr_start]);
+            cursor = attr_start + marker.len();
+            continue;
+        };
+        out.push_str(&svg[cursor..group_start]);
+        cursor = group_end;
+    }
+
+    out.push_str(&svg[cursor..]);
+    out
+}
+
 pub(crate) fn foreign_object_fallback_svg(svg: &str) -> String {
     foreign_object_label_fallback_svg_text(svg)
 }
@@ -78,61 +111,42 @@ pub(crate) fn strip_foreign_objects(svg: &str) -> String {
     while let Some(rel_start) = svg[cursor..].find("<foreignObject") {
         let start = cursor + rel_start;
 
-        // Check if this <foreignObject> is inside a <switch> element.
-        // If so, unwrap the <switch>: remove <switch>, remove <foreignObject>, keep remaining
-        // children (the <text> fallback).
-        let before = &svg[cursor..start];
-        let switch_handled = if let Some(switch_rel) = before.rfind("<switch>") {
-            let switch_start = cursor + switch_rel;
-            // Verify there's nothing meaningful between <switch> and <foreignObject>
-            let between = svg[switch_start + "<switch>".len()..start].trim();
-            if between.is_empty() {
-                // Find the closing </switch>
+        let Some(open_end) = find_tag_end(svg, start) else {
+            out.push_str(&svg[cursor..]);
+            return out;
+        };
+        let fo_tag = &svg[start..=open_end];
+        let is_switch_fo = fo_tag.contains(r#"data-merman-switch="true""#);
+
+        if is_switch_fo {
+            // This foreignObject is tagged as part of a <switch> element.
+            // Unwrap the <switch>: remove <switch> + <foreignObject>, keep sibling <text>
+            // fallback elements.
+            let before = &svg[cursor..start];
+            if let Some(switch_rel) = before.rfind("<switch>") {
+                let switch_start = cursor + switch_rel;
                 if let Some(switch_close_rel) = svg[start..].find("</switch>") {
                     let switch_close_end = start + switch_close_rel + "</switch>".len();
-                    // Output everything before <switch>
                     out.push_str(&svg[cursor..switch_start]);
-                    // Find end of </foreignObject> inside the switch
-                    let fo_open_end = find_tag_end(svg, start);
-                    if let Some(fo_open_end) = fo_open_end {
-                        if !svg[start..=fo_open_end].trim_end().ends_with("/>") {
-                            let fo_close_start = fo_open_end + 1;
-                            if let Some(fo_close_rel) =
-                                svg[fo_close_start..].find("</foreignObject>")
-                            {
-                                let after_fo =
-                                    fo_close_start + fo_close_rel + "</foreignObject>".len();
-                                // Keep everything between </foreignObject> and </switch>
-                                let inner_content =
-                                    &svg[after_fo..start + switch_close_rel];
-                                out.push_str(inner_content);
-                            }
+                    if !fo_tag.trim_end().ends_with("/>") {
+                        let fo_close_start = open_end + 1;
+                        if let Some(fo_close_rel) =
+                            svg[fo_close_start..].find("</foreignObject>")
+                        {
+                            let after_fo =
+                                fo_close_start + fo_close_rel + "</foreignObject>".len();
+                            out.push_str(&svg[after_fo..start + switch_close_rel]);
                         }
                     }
                     cursor = switch_close_end;
-                    true
-                } else {
-                    false
+                    continue;
                 }
-            } else {
-                false
             }
-        } else {
-            false
-        };
-
-        if switch_handled {
-            continue;
         }
 
         out.push_str(&svg[cursor..start]);
 
-        let Some(open_end) = find_tag_end(svg, start) else {
-            out.push_str(&svg[start..]);
-            return out;
-        };
-
-        if svg[start..=open_end].trim_end().ends_with("/>") {
+        if fo_tag.trim_end().ends_with("/>") {
             cursor = open_end + 1;
             continue;
         }
@@ -330,8 +344,8 @@ mod tests {
     }
 
     #[test]
-    fn strip_foreign_objects_unwraps_switch_keeping_text_fallback() {
-        let svg = r##"<svg><switch><foreignObject x="10" y="20" width="100" height="50"><div xmlns="http://www.w3.org/1999/xhtml">Make tea</div></foreignObject><text x="60" y="45">Make tea</text></switch></svg>"##;
+    fn strip_foreign_objects_unwraps_switch_with_tagged_fo() {
+        let svg = r##"<svg><switch><foreignObject x="10" y="20" width="100" height="50" data-merman-switch="true"><div xmlns="http://www.w3.org/1999/xhtml">Make tea</div></foreignObject><text x="60" y="45">Make tea</text></switch></svg>"##;
         let out = strip_foreign_objects(svg);
 
         assert!(!out.contains("<foreignObject"), "foreignObject should be stripped: {out}");
@@ -345,7 +359,7 @@ mod tests {
 
     #[test]
     fn strip_foreign_objects_handles_switch_with_multiple_text_elements() {
-        let svg = r##"<svg><switch><foreignObject x="0" y="0" width="80" height="40"><div xmlns="http://www.w3.org/1999/xhtml">Line 1</div></foreignObject><text x="40" y="15">Line 1</text><text x="40" y="30">Line 2</text></switch></svg>"##;
+        let svg = r##"<svg><switch><foreignObject x="0" y="0" width="80" height="40" data-merman-switch="true"><div xmlns="http://www.w3.org/1999/xhtml">Line 1</div></foreignObject><text x="40" y="15">Line 1</text><text x="40" y="30">Line 2</text></switch></svg>"##;
         let out = strip_foreign_objects(svg);
 
         assert!(!out.contains("<foreignObject"), "{out}");
@@ -356,7 +370,7 @@ mod tests {
 
     #[test]
     fn resvg_safe_pipeline_preserves_switch_text_fallback() {
-        let svg = r##"<svg xmlns="http://www.w3.org/2000/svg"><switch><foreignObject x="150" y="50" width="550" height="50"><div class="journey-section" xmlns="http://www.w3.org/1999/xhtml" style="display: table; height: 100%; width: 100%;"><div class="label" style="display: table-cell; text-align: center; vertical-align: middle;">Go to work</div></div></foreignObject><text x="425" y="75" fill="#333"><tspan x="425" dy="0">Go to work</tspan></text></switch></svg>"##;
+        let svg = r##"<svg xmlns="http://www.w3.org/2000/svg"><switch><foreignObject x="150" y="50" width="550" height="50" data-merman-switch="true"><div class="journey-section" xmlns="http://www.w3.org/1999/xhtml" style="display: table; height: 100%; width: 100%;"><div class="label" style="display: table-cell; text-align: center; vertical-align: middle;">Go to work</div></div></foreignObject><text x="425" y="75" fill="#333"><tspan x="425" dy="0">Go to work</tspan></text></switch></svg>"##;
         let out = SvgPipeline::resvg_safe().process_to_string(svg).unwrap();
 
         assert!(
@@ -371,11 +385,15 @@ mod tests {
             out.contains("Go to work"),
             "text fallback should survive full pipeline: {out}"
         );
+        assert!(
+            !out.contains(r#"data-merman-foreignobject-source"#),
+            "generated fallback should be dropped: {out}"
+        );
     }
 
     #[test]
     fn strip_foreign_objects_handles_journey_switch_pattern() {
-        let svg = r##"<svg><g><rect class="section-type-0"/><switch><foreignObject x="150" y="50" width="550" height="50"><div class="journey-section section-type-0" xmlns="http://www.w3.org/1999/xhtml" style="display: table; height: 100%; width: 100%;"><div class="label" style="display: table-cell; text-align: center; vertical-align: middle;">Go to work</div></div></foreignObject><text x="425" y="75" fill="#333" class="journey-section section-type-0" style="text-anchor: middle;"><tspan x="425" dy="0">Go to work</tspan></text></switch></g></svg>"##;
+        let svg = r##"<svg><g><rect class="section-type-0"/><switch><foreignObject x="150" y="50" width="550" height="50" data-merman-switch="true"><div class="journey-section section-type-0" xmlns="http://www.w3.org/1999/xhtml" style="display: table; height: 100%; width: 100%;"><div class="label" style="display: table-cell; text-align: center; vertical-align: middle;">Go to work</div></div></foreignObject><text x="425" y="75" fill="#333" class="journey-section section-type-0" style="text-anchor: middle;"><tspan x="425" dy="0">Go to work</tspan></text></switch></g></svg>"##;
         let out = strip_foreign_objects(svg);
 
         assert!(!out.contains("<foreignObject"), "foreignObject should be stripped: {out}");
@@ -397,6 +415,25 @@ mod tests {
 
         assert!(!out.contains("<foreignObject"), "{out}");
         assert!(out.contains("<text>World</text>"), "{out}");
+    }
+
+    #[test]
+    fn drop_switch_native_fallbacks_removes_tagged_groups() {
+        let svg = r##"<svg><text x="60" y="45">Make tea</text><g data-merman-foreignobject="fallback" data-merman-foreignobject-source="switch-native-fallback" class="merman-foreignobject-fallback"><text class="merman-foreignobject-fallback-text">Make tea</text></g><g data-merman-foreignobject="fallback" class="merman-foreignobject-fallback"><text class="merman-foreignobject-fallback-text">Other label</text></g></svg>"##;
+        let out = drop_switch_native_fallbacks(svg);
+
+        assert!(
+            !out.contains("switch-native-fallback"),
+            "tagged fallback group should be removed: {out}"
+        );
+        assert!(
+            out.contains("Other label"),
+            "non-switch fallback should be kept: {out}"
+        );
+        assert!(
+            out.contains(r#"<text x="60" y="45">Make tea</text>"#),
+            "native text should remain: {out}"
+        );
     }
 
     #[test]

--- a/crates/merman-render/src/svg/pipeline/builtin/foreign_object.rs
+++ b/crates/merman-render/src/svg/pipeline/builtin/foreign_object.rs
@@ -77,6 +77,54 @@ pub(crate) fn strip_foreign_objects(svg: &str) -> String {
 
     while let Some(rel_start) = svg[cursor..].find("<foreignObject") {
         let start = cursor + rel_start;
+
+        // Check if this <foreignObject> is inside a <switch> element.
+        // If so, unwrap the <switch>: remove <switch>, remove <foreignObject>, keep remaining
+        // children (the <text> fallback).
+        let before = &svg[cursor..start];
+        let switch_handled = if let Some(switch_rel) = before.rfind("<switch>") {
+            let switch_start = cursor + switch_rel;
+            // Verify there's nothing meaningful between <switch> and <foreignObject>
+            let between = svg[switch_start + "<switch>".len()..start].trim();
+            if between.is_empty() {
+                // Find the closing </switch>
+                if let Some(switch_close_rel) = svg[start..].find("</switch>") {
+                    let switch_close_end = start + switch_close_rel + "</switch>".len();
+                    // Output everything before <switch>
+                    out.push_str(&svg[cursor..switch_start]);
+                    // Find end of </foreignObject> inside the switch
+                    let fo_open_end = find_tag_end(svg, start);
+                    if let Some(fo_open_end) = fo_open_end {
+                        if !svg[start..=fo_open_end].trim_end().ends_with("/>") {
+                            let fo_close_start = fo_open_end + 1;
+                            if let Some(fo_close_rel) =
+                                svg[fo_close_start..].find("</foreignObject>")
+                            {
+                                let after_fo =
+                                    fo_close_start + fo_close_rel + "</foreignObject>".len();
+                                // Keep everything between </foreignObject> and </switch>
+                                let inner_content =
+                                    &svg[after_fo..start + switch_close_rel];
+                                out.push_str(inner_content);
+                            }
+                        }
+                    }
+                    cursor = switch_close_end;
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+
+        if switch_handled {
+            continue;
+        }
+
         out.push_str(&svg[cursor..start]);
 
         let Some(open_end) = find_tag_end(svg, start) else {
@@ -279,6 +327,76 @@ mod tests {
             r#"<text class = 'label merman-foreignobject-fallback-text'>"#
         ));
         assert!(!text_tag_is_fallback(r#"<text class = 'label task'>"#));
+    }
+
+    #[test]
+    fn strip_foreign_objects_unwraps_switch_keeping_text_fallback() {
+        let svg = r##"<svg><switch><foreignObject x="10" y="20" width="100" height="50"><div xmlns="http://www.w3.org/1999/xhtml">Make tea</div></foreignObject><text x="60" y="45">Make tea</text></switch></svg>"##;
+        let out = strip_foreign_objects(svg);
+
+        assert!(!out.contains("<foreignObject"), "foreignObject should be stripped: {out}");
+        assert!(!out.contains("<switch>"), "switch wrapper should be removed: {out}");
+        assert!(!out.contains("</switch>"), "switch closing tag should be removed: {out}");
+        assert!(
+            out.contains(r#"<text x="60" y="45">Make tea</text>"#),
+            "text fallback should be preserved: {out}"
+        );
+    }
+
+    #[test]
+    fn strip_foreign_objects_handles_switch_with_multiple_text_elements() {
+        let svg = r##"<svg><switch><foreignObject x="0" y="0" width="80" height="40"><div xmlns="http://www.w3.org/1999/xhtml">Line 1</div></foreignObject><text x="40" y="15">Line 1</text><text x="40" y="30">Line 2</text></switch></svg>"##;
+        let out = strip_foreign_objects(svg);
+
+        assert!(!out.contains("<foreignObject"), "{out}");
+        assert!(!out.contains("<switch>"), "{out}");
+        assert!(out.contains(r#"<text x="40" y="15">Line 1</text>"#), "{out}");
+        assert!(out.contains(r#"<text x="40" y="30">Line 2</text>"#), "{out}");
+    }
+
+    #[test]
+    fn resvg_safe_pipeline_preserves_switch_text_fallback() {
+        let svg = r##"<svg xmlns="http://www.w3.org/2000/svg"><switch><foreignObject x="150" y="50" width="550" height="50"><div class="journey-section" xmlns="http://www.w3.org/1999/xhtml" style="display: table; height: 100%; width: 100%;"><div class="label" style="display: table-cell; text-align: center; vertical-align: middle;">Go to work</div></div></foreignObject><text x="425" y="75" fill="#333"><tspan x="425" dy="0">Go to work</tspan></text></switch></svg>"##;
+        let out = SvgPipeline::resvg_safe().process_to_string(svg).unwrap();
+
+        assert!(
+            !out.contains("<foreignObject"),
+            "foreignObject should be stripped: {out}"
+        );
+        assert!(
+            !out.contains("<switch>"),
+            "switch should be removed: {out}"
+        );
+        assert!(
+            out.contains("Go to work"),
+            "text fallback should survive full pipeline: {out}"
+        );
+    }
+
+    #[test]
+    fn strip_foreign_objects_handles_journey_switch_pattern() {
+        let svg = r##"<svg><g><rect class="section-type-0"/><switch><foreignObject x="150" y="50" width="550" height="50"><div class="journey-section section-type-0" xmlns="http://www.w3.org/1999/xhtml" style="display: table; height: 100%; width: 100%;"><div class="label" style="display: table-cell; text-align: center; vertical-align: middle;">Go to work</div></div></foreignObject><text x="425" y="75" fill="#333" class="journey-section section-type-0" style="text-anchor: middle;"><tspan x="425" dy="0">Go to work</tspan></text></switch></g></svg>"##;
+        let out = strip_foreign_objects(svg);
+
+        assert!(!out.contains("<foreignObject"), "foreignObject should be stripped: {out}");
+        assert!(!out.contains("<switch>"), "switch should be removed: {out}");
+        assert!(
+            out.contains("Go to work"),
+            "section text should be preserved: {out}"
+        );
+        assert!(
+            out.contains(r#"<text x="425" y="75""#),
+            "text element should be preserved: {out}"
+        );
+    }
+
+    #[test]
+    fn strip_foreign_objects_still_works_without_switch() {
+        let svg = r#"<svg><foreignObject width="80" height="24"><div>Hello</div></foreignObject><text>World</text></svg>"#;
+        let out = strip_foreign_objects(svg);
+
+        assert!(!out.contains("<foreignObject"), "{out}");
+        assert!(out.contains("<text>World</text>"), "{out}");
     }
 
     #[test]

--- a/crates/merman-render/src/svg/pipeline/preset.rs
+++ b/crates/merman-render/src/svg/pipeline/preset.rs
@@ -1,7 +1,9 @@
 use super::builtin::{
     attr_sanitize::sanitize_element_attributes,
     css_sanitize::sanitize_style_elements,
-    foreign_object::{foreign_object_fallback_svg, strip_foreign_objects},
+    foreign_object::{
+        drop_switch_native_fallbacks, foreign_object_fallback_svg, strip_foreign_objects,
+    },
 };
 use std::borrow::Cow;
 
@@ -27,6 +29,7 @@ pub enum SvgPipelinePreset {
 pub(crate) enum BuiltinSvgStage {
     ForeignObjectFallback,
     StripForeignObject,
+    DropSwitchNativeFallbacks,
     SanitizeCss,
     SanitizeAttributes,
 }
@@ -36,6 +39,9 @@ impl BuiltinSvgStage {
         match self {
             Self::ForeignObjectFallback => Cow::Owned(foreign_object_fallback_svg(&svg)),
             Self::StripForeignObject => Cow::Owned(strip_foreign_objects(&svg)),
+            Self::DropSwitchNativeFallbacks => {
+                Cow::Owned(drop_switch_native_fallbacks(&svg))
+            }
             Self::SanitizeCss => Cow::Owned(sanitize_style_elements(&svg)),
             Self::SanitizeAttributes => Cow::Owned(sanitize_element_attributes(&svg)),
         }
@@ -49,6 +55,7 @@ pub(crate) fn builtin_stages_for_preset(preset: SvgPipelinePreset) -> &'static [
         SvgPipelinePreset::ResvgSafe => &[
             BuiltinSvgStage::ForeignObjectFallback,
             BuiltinSvgStage::StripForeignObject,
+            BuiltinSvgStage::DropSwitchNativeFallbacks,
             BuiltinSvgStage::SanitizeCss,
             BuiltinSvgStage::SanitizeAttributes,
         ],
@@ -84,6 +91,7 @@ mod tests {
             &[
                 BuiltinSvgStage::ForeignObjectFallback,
                 BuiltinSvgStage::StripForeignObject,
+                BuiltinSvgStage::DropSwitchNativeFallbacks,
                 BuiltinSvgStage::SanitizeCss,
                 BuiltinSvgStage::SanitizeAttributes
             ]


### PR DESCRIPTION
## Summary

Fixes two rendering bugs in journey diagram PNG/raster output (via the resvg pipeline):

- **Strikethrough/double text on task and section labels**: The `ForeignObjectFallback` stage generated overlay text for `<switch>`-wrapped `<foreignObject>` elements that already contained their own `<text>` fallback siblings. Additionally, `StripForeignObject` failed to unwrap `<switch>` elements, leaving orphaned content. Fixed by skipping overlay generation for switch-wrapped foreignObjects, and unwrapping `<switch>` in `strip_foreign_objects()` to preserve the `<text>` fallback children.

- **Invisible section header text** ("Go to work", "Go home"): CSS class rules like `.section-type-0{fill:#ECECFF}` override SVG presentation attributes (`fill="#333"`) due to CSS specificity. resvg correctly applies this, making text the same color as its background rect. Fixed by using inline `style="fill: ..."` for text fill (highest specificity), and using themed fill colors for section/task rectangles.

Fixes #5

## Test plan

- [x] All 698 existing tests pass (3 pre-existing ignored tests unrelated to this change)
- [x] 6 new unit tests covering switch unwrapping, fallback skip, and pipeline integration
- [x] Visual verification of rendered PNG output with the example from #5