### PR TITLE
perf: improve benchmark workflow and repo templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,44 @@
+name: Bug report
+description: Report a rendering, parity, or runtime bug.
+title: "[bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for reproducible bugs, parity gaps, crashes, and unexpected SVG changes.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      placeholder: What is broken?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What should have happened?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      placeholder: Include fixture name, input, command, and whether the issue is deterministic.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      placeholder: Paste logs, SVG snippets, screenshots, or benchmark links.
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: OS, Rust toolchain, browser, and diagram family if relevant.
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Performance workflow
+    url: https://github.com/Latias94/merman/blob/main/docs/performance/BENCHMARKING.md
+    about: Read this before filing a slowdown or benchmark question.
+  - name: Project overview
+    url: https://github.com/Latias94/merman/blob/main/README.md
+    about: Start here for general usage and repository context.
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Suggest a new capability or workflow improvement.
+title: "[feat]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for new capabilities, new diagram families, or workflow improvements.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      placeholder: What are you trying to do?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      placeholder: What should merman do?
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact on parity / performance
+      placeholder: Call out any SVG, parity, or benchmark consequences.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+

--- a/.github/ISSUE_TEMPLATE/perf_regression.yml
+++ b/.github/ISSUE_TEMPLATE/perf_regression.yml
@@ -1,0 +1,50 @@
+name: Performance regression
+description: Report a slowdown or hot path worth investigating.
+title: "[perf]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when a benchmark, stage spotcheck, or comparison report regresses on the same machine.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      placeholder: What got slower, and in which path?
+    validations:
+      required: true
+  - type: input
+    id: benchmark
+    attributes:
+      label: Benchmark / report
+      placeholder: e.g. xychart_medium, docs/performance/COMPARISON.md, or a stage spotcheck path
+    validations:
+      required: true
+  - type: input
+    id: baseline
+    attributes:
+      label: Baseline
+      placeholder: Commit, tag, or report name used as the baseline
+  - type: input
+    id: current
+    attributes:
+      label: Current
+      placeholder: Commit, tag, or report name showing the slowdown
+  - type: textarea
+    id: numbers
+    attributes:
+      label: Numbers
+      placeholder: Paste before/after timings, ratios, or geomean changes.
+    validations:
+      required: true
+  - type: textarea
+    id: setup
+    attributes:
+      label: Measurement setup
+      placeholder: Same machine? Same preset? Warm or cold? Any environment differences?
+  - type: textarea
+    id: suspicion
+    attributes:
+      label: Suspected hotspot
+      placeholder: If you know the stage, module, or function, mention it here.
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+
+## What changed
+
+## Verification
+- [ ] `cargo fmt --all --check`
+- [ ] Relevant tests ran
+- [ ] Benchmark or report updated if this affects performance
+
+## Performance / parity notes
+- Benchmark or report:
+- Parity impact:
+- Rollback risk:
+
+## Follow-ups
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ The format is based on *Keep a Changelog*, and this project adheres to *Semantic
 - Improved `dugong` layered layout performance by avoiding repeated dummy-node ID scans during
   long-edge normalization and by using cached adjacency when removing graph nodes. Added a
   `layout_dagreish` benchmark covering the full layout pipeline and normalize run/undo costs.
+- Improved benchmark coverage and hotspot workflow for Mermaid parity work. Added a corpus-backed
+  perf runner, shared corpus helpers, contract tests, and a profiler-friendly `profile_render`
+  example; Mermaid JS benchmarking now loads ZenUML on demand. Updated the performance docs to use
+  the new canary/default execution order and the broader stage/stress suite naming.
+- Reduced architecture and XYChart hot-path overhead by trimming repeated string formatting,
+  avoiding extra text-measurement work, and shrinking SVG allocation churn in the parity renderers.
+  Against Mermaid JS, the latest cross-family geomean is `0.016x` of Mermaid JS time, which is
+  about `62x` faster overall. `xychart_medium` is `73.62 µs` end-to-end versus `3.00 ms` in
+  Mermaid JS, or about `41x` faster.
 
 ## [0.8.0-alpha.2] - 2026-06-13
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ run on Apple M4, `merman` measured all 34 requested fixtures and used about 1.8%
 Mermaid JS render time across successful Mermaid JS cases, roughly 4.3x to 56.4x faster, with a
 median speedup around 15.8x.
 
+The goal is not to replace Mermaid.js in the browser. This is mostly for native apps, text
+editors, CI pipelines, preview tools, and doc generators where embedding a JS engine just to draw
+a flowchart is heavy and awkward. Criterion benchmarks are kept for regression tracking, but the
+main priorities are parity and predictable headless output, not a marketing claim about being
+"faster Mermaid".
+
 Performance numbers are not a substitute for SVG parity. Missing, skipped, errored, and quality
 comparison results are reported separately by the benchmark harness. See
 [`docs/performance/BENCHMARKING.md`](https://github.com/Latias94/merman/blob/main/docs/performance/BENCHMARKING.md)

--- a/crates/manatee/src/algo/fcose/mod.rs
+++ b/crates/manatee/src/algo/fcose/mod.rs
@@ -30,6 +30,11 @@ struct FcoseSpringTimings {
     collapse_start_positions: web_time::Duration,
     pre_constraints: web_time::Duration,
     constraint_rt: web_time::Duration,
+    repulsion_grid_build: web_time::Duration,
+    repulsion_surrounding: web_time::Duration,
+    repulsion_forces: web_time::Duration,
+    repulsion_overlap_force: web_time::Duration,
+    repulsion_non_overlapping_force: web_time::Duration,
     iterations: web_time::Duration,
 }
 
@@ -259,6 +264,7 @@ pub fn layout_indexed(
         .ok()
         .as_deref()
         == Some("1");
+    let mut owner_bounds = OwnerBounds::new(sim.nodes.len() + 1);
 
     for run_idx in 0..run_count {
         let rng_calls_before = rng.calls();
@@ -272,7 +278,7 @@ pub fn layout_indexed(
                 }
             }
         }
-        let _ = sim.update_bounds();
+        sim.update_bounds(&mut owner_bounds);
         if collect_debug_trace {
             sim.push_debug_stage(
                 &mut debug_stages,
@@ -316,6 +322,7 @@ pub fn layout_indexed(
             opts,
             &mut rng,
             run_idx,
+            &mut owner_bounds,
             collect_debug_trace.then_some(&mut debug_stages),
             if timing_enabled {
                 Some(&mut timings.spring)
@@ -338,7 +345,7 @@ pub fn layout_indexed(
 
         // Ensure compound node rectangles reflect the final child placements before we compute the
         // "current" component bounding box for relocation (`aux.relocateComponent(...)` parity).
-        let _ = sim.update_bounds();
+        sim.update_bounds(&mut owner_bounds);
 
         let new_center = sim.bounding_box_center_rects().unwrap_or((0.0, 0.0));
         let translate_start = timing_enabled.then(web_time::Instant::now);
@@ -390,7 +397,7 @@ pub fn layout_indexed(
         }
 
         if run_idx + 1 < run_count {
-            let _ = sim.update_bounds();
+            sim.update_bounds(&mut owner_bounds);
         }
     }
 
@@ -426,7 +433,7 @@ pub fn layout_indexed(
     if let Some(s) = total_start {
         timings.total = s.elapsed();
         eprintln!(
-            "[manatee-fcose-timing] total={:?} from_indexed={:?} constraints={:?} spring_total={:?} spring_opts_prep={:?} spring_spectral={:?} spring_root_compound={:?} spring_collapse_start={:?} spring_pre_constraints={:?} spring_constraint_rt={:?} spring_iterations={:?} translate={:?} output={:?} nodes={} edges={} compounds={} iterations={} spectral_applied={}",
+            "[manatee-fcose-timing] total={:?} from_indexed={:?} constraints={:?} spring_total={:?} spring_opts_prep={:?} spring_spectral={:?} spring_root_compound={:?} spring_collapse_start={:?} spring_pre_constraints={:?} spring_constraint_rt={:?} spring_repulsion_grid_build={:?} spring_repulsion_surrounding={:?} spring_repulsion_overlap_force={:?} spring_repulsion_non_overlapping_force={:?} spring_repulsion_forces={:?} spring_iterations={:?} translate={:?} output={:?} nodes={} edges={} compounds={} iterations={} spectral_applied={}",
             timings.total,
             timings.from_indexed,
             timings.constraints,
@@ -437,6 +444,11 @@ pub fn layout_indexed(
             timings.spring.collapse_start_positions,
             timings.spring.pre_constraints,
             timings.spring.constraint_rt,
+            timings.spring.repulsion_grid_build,
+            timings.spring.repulsion_surrounding,
+            timings.spring.repulsion_overlap_force,
+            timings.spring.repulsion_non_overlapping_force,
+            timings.spring.repulsion_forces,
             timings.spring.iterations,
             timings.translate,
             timings.output,
@@ -1151,6 +1163,8 @@ struct SimGraph {
     // Immediate children list for each owner graph (owner idx is a compound node idx, or
     // `root_owner_idx` for the root graph).
     children_by_owner: Vec<Vec<usize>>,
+    // Reusable mark array for repulsion grid neighborhood deduplication.
+    surrounding_seen: Vec<u32>,
     // Compound node indices in descending inclusion depth (deepest first), for updateBounds.
     compounds_deep_first: Vec<usize>,
     // Descendant leaf indices for each node (empty for leaves).
@@ -1167,6 +1181,31 @@ struct OwnerBounds {
     right: Vec<f64>,
     top: Vec<f64>,
     bottom: Vec<f64>,
+}
+
+impl OwnerBounds {
+    fn new(owner_count: usize) -> Self {
+        let mut bounds = Self {
+            left: Vec::new(),
+            right: Vec::new(),
+            top: Vec::new(),
+            bottom: Vec::new(),
+        };
+        bounds.reset(owner_count);
+        bounds
+    }
+
+    fn reset(&mut self, owner_count: usize) {
+        self.left.resize(owner_count, f64::INFINITY);
+        self.right.resize(owner_count, f64::NEG_INFINITY);
+        self.top.resize(owner_count, f64::INFINITY);
+        self.bottom.resize(owner_count, f64::NEG_INFINITY);
+
+        self.left.fill(f64::INFINITY);
+        self.right.fill(f64::NEG_INFINITY);
+        self.top.fill(f64::INFINITY);
+        self.bottom.fill(f64::NEG_INFINITY);
+    }
 }
 
 impl SimGraph {
@@ -1486,6 +1525,7 @@ impl SimGraph {
             leaf_count,
             root_owner_idx,
             children_by_owner,
+            surrounding_seen: vec![0; leaf_count + compound_count],
             compounds_deep_first,
             descendant_leaves,
             owner_estimated_size,
@@ -2010,14 +2050,15 @@ impl SimGraph {
         Some(((min_x + max_x) / 2.0, (min_y + max_y) / 2.0))
     }
 
-    fn update_bounds(&mut self) -> OwnerBounds {
+    fn update_bounds(&mut self, bounds: &mut OwnerBounds) {
         debug_assert_eq!(self.root_owner_idx, self.nodes.len());
 
         let owner_count = self.nodes.len() + 1;
-        let mut left: Vec<f64> = vec![f64::INFINITY; owner_count];
-        let mut right: Vec<f64> = vec![f64::NEG_INFINITY; owner_count];
-        let mut top: Vec<f64> = vec![f64::INFINITY; owner_count];
-        let mut bottom: Vec<f64> = vec![f64::NEG_INFINITY; owner_count];
+        bounds.reset(owner_count);
+        let left = &mut bounds.left;
+        let right = &mut bounds.right;
+        let top = &mut bounds.top;
+        let bottom = &mut bounds.bottom;
 
         // Mirror layout-base `graphManager.updateBounds()`:
         // - update child compound bounds first
@@ -2087,13 +2128,6 @@ impl SimGraph {
                 bottom[self.root_owner_idx] = max_y + margin;
             }
         }
-
-        OwnerBounds {
-            left,
-            right,
-            top,
-            bottom,
-        }
     }
 
     fn all_nodes_layout_order(&self) -> Vec<usize> {
@@ -2143,6 +2177,7 @@ impl SimGraph {
         opts: &IndexedFcoseOptions,
         rng: &mut XorShift64Star,
         run_idx: usize,
+        owner_bounds: &mut OwnerBounds,
         mut debug_stages: Option<&mut Vec<IndexedFcoseDebugStage>>,
         mut timings: Option<&mut FcoseSpringTimings>,
     ) -> SpringStats {
@@ -2394,9 +2429,11 @@ impl SimGraph {
             == Some("1");
 
         let iterations_start = timing_enabled.then(web_time::Instant::now);
-        let mut processed: Vec<bool> = vec![false; self.nodes.len()];
+        let mut processed_generation: Vec<u32> = vec![0; self.nodes.len()];
         let mut disps: Vec<(f64, f64)> = vec![(0.0, 0.0); self.nodes.len()];
         let all_nodes_in_layout_order = self.all_nodes_layout_order();
+        let mut current_processed_generation: u32 = 0;
+        let mut surrounding_seen_generation: u32 = 1;
         loop {
             total_iterations += 1;
             if total_iterations == max_iterations {
@@ -2426,7 +2463,7 @@ impl SimGraph {
             let mut total_displacement = 0.0f64;
 
             // Match `cose-base` tick order: update compound bounds (with padding) before forces.
-            let bounds = self.update_bounds();
+            self.update_bounds(owner_bounds);
             if Self::should_trace_iteration(total_iterations)
                 && let Some(stages) = debug_stages.as_deref_mut()
             {
@@ -2450,7 +2487,8 @@ impl SimGraph {
                 if rects_intersect(&self.nodes[a], &self.nodes[b]) {
                     continue;
                 }
-                let (ax, ay, bx, by) = rect_clip_points(&self.nodes[a], &self.nodes[b]);
+                let (ax, ay, bx, by) =
+                    rect_intersection_points_no_overlap_check(&self.nodes[a], &self.nodes[b]);
                 let mut lx = bx - ax;
                 let mut ly = by - ay;
                 let raw_lx = lx;
@@ -2513,14 +2551,21 @@ impl SimGraph {
             // Upstream refreshes the grid + surrounding lists when `totalIterations % 10 == 1`,
             // then reuses those "stale" surrounding lists for the next 9 iterations.
             let refresh_surrounding = (total_iterations % Self::GRID_CALCULATION_CHECK_PERIOD) == 1;
+            current_processed_generation = current_processed_generation.wrapping_add(1);
+            if current_processed_generation == 0 {
+                processed_generation.fill(0);
+                current_processed_generation = 1;
+            }
             if refresh_surrounding {
+                let repulsion_grid_build_start = timing_enabled.then(web_time::Instant::now);
                 let (l, r, t, b) = (
-                    bounds.left[self.root_owner_idx],
-                    bounds.right[self.root_owner_idx],
-                    bounds.top[self.root_owner_idx],
-                    bounds.bottom[self.root_owner_idx],
+                    owner_bounds.left[self.root_owner_idx],
+                    owner_bounds.right[self.root_owner_idx],
+                    owner_bounds.top[self.root_owner_idx],
+                    owner_bounds.bottom[self.root_owner_idx],
                 );
-                repulsion_grid = RepulsionGrid::build(
+                repulsion_grid = RepulsionGrid::build_or_reuse(
+                    repulsion_grid,
                     l,
                     t,
                     r,
@@ -2529,44 +2574,62 @@ impl SimGraph {
                     repulsion_range,
                     &all_nodes_in_layout_order,
                 );
+                if let (Some(t), Some(s)) = (timings.as_deref_mut(), repulsion_grid_build_start) {
+                    t.repulsion_grid_build += s.elapsed();
+                }
             }
 
             if repulsion_range.is_finite() && repulsion_range > 0.0 {
-                processed.fill(false);
                 for &i in &all_nodes_in_layout_order {
-                    if i >= self.nodes.len() {
-                        continue;
-                    }
                     if refresh_surrounding {
+                        let repulsion_surrounding_start =
+                            timing_enabled.then(web_time::Instant::now);
                         if let Some(g) = &repulsion_grid {
                             g.refresh_node_surrounding(
                                 i,
                                 &mut self.nodes,
-                                &processed,
+                                &processed_generation,
+                                current_processed_generation,
                                 repulsion_range,
+                                &mut self.surrounding_seen,
+                                &mut surrounding_seen_generation,
                             );
                         } else {
                             self.nodes[i].surrounding.clear();
                         }
+                        if let (Some(t), Some(s)) =
+                            (timings.as_deref_mut(), repulsion_surrounding_start)
+                        {
+                            t.repulsion_surrounding += s.elapsed();
+                        }
                     }
 
+                    let repulsion_forces_start = timing_enabled.then(web_time::Instant::now);
                     let surrounding = std::mem::take(&mut self.nodes[i].surrounding);
+                    let node_i_center_x = self.nodes[i].center_x();
+                    let node_i_center_y = self.nodes[i].center_y();
                     for &j in &surrounding {
-                        if i == j {
-                            continue;
-                        }
-                        if j >= self.nodes.len() {
-                            continue;
-                        }
-                        if self.nodes[i].owner_idx != self.nodes[j].owner_idx {
-                            continue;
-                        }
+                        let repulsion_force_start = timing_enabled.then(web_time::Instant::now);
+                        let node_j_center_x = self.nodes[j].center_x();
+                        let node_j_center_y = self.nodes[j].center_y();
                         let (rfx, rfy) = calc_repulsion_force(
                             &self.nodes[i],
                             &self.nodes[j],
                             min_repulsion_dist,
                             half_default_edge_length,
+                            node_i_center_x,
+                            node_i_center_y,
+                            node_j_center_x,
+                            node_j_center_y,
                         );
+                        if let (Some(t), Some(s)) = (timings.as_deref_mut(), repulsion_force_start)
+                        {
+                            if rects_intersect(&self.nodes[i], &self.nodes[j]) {
+                                t.repulsion_overlap_force += s.elapsed();
+                            } else {
+                                t.repulsion_non_overlapping_force += s.elapsed();
+                            }
+                        }
                         // Apply a symmetric pairwise force.
                         //
                         // Unlike `i < j` index-based deduping, upstream CoSE/FCoSE dedupes via a
@@ -2578,20 +2641,31 @@ impl SimGraph {
                         self.nodes[j].repulsion_fy -= rfy;
                     }
                     self.nodes[i].surrounding = surrounding;
-                    processed[i] = true;
+                    if let (Some(t), Some(s)) = (timings.as_deref_mut(), repulsion_forces_start) {
+                        t.repulsion_forces += s.elapsed();
+                    }
+                    processed_generation[i] = current_processed_generation;
                 }
             } else {
                 // Fallback: unbounded repulsion (all pairs).
                 for i in 0..self.nodes.len() {
+                    let node_i_center_x = self.nodes[i].center_x();
+                    let node_i_center_y = self.nodes[i].center_y();
                     for j in (i + 1)..self.nodes.len() {
                         if self.nodes[i].owner_idx != self.nodes[j].owner_idx {
                             continue;
                         }
+                        let node_j_center_x = self.nodes[j].center_x();
+                        let node_j_center_y = self.nodes[j].center_y();
                         let (rfx, rfy) = calc_repulsion_force(
                             &self.nodes[i],
                             &self.nodes[j],
                             min_repulsion_dist,
                             half_default_edge_length,
+                            node_i_center_x,
+                            node_i_center_y,
+                            node_j_center_x,
+                            node_j_center_y,
                         );
                         self.nodes[i].repulsion_fx += rfx;
                         self.nodes[i].repulsion_fy += rfy;
@@ -2611,10 +2685,10 @@ impl SimGraph {
 
                 let owner = n.owner_idx;
                 let (l, r, t, b) = (
-                    bounds.left.get(owner).copied().unwrap_or(0.0),
-                    bounds.right.get(owner).copied().unwrap_or(0.0),
-                    bounds.top.get(owner).copied().unwrap_or(0.0),
-                    bounds.bottom.get(owner).copied().unwrap_or(0.0),
+                    owner_bounds.left.get(owner).copied().unwrap_or(0.0),
+                    owner_bounds.right.get(owner).copied().unwrap_or(0.0),
+                    owner_bounds.top.get(owner).copied().unwrap_or(0.0),
+                    owner_bounds.bottom.get(owner).copied().unwrap_or(0.0),
                 );
                 if !(l.is_finite() && r.is_finite() && t.is_finite() && b.is_finite()) {
                     continue;
@@ -2829,7 +2903,7 @@ impl SimGraph {
 
         // Ensure compound rectangles reflect the final leaf positions before callers compute
         // component bbox/centering (e.g. `aux.relocateComponent(...)` parity).
-        let _ = self.update_bounds();
+        self.update_bounds(owner_bounds);
         if let Some(stages) = debug_stages {
             self.push_debug_stage(
                 stages,
@@ -4643,7 +4717,8 @@ mod tests {
             bottom = bottom.max(n.top + n.height);
         }
         let node_order = [0usize, 1, 2];
-        let grid = RepulsionGrid::build(
+        let grid = RepulsionGrid::build_or_reuse(
+            None,
             left,
             top,
             right,
@@ -4654,12 +4729,31 @@ mod tests {
         )
         .expect("grid");
 
-        let mut processed = vec![false; nodes.len()];
-        grid.refresh_node_surrounding(0, &mut nodes, &processed, repulsion_range);
+        let mut processed_generation = vec![0u32; nodes.len()];
+        let current_processed_generation = 1u32;
+        let mut surrounding_seen = vec![0u32; nodes.len()];
+        let mut surrounding_seen_generation = 1u32;
+        grid.refresh_node_surrounding(
+            0,
+            &mut nodes,
+            &processed_generation,
+            current_processed_generation,
+            repulsion_range,
+            &mut surrounding_seen,
+            &mut surrounding_seen_generation,
+        );
         assert_eq!(nodes[0].surrounding, vec![1]);
 
-        processed[0] = true;
-        grid.refresh_node_surrounding(1, &mut nodes, &processed, repulsion_range);
+        processed_generation[0] = current_processed_generation;
+        grid.refresh_node_surrounding(
+            1,
+            &mut nodes,
+            &processed_generation,
+            current_processed_generation,
+            repulsion_range,
+            &mut surrounding_seen,
+            &mut surrounding_seen_generation,
+        );
         assert!(
             !nodes[1].surrounding.contains(&0),
             "node1 should not include already-processed node0"
@@ -4991,7 +5085,33 @@ fn get_cardinal_direction(slope: f64, slope_prime: f64, line: i32) -> i32 {
     }
 }
 
+#[cfg(test)]
 fn rect_clip_points(a: &SimNode, b: &SimNode) -> (f64, f64, f64, f64) {
+    let (ax, ay, bx, by, overlapped) = rect_intersection_points(a, b);
+    if overlapped {
+        return (a.center_x(), a.center_y(), b.center_x(), b.center_y());
+    }
+    (ax, ay, bx, by)
+}
+
+#[cfg(test)]
+#[inline]
+fn rect_intersection_points(a: &SimNode, b: &SimNode) -> (f64, f64, f64, f64, bool) {
+    let p1x = a.center_x();
+    let p1y = a.center_y();
+    let p2x = b.center_x();
+    let p2y = b.center_y();
+
+    if rects_intersect(a, b) {
+        return (p1x, p1y, p2x, p2y, true);
+    }
+
+    let (ax, ay, bx, by) = rect_intersection_points_no_overlap_check(a, b);
+    (ax, ay, bx, by, false)
+}
+
+#[inline]
+fn rect_intersection_points_no_overlap_check(a: &SimNode, b: &SimNode) -> (f64, f64, f64, f64) {
     // Port of layout-base `IGeometry.getIntersection2(rectA, rectB, result)`.
     //
     // result[0-1] contains clip point on rectA; result[2-3] contains clip point on rectB.
@@ -5000,25 +5120,17 @@ fn rect_clip_points(a: &SimNode, b: &SimNode) -> (f64, f64, f64, f64) {
     let p2x = b.center_x();
     let p2y = b.center_y();
 
-    if rects_intersect(a, b) {
-        return (p1x, p1y, p2x, p2y);
-    }
-
-    let top_left_ax = a.left;
-    let top_left_ay = a.top;
-    let top_right_ax = a.right();
-    let bottom_left_ax = a.left;
-    let bottom_left_ay = a.bottom();
-    let bottom_right_ax = a.right();
+    let left_a = a.left;
+    let right_a = a.right();
+    let top_a = a.top;
+    let bottom_a = a.bottom();
     let half_width_a = a.half_w();
     let half_height_a = a.half_h();
 
-    let top_left_bx = b.left;
-    let top_left_by = b.top;
-    let top_right_bx = b.right();
-    let bottom_left_bx = b.left;
-    let bottom_left_by = b.bottom();
-    let bottom_right_bx = b.right();
+    let left_b = b.left;
+    let right_b = b.right();
+    let top_b = b.top;
+    let bottom_b = b.bottom();
     let half_width_b = b.half_w();
     let half_height_b = b.half_h();
 
@@ -5029,15 +5141,15 @@ fn rect_clip_points(a: &SimNode, b: &SimNode) -> (f64, f64, f64, f64) {
 
     if p1x == p2x {
         if p1y > p2y {
-            return (p1x, top_left_ay, p2x, bottom_left_by);
+            return (p1x, top_a, p2x, bottom_b);
         } else if p1y < p2y {
-            return (p1x, bottom_left_ay, p2x, top_left_by);
+            return (p1x, bottom_a, p2x, top_b);
         }
     } else if p1y == p2y {
         if p1x > p2x {
-            return (top_left_ax, p1y, top_right_bx, p2y);
+            return (left_a, p1y, right_b, p2y);
         } else if p1x < p2x {
-            return (top_right_ax, p1y, top_left_bx, p2y);
+            return (right_a, p1y, left_b, p2y);
         }
     } else {
         let slope_a = a.height / a.width;
@@ -5049,44 +5161,44 @@ fn rect_clip_points(a: &SimNode, b: &SimNode) -> (f64, f64, f64, f64) {
 
         if -slope_a == slope_prime {
             if p1x > p2x {
-                clip_ax = bottom_left_ax;
-                clip_ay = bottom_left_ay;
+                clip_ax = left_a;
+                clip_ay = bottom_a;
                 clip_a_found = true;
             } else {
-                clip_ax = top_right_ax;
-                clip_ay = top_left_ay;
+                clip_ax = right_a;
+                clip_ay = top_a;
                 clip_a_found = true;
             }
         } else if slope_a == slope_prime {
             if p1x > p2x {
-                clip_ax = top_left_ax;
-                clip_ay = top_left_ay;
+                clip_ax = left_a;
+                clip_ay = top_a;
                 clip_a_found = true;
             } else {
-                clip_ax = bottom_right_ax;
-                clip_ay = bottom_left_ay;
+                clip_ax = right_a;
+                clip_ay = bottom_a;
                 clip_a_found = true;
             }
         }
 
         if -slope_b == slope_prime {
             if p2x > p1x {
-                clip_bx = bottom_left_bx;
-                clip_by = bottom_left_by;
+                clip_bx = left_b;
+                clip_by = bottom_b;
                 clip_b_found = true;
             } else {
-                clip_bx = top_right_bx;
-                clip_by = top_left_by;
+                clip_bx = right_b;
+                clip_by = top_b;
                 clip_b_found = true;
             }
         } else if slope_b == slope_prime {
             if p2x > p1x {
-                clip_bx = top_left_bx;
-                clip_by = top_left_by;
+                clip_bx = left_b;
+                clip_by = top_b;
                 clip_b_found = true;
             } else {
-                clip_bx = bottom_right_bx;
-                clip_by = bottom_left_by;
+                clip_bx = right_b;
+                clip_by = bottom_b;
                 clip_b_found = true;
             }
         }
@@ -5119,19 +5231,19 @@ fn rect_clip_points(a: &SimNode, b: &SimNode) -> (f64, f64, f64, f64) {
             if !clip_a_found {
                 match card_a {
                     1 => {
-                        clip_ay = top_left_ay;
+                        clip_ay = top_a;
                         clip_ax = p1x + -half_height_a / slope_prime;
                     }
                     2 => {
-                        clip_ax = bottom_right_ax;
+                        clip_ax = right_a;
                         clip_ay = p1y + half_width_a * slope_prime;
                     }
                     3 => {
-                        clip_ay = bottom_left_ay;
+                        clip_ay = bottom_a;
                         clip_ax = p1x + half_height_a / slope_prime;
                     }
                     4 => {
-                        clip_ax = bottom_left_ax;
+                        clip_ax = left_a;
                         clip_ay = p1y + -half_width_a * slope_prime;
                     }
                     _ => {}
@@ -5141,19 +5253,19 @@ fn rect_clip_points(a: &SimNode, b: &SimNode) -> (f64, f64, f64, f64) {
             if !clip_b_found {
                 match card_b {
                     1 => {
-                        clip_by = top_left_by;
+                        clip_by = top_b;
                         clip_bx = p2x + -half_height_b / slope_prime;
                     }
                     2 => {
-                        clip_bx = bottom_right_bx;
+                        clip_bx = right_b;
                         clip_by = p2y + half_width_b * slope_prime;
                     }
                     3 => {
-                        clip_by = bottom_left_by;
+                        clip_by = bottom_b;
                         clip_bx = p2x + half_height_b / slope_prime;
                     }
                     4 => {
-                        clip_bx = bottom_left_bx;
+                        clip_bx = left_b;
                         clip_by = p2y + -half_width_b * slope_prime;
                     }
                     _ => {}
@@ -5165,55 +5277,131 @@ fn rect_clip_points(a: &SimNode, b: &SimNode) -> (f64, f64, f64, f64) {
     (clip_ax, clip_ay, clip_bx, clip_by)
 }
 
+#[inline]
+fn calc_repulsion_force_overlapping(
+    a: &SimNode,
+    b: &SimNode,
+    separation_buffer: f64,
+    a_center_x: f64,
+    a_center_y: f64,
+    b_center_x: f64,
+    b_center_y: f64,
+) -> (f64, f64) {
+    let (ox, oy) = calc_separation_amount_with_centers(
+        a,
+        b,
+        separation_buffer,
+        a_center_x,
+        a_center_y,
+        b_center_x,
+        b_center_y,
+    );
+    let repulsion_fx = 2.0 * ox;
+    let repulsion_fy = 2.0 * oy;
+
+    // layout-base: scale overlap separation by a children constant so large compounds move
+    // more slowly than leaves (and to reduce oscillation).
+    let denom = (a.no_of_children + b.no_of_children).max(1.0);
+    let children_constant = (a.no_of_children * b.no_of_children) / denom;
+
+    // Return a force delta to be applied as:
+    // - nodeA += rfx/rfy
+    // - nodeB -= rfx/rfy
+    (
+        -children_constant * repulsion_fx,
+        -children_constant * repulsion_fy,
+    )
+}
+
+#[inline]
+fn calc_repulsion_force_non_overlapping_from_points(
+    min_repulsion_dist: f64,
+    children_product: f64,
+    ax: f64,
+    ay: f64,
+    bx: f64,
+    by: f64,
+) -> (f64, f64) {
+    let mut dx = bx - ax;
+    let mut dy = by - ay;
+
+    if dx.abs() < min_repulsion_dist {
+        dx = imath_sign(dx) * min_repulsion_dist;
+    }
+    if dy.abs() < min_repulsion_dist {
+        dy = imath_sign(dy) * min_repulsion_dist;
+    }
+
+    let dist_sq = dx * dx + dy * dy;
+    let dist = dist_sq.sqrt();
+    if dist_sq == 0.0 {
+        return (0.0, 0.0);
+    }
+
+    // layout-base:
+    // `(nodeA.nodeRepulsion/2 + nodeB.nodeRepulsion/2) * noOfChildrenA * noOfChildrenB / dist^2`.
+    // Default node repulsion is 4500 for both nodes.
+    let repulsion_force = SimGraph::DEFAULT_REPULSION_STRENGTH * children_product / dist_sq;
+    let repulsion_fx = repulsion_force * dx / dist;
+    let repulsion_fy = repulsion_force * dy / dist;
+    (-repulsion_fx, -repulsion_fy)
+}
+
+#[inline]
 fn calc_repulsion_force(
     a: &SimNode,
     b: &SimNode,
     min_repulsion_dist: f64,
     separation_buffer: f64,
+    a_center_x: f64,
+    a_center_y: f64,
+    b_center_x: f64,
+    b_center_y: f64,
+) -> (f64, f64) {
+    calc_repulsion_force_with_centers(
+        a,
+        b,
+        min_repulsion_dist,
+        separation_buffer,
+        a_center_x,
+        a_center_y,
+        b_center_x,
+        b_center_y,
+    )
+}
+
+#[inline]
+fn calc_repulsion_force_with_centers(
+    a: &SimNode,
+    b: &SimNode,
+    min_repulsion_dist: f64,
+    separation_buffer: f64,
+    a_center_x: f64,
+    a_center_y: f64,
+    b_center_x: f64,
+    b_center_y: f64,
 ) -> (f64, f64) {
     if rects_intersect(a, b) {
-        let (ox, oy) = calc_separation_amount(a, b, separation_buffer);
-        let repulsion_fx = 2.0 * ox;
-        let repulsion_fy = 2.0 * oy;
-
-        // layout-base: scale overlap separation by a children constant so large compounds move
-        // more slowly than leaves (and to reduce oscillation).
-        let denom = (a.no_of_children + b.no_of_children).max(1.0);
-        let children_constant = (a.no_of_children * b.no_of_children) / denom;
-
-        // Return a force delta to be applied as:
-        // - nodeA += rfx/rfy
-        // - nodeB -= rfx/rfy
-        (
-            -children_constant * repulsion_fx,
-            -children_constant * repulsion_fy,
+        calc_repulsion_force_overlapping(
+            a,
+            b,
+            separation_buffer,
+            a_center_x,
+            a_center_y,
+            b_center_x,
+            b_center_y,
         )
     } else {
-        let (ax, ay, bx, by) = rect_clip_points(a, b);
-        let mut dx = bx - ax;
-        let mut dy = by - ay;
-
-        if dx.abs() < min_repulsion_dist {
-            dx = imath_sign(dx) * min_repulsion_dist;
-        }
-        if dy.abs() < min_repulsion_dist {
-            dy = imath_sign(dy) * min_repulsion_dist;
-        }
-
-        let dist_sq = dx * dx + dy * dy;
-        let dist = dist_sq.sqrt();
-        if dist_sq == 0.0 || dist == 0.0 {
-            return (0.0, 0.0);
-        }
-
-        // layout-base:
-        // `(nodeA.nodeRepulsion/2 + nodeB.nodeRepulsion/2) * noOfChildrenA * noOfChildrenB / dist^2`.
-        // Default node repulsion is 4500 for both nodes.
-        let repulsion_force =
-            SimGraph::DEFAULT_REPULSION_STRENGTH * a.no_of_children * b.no_of_children / dist_sq;
-        let repulsion_fx = repulsion_force * dx / dist;
-        let repulsion_fy = repulsion_force * dy / dist;
-        (-repulsion_fx, -repulsion_fy)
+        let children_product = a.no_of_children * b.no_of_children;
+        let (ax, ay, bx, by) = rect_intersection_points_no_overlap_check(a, b);
+        calc_repulsion_force_non_overlapping_from_points(
+            min_repulsion_dist,
+            children_product,
+            ax,
+            ay,
+            bx,
+            by,
+        )
     }
 }
 
@@ -5234,7 +5422,18 @@ impl RepulsionGrid {
         &self.cells[self.idx(x, y)]
     }
 
-    fn build(
+    fn reset(&mut self, size_x: i32, size_y: i32) {
+        self.size_x = size_x;
+        self.size_y = size_y;
+        let target = (size_x as usize) * (size_y as usize);
+        self.cells.resize_with(target, Vec::new);
+        for cell in &mut self.cells {
+            cell.clear();
+        }
+    }
+
+    fn build_or_reuse(
+        grid: Option<Self>,
         left: f64,
         top: f64,
         right: f64,
@@ -5262,7 +5461,12 @@ impl RepulsionGrid {
         // layout-base `FDLayout.calcGrid`: size = ceil((graph.right - graph.left) / repulsionRange).
         let size_x = ((w / repulsion_range).ceil() as i32).max(1);
         let size_y = ((h / repulsion_range).ceil() as i32).max(1);
-        let mut cells: Vec<Vec<usize>> = vec![Vec::new(); (size_x as usize) * (size_y as usize)];
+        let mut grid = grid.unwrap_or_else(|| Self {
+            size_x,
+            size_y,
+            cells: Vec::new(),
+        });
+        grid.reset(size_x, size_y);
 
         // Mirror layout-base `addNodeToGrid`: push the node into every cell that intersects the
         // node's rect, using top-left anchored coordinates.
@@ -5294,33 +5498,50 @@ impl RepulsionGrid {
                         continue;
                     }
                     let cell_idx = (gx as usize) * (size_y as usize) + (gy as usize);
-                    cells[cell_idx].push(idx);
+                    grid.cells[cell_idx].push(idx);
                 }
             }
         }
 
-        Some(Self {
-            size_x,
-            size_y,
-            cells,
-        })
+        Some(grid)
     }
 
     fn refresh_node_surrounding(
         &self,
         node_idx: usize,
         nodes: &mut [SimNode],
-        processed: &[bool],
+        processed_generation: &[u32],
+        current_processed_generation: u32,
         repulsion_range: f64,
+        surrounding_seen: &mut [u32],
+        surrounding_seen_generation: &mut u32,
     ) {
+        if node_idx >= nodes.len() {
+            return;
+        }
         let start_x = nodes[node_idx].grid_start_x;
         let finish_x = nodes[node_idx].grid_finish_x;
         let start_y = nodes[node_idx].grid_start_y;
         let finish_y = nodes[node_idx].grid_finish_y;
-
-        let mut seen: Vec<bool> = vec![false; nodes.len()];
-        let mut surrounding: Vec<usize> = Vec::new();
-
+        let node_owner_idx = nodes[node_idx].owner_idx;
+        let node_center_x = nodes[node_idx].center_x();
+        let node_center_y = nodes[node_idx].center_y();
+        let node_half_w = nodes[node_idx].half_w();
+        let node_half_h = nodes[node_idx].half_h();
+        let (left, rest) = nodes.split_at_mut(node_idx);
+        let (node, right) = rest
+            .split_first_mut()
+            .expect("node_idx checked against nodes len");
+        let left: &[SimNode] = left;
+        let right: &[SimNode] = right;
+        let surrounding = &mut node.surrounding;
+        surrounding.clear();
+        *surrounding_seen_generation = surrounding_seen_generation.wrapping_add(1);
+        if *surrounding_seen_generation == 0 {
+            surrounding_seen.fill(0);
+            *surrounding_seen_generation = 1;
+        }
+        let generation = *surrounding_seen_generation;
         for gx in (start_x - 1)..=(finish_x + 1) {
             if gx < 0 || gx >= self.size_x {
                 continue;
@@ -5333,33 +5554,61 @@ impl RepulsionGrid {
                     if other == node_idx {
                         continue;
                     }
-                    if processed.get(other).copied().unwrap_or(false) {
+                    if processed_generation[other] == current_processed_generation {
                         continue;
                     }
-                    if seen[other] {
+                    if surrounding_seen[other] == generation {
                         continue;
                     }
-                    if nodes[node_idx].owner_idx != nodes[other].owner_idx {
+                    let other_node = if other < node_idx {
+                        &left[other]
+                    } else {
+                        &right[other - node_idx - 1]
+                    };
+                    if node_owner_idx != other_node.owner_idx {
                         continue;
                     }
 
-                    let dx = (nodes[node_idx].center_x() - nodes[other].center_x()).abs()
-                        - (nodes[node_idx].half_w() + nodes[other].half_w());
-                    let dy = (nodes[node_idx].center_y() - nodes[other].center_y()).abs()
-                        - (nodes[node_idx].half_h() + nodes[other].half_h());
+                    let other_center_x = other_node.center_x();
+                    let other_center_y = other_node.center_y();
+                    let other_half_w = other_node.half_w();
+                    let other_half_h = other_node.half_h();
+
+                    let dx = (node_center_x - other_center_x).abs() - (node_half_w + other_half_w);
+                    let dy = (node_center_y - other_center_y).abs() - (node_half_h + other_half_h);
                     if dx <= repulsion_range && dy <= repulsion_range {
-                        seen[other] = true;
+                        surrounding_seen[other] = generation;
                         surrounding.push(other);
                     }
                 }
             }
         }
-
-        nodes[node_idx].surrounding = surrounding;
     }
 }
 
+#[cfg(test)]
 fn calc_separation_amount(a: &SimNode, b: &SimNode, separation_buffer: f64) -> (f64, f64) {
+    calc_separation_amount_with_centers(
+        a,
+        b,
+        separation_buffer,
+        a.center_x(),
+        a.center_y(),
+        b.center_x(),
+        b.center_y(),
+    )
+}
+
+#[inline]
+fn calc_separation_amount_with_centers(
+    a: &SimNode,
+    b: &SimNode,
+    separation_buffer: f64,
+    a_center_x: f64,
+    a_center_y: f64,
+    b_center_x: f64,
+    b_center_y: f64,
+) -> (f64, f64) {
     debug_assert!(rects_intersect(a, b));
 
     let (dir_x, dir_y) = decide_directions_for_overlapping_nodes(a, b);
@@ -5379,8 +5628,8 @@ fn calc_separation_amount(a: &SimNode, b: &SimNode, separation_buffer: f64) -> (
         overlap_y += (a.top - b.top).min(b.bottom() - a.bottom());
     }
 
-    let center_dx = b.center_x() - a.center_x();
-    let center_dy = b.center_y() - a.center_y();
+    let center_dx = b_center_x - a_center_x;
+    let center_dy = b_center_y - a_center_y;
     let mut slope = (center_dy / center_dx).abs();
     if nearly_equal(center_dy, 0.0) && nearly_equal(center_dx, 0.0) {
         slope = 1.0;

--- a/crates/merman-core/src/config/mod.rs
+++ b/crates/merman-core/src/config/mod.rs
@@ -34,6 +34,14 @@ impl MermaidConfig {
         self.0.as_ref()
     }
 
+    pub(crate) fn is_empty_object(&self) -> bool {
+        matches!(self.as_value(), Value::Object(map) if map.is_empty())
+    }
+
+    pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+
     pub fn as_value_mut(&mut self) -> &mut Value {
         self.value_mut()
     }

--- a/crates/merman-core/src/diagrams/mindmap/db.rs
+++ b/crates/merman-core/src/diagrams/mindmap/db.rs
@@ -9,6 +9,21 @@ use super::{
     NODE_TYPE_RECT, NODE_TYPE_ROUNDED_RECT,
 };
 
+#[derive(Debug, Clone, Copy)]
+pub(super) struct MindmapParseConfig {
+    padding: i64,
+    max_node_width: i64,
+}
+
+impl MindmapParseConfig {
+    pub(super) fn from_config(config: &MermaidConfig) -> Self {
+        Self {
+            padding: get_i64(config, "mindmap.padding").unwrap_or(10),
+            max_node_width: get_i64(config, "mindmap.maxNodeWidth").unwrap_or(200),
+        }
+    }
+}
+
 fn mindmap_look(config: &MermaidConfig) -> String {
     config.get_str("look").unwrap_or("classic").to_string()
 }
@@ -240,6 +255,7 @@ impl MindmapDb {
         &mut self,
         input: MindmapNodeInput<'_>,
         config: &MermaidConfig,
+        parse_config: MindmapParseConfig,
     ) -> Result<()> {
         let mut level = input.indent_level;
         let is_root;
@@ -254,8 +270,8 @@ impl MindmapDb {
             is_root = false;
         }
 
-        let mut padding = get_i64(config, "mindmap.padding").unwrap_or(10);
-        let width = get_i64(config, "mindmap.maxNodeWidth").unwrap_or(200);
+        let mut padding = parse_config.padding;
+        let width = parse_config.max_node_width;
 
         match input.ty {
             NODE_TYPE_ROUNDED_RECT | NODE_TYPE_RECT | NODE_TYPE_HEXAGON => {

--- a/crates/merman-core/src/diagrams/mindmap/parse.rs
+++ b/crates/merman-core/src/diagrams/mindmap/parse.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::{Error, ParseMetadata, Result};
 
-use super::db::MindmapDb;
+use super::db::{MindmapDb, MindmapParseConfig};
 use super::render_model::MindmapDiagramRenderModel;
 use super::utils::{
     parse_node_spec, split_indent, starts_with_case_insensitive, strip_inline_comment,
@@ -35,6 +35,7 @@ pub fn parse_mindmap_model_for_render(
 fn parse_mindmap_db(code: &str, meta: &ParseMetadata) -> Result<MindmapDb> {
     let mut db = MindmapDb::default();
     db.clear();
+    let parse_config = MindmapParseConfig::from_config(&meta.effective_config);
 
     let mut lines = code.lines();
     let mut found_header = false;
@@ -138,6 +139,7 @@ fn parse_mindmap_db(code: &str, meta: &ParseMetadata) -> Result<MindmapDb> {
                 diagram_type: &meta.diagram_type,
             },
             &meta.effective_config,
+            parse_config,
         )?;
         Ok(HandleOutcome::Done)
     };

--- a/crates/merman-core/src/lib.rs
+++ b/crates/merman-core/src/lib.rs
@@ -75,6 +75,20 @@ pub fn selected_baseline_registry_profile() -> baseline::BaselineRegistryProfile
     family::selected_registry_profile()
 }
 
+fn build_default_effective_config(site_config: &MermaidConfig) -> MermaidConfig {
+    let mut effective_config = site_config.clone();
+    theme::apply_theme_defaults(&mut effective_config);
+    effective_config
+}
+
+fn generated_default_effective_config() -> MermaidConfig {
+    static DEFAULT_EFFECTIVE_CONFIG: std::sync::OnceLock<MermaidConfig> =
+        std::sync::OnceLock::new();
+    DEFAULT_EFFECTIVE_CONFIG
+        .get_or_init(|| build_default_effective_config(&generated::default_site_config()))
+        .clone()
+}
+
 /// Parser behavior switches shared by metadata, semantic JSON, and typed render-model parsing.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ParseOptions {
@@ -122,6 +136,7 @@ pub struct Engine {
     diagram_registry: DiagramRegistry,
     render_diagram_registry: RenderDiagramRegistry,
     site_config: MermaidConfig,
+    default_effective_config: MermaidConfig,
     fixed_today_local: Option<chrono::NaiveDate>,
     fixed_local_offset_minutes: Option<i32>,
 }
@@ -129,12 +144,14 @@ pub struct Engine {
 impl Default for Engine {
     fn default() -> Self {
         let site_config = generated::default_site_config();
+        let default_effective_config = generated_default_effective_config();
 
         Self {
             registry: DetectorRegistry::for_pinned_mermaid_baseline(),
             diagram_registry: DiagramRegistry::for_pinned_mermaid_baseline(),
             render_diagram_registry: RenderDiagramRegistry::for_pinned_mermaid_baseline(),
             site_config,
+            default_effective_config,
             fixed_today_local: None,
             fixed_local_offset_minutes: None,
         }
@@ -168,6 +185,10 @@ impl Engine {
         Self::default()
     }
 
+    pub(crate) fn default_effective_config(&self) -> MermaidConfig {
+        self.default_effective_config.clone()
+    }
+
     /// Overrides the "today" value used by diagrams that depend on local time (e.g. Gantt).
     ///
     /// This exists primarily to make fixture snapshots deterministic. By default, Mermaid uses the
@@ -192,6 +213,7 @@ impl Engine {
         // Merge overrides onto Mermaid schema defaults so detectors keep working.
         config::mirror_legacy_font_family_into_theme_variables(&mut site_config);
         self.site_config.deep_merge(site_config.as_value());
+        self.default_effective_config = build_default_effective_config(&self.site_config);
         self
     }
 

--- a/crates/merman-core/src/parse_pipeline.rs
+++ b/crates/merman-core/src/parse_pipeline.rs
@@ -176,9 +176,9 @@ impl<'a> ParsePipeline<'a> {
             return Err(Error::MalformedFrontMatter);
         }
 
-        let mut effective_config = self.engine.site_config.clone();
-        let effective_overrides = effective_config.secure_filtered_overrides(&pre.config);
-        effective_config.deep_merge(effective_overrides.as_value());
+        let has_config_overrides = !pre.config.is_empty_object();
+        let mut effective_config = self.effective_config_before_detect(&pre.config);
+        let cached_effective_config = (!has_config_overrides).then(|| effective_config.clone());
 
         let diagram_type = match self
             .engine
@@ -193,7 +193,16 @@ impl<'a> ParsePipeline<'a> {
                 return Err(err);
             }
         };
-        theme::apply_theme_defaults(&mut effective_config);
+        if has_config_overrides {
+            theme::apply_theme_defaults(&mut effective_config);
+        } else if cached_effective_config
+            .as_ref()
+            .is_some_and(|cached| effective_config.ptr_eq(cached))
+        {
+            effective_config = self.engine.default_effective_config();
+        } else {
+            theme::apply_theme_defaults(&mut effective_config);
+        }
 
         let title = sanitized_title(pre.title.as_deref(), &effective_config);
 
@@ -221,11 +230,20 @@ impl<'a> ParsePipeline<'a> {
             return Err(Error::MalformedFrontMatter);
         }
 
-        let mut effective_config = self.engine.site_config.clone();
-        let effective_overrides = effective_config.secure_filtered_overrides(&pre.config);
-        effective_config.deep_merge(effective_overrides.as_value());
+        let has_config_overrides = !pre.config.is_empty_object();
+        let mut effective_config = self.effective_config_before_detect(&pre.config);
+        let cached_effective_config = (!has_config_overrides).then(|| effective_config.clone());
         family::apply_known_type_detector_side_effects(diagram_type, &mut effective_config);
-        theme::apply_theme_defaults(&mut effective_config);
+        if has_config_overrides {
+            theme::apply_theme_defaults(&mut effective_config);
+        } else if cached_effective_config
+            .as_ref()
+            .is_some_and(|cached| effective_config.ptr_eq(cached))
+        {
+            effective_config = self.engine.default_effective_config();
+        } else {
+            theme::apply_theme_defaults(&mut effective_config);
+        }
 
         let title = sanitized_title(pre.title.as_deref(), &effective_config);
 
@@ -244,6 +262,17 @@ impl<'a> ParsePipeline<'a> {
         runtime::with_fixed_today_local(self.engine.fixed_today_local, || {
             runtime::with_fixed_local_offset_minutes(self.engine.fixed_local_offset_minutes, f)
         })
+    }
+
+    fn effective_config_before_detect(&self, overrides: &MermaidConfig) -> MermaidConfig {
+        if overrides.is_empty_object() {
+            return self.engine.site_config.clone();
+        }
+
+        let mut effective_config = self.engine.site_config.clone();
+        let effective_overrides = effective_config.secure_filtered_overrides(overrides);
+        effective_config.deep_merge(effective_overrides.as_value());
+        effective_config
     }
 }
 

--- a/crates/merman-core/src/tests/misc.rs
+++ b/crates/merman-core/src/tests/misc.rs
@@ -12,6 +12,10 @@ fn parse_graph_defaults_to_flowchart_v2() {
         .unwrap();
     assert_eq!(res.diagram_type, "flowchart-v2");
     assert_eq!(res.config.as_value(), &json!({}));
+    assert_eq!(
+        res.effective_config.get_str("themeVariables.mainBkg"),
+        Some("#ECECFF")
+    );
 }
 
 #[test]

--- a/crates/merman-render/src/architecture.rs
+++ b/crates/merman-render/src/architecture.rs
@@ -554,21 +554,11 @@ fn architecture_fcose_node_bounds_extras<'a>(
     } = input;
     let text_style = architecture_cytoscape_text_style(font_size_px, font_family);
 
-    let mut node_title: FxHashMap<&str, &str> = FxHashMap::default();
-    node_title.reserve(model.nodes.len().saturating_mul(2));
-
-    for n in &model.nodes {
-        if let Some(t) = n.title {
-            node_title.insert(n.id, t);
-        }
-    }
-
     let mut node_bounds_extras: FxHashMap<&str, manatee::BoundsExtras> = FxHashMap::default();
     node_bounds_extras.reserve(model.nodes.len().saturating_mul(2));
     for n in &model.nodes {
-        let title = node_title.get(n.id).copied();
         let bounds_extras = architecture_measure_cytoscape_node_bbox_extras(
-            title,
+            n.title,
             text_measurer,
             &text_style,
             icon_size,

--- a/crates/merman-render/src/sequence/metrics.rs
+++ b/crates/merman-render/src/sequence/metrics.rs
@@ -24,24 +24,19 @@ pub(super) fn measure_svg_like_with_html_br(
     if lines.len() <= 1 {
         // Mermaid's `calculateTextDimensions` draws one `<text>/<tspan>` run per line, rounds
         // that bbox width, and keeps height from the same single-run bbox path.
-        let width_metrics = measurer.measure_wrapped(text, style, None, WrapMode::SvgLikeSingleRun);
         let metrics = measurer.measure_wrapped(text, style, None, WrapMode::SvgLikeSingleRun);
         let h = if metrics.height > 0.0 {
             metrics.height
         } else {
             default_line_height
         };
-        return (
-            width_metrics.width.round().max(0.0),
-            normalize_line_height(h),
-        );
+        return (metrics.width.round().max(0.0), normalize_line_height(h));
     }
     let mut max_w: f64 = 0.0;
     let mut line_h: f64 = 0.0;
     for line in &lines {
-        let width_metrics = measurer.measure_wrapped(line, style, None, WrapMode::SvgLikeSingleRun);
-        max_w = max_w.max(width_metrics.width.round().max(0.0));
         let metrics = measurer.measure_wrapped(line, style, None, WrapMode::SvgLikeSingleRun);
+        max_w = max_w.max(metrics.width.round().max(0.0));
         let h = if metrics.height > 0.0 {
             metrics.height
         } else {

--- a/crates/merman-render/src/svg/parity/architecture/edges.rs
+++ b/crates/merman-render/src/svg/parity/architecture/edges.rs
@@ -7,11 +7,8 @@ use crate::architecture_metrics::{
 use crate::model::Bounds;
 use crate::text::{TextMeasurer, VendoredFontMetricsTextMeasurer};
 
-use super::super::{escape_xml, fmt};
-use super::geometry::{
-    arrow_points, arrow_shift, bounds_from_rect, edge_id, extend_bounds, is_arch_dir_x,
-    is_arch_dir_y,
-};
+use super::super::{escape_xml_into, fmt, fmt_into, fmt_string};
+use super::geometry::{arrow_shift, bounds_from_rect, extend_bounds, is_arch_dir_x, is_arch_dir_y};
 use super::labels::{svg_line_plain_text, wrap_svg_words_to_lines, write_svg_text_lines};
 use super::model::ArchitectureModelAccess;
 use super::settings::ArchitectureRenderSettings;
@@ -46,10 +43,136 @@ struct ArchitectureEdgePoints {
     end_y: f64,
 }
 
-struct ArchitectureArrowGeometry {
-    points: String,
-    transform: String,
+struct ArchitectureArrowPoints {
+    left: String,
+    right: String,
+    top: String,
+    bottom: String,
+}
+
+impl ArchitectureArrowPoints {
+    fn new(arrow_size: f64) -> Self {
+        let s = fmt_string(arrow_size);
+        let hs = fmt_string(arrow_size / 2.0);
+        Self {
+            left: format!("{s},{hs} 0,{s} 0,0"),
+            right: format!("0,{hs} {s},0 {s},{s}"),
+            top: format!("0,0 {s},0 {hs},{s}"),
+            bottom: format!("{hs},0 {s},{s} 0,{s}"),
+        }
+    }
+
+    fn get(&self, dir: char) -> &str {
+        match dir {
+            'L' => self.left.as_str(),
+            'R' => self.right.as_str(),
+            'T' => self.top.as_str(),
+            'B' => self.bottom.as_str(),
+            _ => self.right.as_str(),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ArchitectureArrowTransform {
+    Translate {
+        x: f64,
+        y: f64,
+    },
+    TranslateRotate {
+        x: f64,
+        y: f64,
+        angle: f64,
+        cx: f64,
+        cy: f64,
+    },
+}
+
+struct ArchitectureArrowGeometry<'a> {
+    points: &'a str,
+    transform: ArchitectureArrowTransform,
     bounds: Bounds,
+}
+
+fn write_architecture_edge_id_attr(
+    out: &mut String,
+    diagram_id: &str,
+    prefix: &str,
+    from: &str,
+    to: &str,
+    counter: usize,
+) {
+    escape_xml_into(out, diagram_id);
+    out.push('-');
+    escape_xml_into(out, prefix);
+    out.push('_');
+    escape_xml_into(out, from);
+    out.push('_');
+    escape_xml_into(out, to);
+    out.push('_');
+    let _ = write!(out, "{counter}");
+}
+
+fn write_architecture_edge_path(
+    out: &mut String,
+    diagram_id: &str,
+    edge: super::model::ArchitectureEdgeRef<'_>,
+    points: ArchitectureEdgePoints,
+) {
+    out.push_str(r#"<path d="M "#);
+    fmt_into(out, points.start_x);
+    out.push(',');
+    fmt_into(out, points.start_y);
+    out.push_str(" L ");
+    fmt_into(out, points.mid_x);
+    out.push(',');
+    fmt_into(out, points.mid_y);
+    out.push_str(" L");
+    fmt_into(out, points.end_x);
+    out.push(',');
+    fmt_into(out, points.end_y);
+    out.push_str(r#" " class="edge" id=""#);
+    write_architecture_edge_id_attr(out, diagram_id, "L", edge.lhs_id, edge.rhs_id, 0);
+    out.push_str(r#""/>"#);
+}
+
+fn write_architecture_arrow_transform(out: &mut String, transform: ArchitectureArrowTransform) {
+    match transform {
+        ArchitectureArrowTransform::Translate { x, y } => {
+            out.push_str("translate(");
+            fmt_into(out, x);
+            out.push(',');
+            fmt_into(out, y);
+            out.push(')');
+        }
+        ArchitectureArrowTransform::TranslateRotate {
+            x,
+            y,
+            angle,
+            cx,
+            cy,
+        } => {
+            out.push_str("translate(");
+            fmt_into(out, x);
+            out.push(',');
+            fmt_into(out, y);
+            out.push_str(") rotate(");
+            fmt_into(out, angle);
+            out.push(',');
+            fmt_into(out, cx);
+            out.push(',');
+            fmt_into(out, cy);
+            out.push(')');
+        }
+    }
+}
+
+fn write_architecture_arrow_polygon(out: &mut String, arrow: &ArchitectureArrowGeometry<'_>) {
+    out.push_str(r#"<polygon points=""#);
+    out.push_str(arrow.points);
+    out.push_str(r#"" transform=""#);
+    write_architecture_arrow_transform(out, arrow.transform);
+    out.push_str(r#"" class="arrow"/>"#);
 }
 
 fn architecture_dir_unit(dir: char) -> (f64, f64) {
@@ -62,14 +185,15 @@ fn architecture_dir_unit(dir: char) -> (f64, f64) {
     }
 }
 
-fn architecture_arrow_geometry(
+fn architecture_arrow_geometry<'a>(
     dir: char,
     anchor_x: f64,
     anchor_y: f64,
     adjacent_x: f64,
     adjacent_y: f64,
     arrow_size: f64,
-) -> ArchitectureArrowGeometry {
+    arrow_points: &'a ArchitectureArrowPoints,
+) -> ArchitectureArrowGeometry<'a> {
     let half_arrow_size = arrow_size / 2.0;
     let dx = anchor_x - adjacent_x;
     let dy = anchor_y - adjacent_y;
@@ -93,8 +217,11 @@ fn architecture_arrow_geometry(
 
     if ux.abs() < 1e-6 || uy.abs() < 1e-6 {
         return ArchitectureArrowGeometry {
-            points: arrow_points(dir, arrow_size),
-            transform: format!("translate({},{})", fmt(port_x_shift), fmt(port_y_shift)),
+            points: arrow_points.get(dir),
+            transform: ArchitectureArrowTransform::Translate {
+                x: port_x_shift,
+                y: port_y_shift,
+            },
             bounds: bounds_from_rect(port_x_shift, port_y_shift, arrow_size, arrow_size),
         };
     }
@@ -121,21 +248,29 @@ fn architecture_arrow_geometry(
     let angle = (-ux).atan2(uy).to_degrees();
 
     ArchitectureArrowGeometry {
-        points: arrow_points('T', arrow_size),
-        transform: format!(
-            "translate({},{}) rotate({},{},{})",
-            fmt(tip_x - half_arrow_size),
-            fmt(tip_y - arrow_size),
-            fmt(angle),
-            fmt(half_arrow_size),
-            fmt(arrow_size)
-        ),
+        points: arrow_points.get('T'),
+        transform: ArchitectureArrowTransform::TranslateRotate {
+            x: tip_x - half_arrow_size,
+            y: tip_y - arrow_size,
+            angle,
+            cx: half_arrow_size,
+            cy: arrow_size,
+        },
         bounds: Bounds {
             min_x: exact_bounds.min_x.min(port_bounds.min_x),
             min_y: exact_bounds.min_y.min(port_bounds.min_y),
             max_x: exact_bounds.max_x.max(port_bounds.max_x),
             max_y: exact_bounds.max_y.max(port_bounds.max_y),
         },
+    }
+}
+
+fn architecture_edge_segment_bounds(points: ArchitectureEdgePoints) -> Bounds {
+    Bounds {
+        min_x: points.start_x.min(points.mid_x).min(points.end_x),
+        min_y: points.start_y.min(points.mid_y).min(points.end_y),
+        max_x: points.start_x.max(points.mid_x).max(points.end_x),
+        max_y: points.start_y.max(points.mid_y).max(points.end_y),
     }
 }
 
@@ -415,46 +550,40 @@ pub(super) fn push_architecture_edges<M: ArchitectureModelAccess>(
     // Edges (including conservative label bounds).
     if model.edges_len() != 0 {
         let arrow_size = settings.icon_size_px / 6.0;
+        let arrow_points = ArchitectureArrowPoints::new(arrow_size);
         for (edge_idx, edge) in model.edges().enumerate() {
             let points = edge_points(edge_idx, edge);
-
-            extend_bounds(
-                content_bounds,
-                Bounds::from_points(vec![
-                    (points.start_x, points.start_y),
-                    (points.mid_x, points.mid_y),
-                    (points.end_x, points.end_y),
-                ])
-                .unwrap_or(Bounds {
-                    min_x: points.start_x,
-                    min_y: points.start_y,
-                    max_x: points.end_x,
-                    max_y: points.end_y,
-                }),
-            );
-
-            if edge.lhs_into == Some(true) {
-                let arrow = architecture_arrow_geometry(
+            let lhs_arrow = (edge.lhs_into == Some(true)).then(|| {
+                architecture_arrow_geometry(
                     edge.lhs_dir,
                     points.start_x,
                     points.start_y,
                     points.mid_x,
                     points.mid_y,
                     arrow_size,
-                );
-                extend_bounds(content_bounds, arrow.bounds);
-            }
-
-            if edge.rhs_into == Some(true) {
-                let arrow = architecture_arrow_geometry(
+                    &arrow_points,
+                )
+            });
+            let rhs_arrow = (edge.rhs_into == Some(true)).then(|| {
+                architecture_arrow_geometry(
                     edge.rhs_dir,
                     points.end_x,
                     points.end_y,
                     points.mid_x,
                     points.mid_y,
                     arrow_size,
-                );
-                extend_bounds(content_bounds, arrow.bounds);
+                    &arrow_points,
+                )
+            });
+
+            extend_bounds(content_bounds, architecture_edge_segment_bounds(points));
+
+            if let Some(arrow) = lhs_arrow.as_ref() {
+                extend_bounds(content_bounds, arrow.bounds.clone());
+            }
+
+            if let Some(arrow) = rhs_arrow.as_ref() {
+                extend_bounds(content_bounds, arrow.bounds.clone());
             }
 
             let label_plan = architecture_edge_label_plan(edge, points, settings, text_measurer);
@@ -463,51 +592,14 @@ pub(super) fn push_architecture_edges<M: ArchitectureModelAccess>(
             }
 
             out.push_str("<g>");
-            let id = format!("{diagram_id}-{}", edge_id("L", edge.lhs_id, edge.rhs_id, 0));
-            let _ = write!(
-                out,
-                r#"<path d="M {sx},{sy} L {mx},{my} L{ex},{ey} " class="edge" id="{id}"/>"#,
-                sx = fmt(points.start_x),
-                sy = fmt(points.start_y),
-                mx = fmt(points.mid_x),
-                my = fmt(points.mid_y),
-                ex = fmt(points.end_x),
-                ey = fmt(points.end_y),
-                id = escape_xml(&id)
-            );
+            write_architecture_edge_path(out, diagram_id, edge, points);
 
-            if edge.lhs_into == Some(true) {
-                let arrow = architecture_arrow_geometry(
-                    edge.lhs_dir,
-                    points.start_x,
-                    points.start_y,
-                    points.mid_x,
-                    points.mid_y,
-                    arrow_size,
-                );
-                let _ = write!(
-                    out,
-                    r#"<polygon points="{pts}" transform="{transform}" class="arrow"/>"#,
-                    pts = arrow.points,
-                    transform = arrow.transform
-                );
+            if let Some(arrow) = lhs_arrow.as_ref() {
+                write_architecture_arrow_polygon(out, arrow);
             }
 
-            if edge.rhs_into == Some(true) {
-                let arrow = architecture_arrow_geometry(
-                    edge.rhs_dir,
-                    points.end_x,
-                    points.end_y,
-                    points.mid_x,
-                    points.mid_y,
-                    arrow_size,
-                );
-                let _ = write!(
-                    out,
-                    r#"<polygon points="{pts}" transform="{transform}" class="arrow"/>"#,
-                    pts = arrow.points,
-                    transform = arrow.transform
-                );
+            if let Some(arrow) = rhs_arrow.as_ref() {
+                write_architecture_arrow_polygon(out, arrow);
             }
 
             if let Some(label_plan) = label_plan {

--- a/crates/merman-render/src/svg/parity/architecture/geometry.rs
+++ b/crates/merman-render/src/svg/parity/architecture/geometry.rs
@@ -1,4 +1,4 @@
-use super::super::{Bounds, fmt};
+use super::super::Bounds;
 use crate::architecture_metrics::architecture_svg_group_bbox_padding_px;
 
 pub(super) fn is_arch_dir_x(dir: char) -> bool {
@@ -9,32 +9,6 @@ pub(super) fn is_arch_dir_y(dir: char) -> bool {
     matches!(dir, 'T' | 'B')
 }
 
-pub(super) fn arrow_points(dir: char, arrow_size: f64) -> String {
-    match dir {
-        'L' => format!(
-            "{s},{hs} 0,{s} 0,0",
-            s = fmt(arrow_size),
-            hs = fmt(arrow_size / 2.0)
-        ),
-        'R' => format!(
-            "0,{hs} {s},0 {s},{s}",
-            s = fmt(arrow_size),
-            hs = fmt(arrow_size / 2.0)
-        ),
-        'T' => format!(
-            "0,0 {s},0 {hs},{s}",
-            s = fmt(arrow_size),
-            hs = fmt(arrow_size / 2.0)
-        ),
-        'B' => format!(
-            "{hs},0 {s},{s} 0,{s}",
-            s = fmt(arrow_size),
-            hs = fmt(arrow_size / 2.0)
-        ),
-        _ => arrow_points('R', arrow_size),
-    }
-}
-
 pub(super) fn arrow_shift(dir: char, orig: f64, arrow_size: f64) -> f64 {
     // Mermaid@11.12.2 `ArchitectureDirectionArrowShift`.
     match dir {
@@ -42,11 +16,6 @@ pub(super) fn arrow_shift(dir: char, orig: f64, arrow_size: f64) -> f64 {
         'R' | 'B' => orig - 2.0,
         _ => orig,
     }
-}
-
-pub(super) fn edge_id(prefix: &str, from: &str, to: &str, counter: usize) -> String {
-    // Mirrors Mermaid `getEdgeId(from, to, { prefix })` (counter defaults to 0).
-    format!("{prefix}_{from}_{to}_{counter}")
 }
 
 pub(super) fn extend_bounds(bounds: &mut Option<Bounds>, other: Bounds) {

--- a/crates/merman-render/src/svg/parity/architecture/icons.rs
+++ b/crates/merman-render/src/svg/parity/architecture/icons.rs
@@ -1,6 +1,7 @@
 use crate::svg::icon_registry::scope_svg_internal_ids;
 
-use super::super::fmt;
+use super::super::fmt_into;
+use std::borrow::Cow;
 
 pub(super) fn arch_icon_body(name: &str) -> &'static str {
     // Copied from Mermaid@11.12.2 `packages/mermaid/src/diagrams/architecture/architectureIcons.ts`.
@@ -33,33 +34,127 @@ pub(super) fn arch_icon_body(name: &str) -> &'static str {
     }
 }
 
-pub(super) fn arch_icon_svg(icon_name: &str, icon_size_px: f64, id_scope: &str) -> String {
-    let body = arch_icon_body(icon_name);
-    let body = scope_svg_internal_ids(body, id_scope);
-    format!(
-        r#"<svg xmlns="http://www.w3.org/2000/svg" width="{w}" height="{h}" viewBox="0 0 80 80">{body}</svg>"#,
-        w = fmt(icon_size_px),
-        h = fmt(icon_size_px),
-        body = body
-    )
+fn arch_icon_body_has_internal_ids(name: &str) -> bool {
+    matches!(name, "database")
 }
 
-pub(super) fn arch_icon_svg_with_registry(
+pub(super) fn arch_icon_needs_id_scope(icon_name: &str, has_registry: bool) -> bool {
+    has_registry || arch_icon_body_has_internal_ids(icon_name)
+}
+
+pub(super) fn write_arch_icon_svg(
+    out: &mut String,
+    icon_name: &str,
+    icon_size_px: f64,
+    id_scope: &str,
+) {
+    let body = arch_icon_body(icon_name);
+    let body = if arch_icon_body_has_internal_ids(icon_name) {
+        Cow::Owned(scope_svg_internal_ids(body, id_scope))
+    } else {
+        Cow::Borrowed(body)
+    };
+    out.push_str(r#"<svg xmlns="http://www.w3.org/2000/svg" width=""#);
+    fmt_into(out, icon_size_px);
+    out.push_str(r#"" height=""#);
+    fmt_into(out, icon_size_px);
+    out.push_str(r#"" viewBox="0 0 80 80">"#);
+    out.push_str(body.as_ref());
+    out.push_str("</svg>");
+}
+
+pub(super) fn write_arch_icon_svg_with_registry(
+    out: &mut String,
     icon_name: &str,
     icon_size_px: f64,
     icon_registry: Option<&crate::svg::IconRegistry>,
     id_scope: &str,
-) -> String {
-    icon_registry
-        .and_then(|registry| {
-            registry.svg_for_scoped(
-                icon_name,
-                icon_size_px,
-                icon_size_px,
-                Some("architecture"),
-                None,
-                id_scope,
-            )
-        })
-        .unwrap_or_else(|| arch_icon_svg(icon_name, icon_size_px, id_scope))
+) {
+    if let Some(svg) = icon_registry.and_then(|registry| {
+        registry.svg_for_scoped(
+            icon_name,
+            icon_size_px,
+            icon_size_px,
+            Some("architecture"),
+            None,
+            id_scope,
+        )
+    }) {
+        out.push_str(&svg);
+    } else {
+        write_arch_icon_svg(out, icon_name, icon_size_px, id_scope);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::svg::{IconRegistry, IconSvg};
+
+    #[test]
+    fn write_arch_icon_svg_preserves_builtin_id_scoping_behavior() {
+        let mut server = String::new();
+        write_arch_icon_svg(&mut server, "server", 80.0, "scope-a");
+        assert!(server.starts_with(
+            r#"<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">"#
+        ));
+        assert!(server.contains(r#"<rect x="17.5" y="17.5""#));
+        assert!(!server.contains("IconifyId"), "{server}");
+
+        let mut database = String::new();
+        write_arch_icon_svg(&mut database, "database", 80.0, "scope-b");
+        assert!(database.contains(r#"id="IconifyId"#), "{database}");
+        assert!(!database.contains(r#"id="b""#), "{database}");
+    }
+
+    #[test]
+    fn arch_icon_scope_requirement_tracks_registry_and_internal_ids() {
+        assert!(arch_icon_needs_id_scope("database", false));
+        assert!(arch_icon_needs_id_scope("server", true));
+        assert!(!arch_icon_needs_id_scope("server", false));
+        assert!(!arch_icon_needs_id_scope("blank", false));
+    }
+
+    #[test]
+    fn write_arch_icon_svg_with_registry_scopes_internal_ids_per_architecture_node() {
+        let mut registry = IconRegistry::new();
+        registry.insert(
+            "test:clip",
+            IconSvg::new(
+                r##"<defs><clipPath id="clip"><path id="shape" d="M0 0H16V16H0z"/></clipPath></defs><path data-icon="fixture" clip-path="url(#clip)" d="M0 0H16V16H0z"/><use href="#shape" xlink:href="#shape"/>"##,
+                16.0,
+                16.0,
+            ),
+        );
+
+        let mut service = String::new();
+        write_arch_icon_svg_with_registry(
+            &mut service,
+            "test:clip",
+            80.0,
+            Some(&registry),
+            "diagram-service-a-icon",
+        );
+        let mut group = String::new();
+        write_arch_icon_svg_with_registry(
+            &mut group,
+            "test:clip",
+            60.0,
+            Some(&registry),
+            "diagram-group-app-icon",
+        );
+
+        for svg in [&service, &group] {
+            assert!(!svg.contains(r#"id="clip""#), "{svg}");
+            assert!(!svg.contains(r#"id="shape""#), "{svg}");
+            assert!(!svg.contains(r#"url(#clip)"#), "{svg}");
+            assert!(!svg.contains(r##"href="#shape""##), "{svg}");
+            assert_eq!(svg.matches(r#"data-icon="fixture""#).count(), 1, "{svg}");
+            assert_eq!(svg.matches(r#"id="IconifyId"#).count(), 2, "{svg}");
+        }
+
+        assert_ne!(service, group);
+        assert!(service.contains(r#"width="80" height="80""#), "{service}");
+        assert!(group.contains(r#"width="60" height="60""#), "{group}");
+    }
 }

--- a/crates/merman-render/src/svg/parity/architecture/labels.rs
+++ b/crates/merman-render/src/svg/parity/architecture/labels.rs
@@ -357,6 +357,87 @@ pub(super) fn write_svg_text_lines(out: &mut String, lines: &[SvgLine]) {
     out.push_str("</text>");
 }
 
+fn plain_single_word_title_fits(
+    title: &str,
+    title_width_px: f64,
+    measurer: &dyn crate::text::TextMeasurer,
+    style: &crate::text::TextStyle,
+) -> bool {
+    if !(title_width_px.is_finite() && title_width_px > 0.0) {
+        return false;
+    }
+    if title.is_empty() || !title.bytes().all(|b| b.is_ascii_alphanumeric()) {
+        return false;
+    }
+
+    let conservative_width = title.len() as f64 * style.font_size.max(1.0);
+    if conservative_width <= title_width_px {
+        return true;
+    }
+
+    measurer.measure(title, style).width <= title_width_px
+}
+
+fn plain_ascii_words_title(text: &str) -> bool {
+    if text.is_empty() {
+        return false;
+    }
+
+    let mut prev_space = false;
+    for (idx, b) in text.bytes().enumerate() {
+        if b == b' ' {
+            if idx == 0 || prev_space {
+                return false;
+            }
+            prev_space = true;
+            continue;
+        }
+        if !b.is_ascii_alphanumeric() {
+            return false;
+        }
+        prev_space = false;
+    }
+
+    !prev_space
+}
+
+pub(super) fn plain_ascii_words_single_line_width(
+    title: &str,
+    title_width_px: f64,
+    measurer: &dyn crate::text::TextMeasurer,
+    style: &crate::text::TextStyle,
+) -> Option<f64> {
+    if !(title_width_px.is_finite() && title_width_px > 0.0) || !plain_ascii_words_title(title) {
+        return None;
+    }
+
+    let width = measurer.measure(title, style).width;
+    if width <= title_width_px {
+        Some(width)
+    } else {
+        None
+    }
+}
+
+pub(super) fn write_svg_plain_ascii_words_text_line(out: &mut String, text: &str) {
+    out.push_str(r#"<text y="-10.1" style=""><tspan class="text-outer-tspan" x="0" y="-0.1em" dy="1.1em"><tspan font-style="normal" class="text-inner-tspan" font-weight="normal">"#);
+    if let Some((first, rest)) = text.split_once(' ') {
+        out.push_str(first);
+        out.push_str("</tspan>");
+        for word in rest.split(' ') {
+            out.push_str(
+                r#"<tspan font-style="normal" class="text-inner-tspan" font-weight="normal"> "#,
+            );
+            out.push_str(word);
+            out.push_str("</tspan>");
+        }
+        out.push_str("</tspan></text>");
+    } else {
+        out.push_str(text);
+        out.push_str("</tspan></tspan></text>");
+    }
+}
+
 pub(super) fn write_architecture_service_title(
     out: &mut String,
     title: &str,
@@ -365,7 +446,7 @@ pub(super) fn write_architecture_service_title(
     measurer: &crate::text::VendoredFontMetricsTextMeasurer,
     style: &crate::text::TextStyle,
 ) {
-    let lines = wrap_svg_words_to_lines(title, title_width_px, measurer, style);
+    let plain_single_line = plain_single_word_title_fits(title, title_width_px, measurer, style);
 
     let _ = write!(
         out,
@@ -373,6 +454,99 @@ pub(super) fn write_architecture_service_title(
         x = fmt(icon_size_px / 2.0),
         y = fmt(icon_size_px)
     );
-    write_svg_text_lines(out, &lines);
+    if plain_single_line {
+        write_svg_plain_ascii_words_text_line(out, title);
+    } else {
+        let lines = wrap_svg_words_to_lines(title, title_width_px, measurer, style);
+        write_svg_text_lines(out, &lines);
+    }
     out.push_str("</g></g>");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::text::TextMeasurer;
+
+    fn text_style() -> crate::text::TextStyle {
+        crate::text::TextStyle {
+            font_family: Some("\"trebuchet ms\", verdana, arial, sans-serif".to_string()),
+            font_size: 16.0,
+            font_weight: None,
+        }
+    }
+
+    #[test]
+    fn plain_single_word_title_fast_path_is_narrow_and_width_checked() {
+        let measurer = crate::text::VendoredFontMetricsTextMeasurer::default();
+        let style = text_style();
+
+        assert!(plain_single_word_title_fits("s1", 120.0, &measurer, &style));
+        assert!(!plain_single_word_title_fits(
+            "s 1", 120.0, &measurer, &style
+        ));
+        assert!(!plain_single_word_title_fits(
+            "s_1", 120.0, &measurer, &style
+        ));
+        assert!(plain_ascii_words_title("Service Farm"));
+        assert!(!plain_ascii_words_title("Service  Farm"));
+        assert!(!plain_ascii_words_title("Service-Farm"));
+        assert!(!plain_single_word_title_fits(
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+            1.0,
+            &measurer,
+            &style
+        ));
+    }
+
+    #[test]
+    fn architecture_plain_service_title_fast_path_matches_single_word_dom() {
+        let measurer = crate::text::VendoredFontMetricsTextMeasurer::default();
+        let style = text_style();
+        let mut out = String::new();
+
+        write_architecture_service_title(&mut out, "s1", 80.0, 120.0, &measurer, &style);
+
+        assert_eq!(
+            out,
+            r#"<g dy="1em" alignment-baseline="middle" dominant-baseline="middle" text-anchor="middle" transform="translate(40, 80)"><g><rect class="background" style="stroke: none"/><text y="-10.1" style=""><tspan class="text-outer-tspan" x="0" y="-0.1em" dy="1.1em"><tspan font-style="normal" class="text-inner-tspan" font-weight="normal">s1</tspan></tspan></text></g></g>"#
+        );
+    }
+
+    #[test]
+    fn architecture_plain_words_fast_path_matches_single_line_dom() {
+        let measurer = crate::text::VendoredFontMetricsTextMeasurer::default();
+        let style = text_style();
+        let mut out = String::new();
+        let mut wrapped = String::new();
+
+        write_svg_plain_ascii_words_text_line(&mut out, "Service Farm");
+        write_svg_text_lines(
+            &mut wrapped,
+            &wrap_svg_words_to_lines("Service Farm", 120.0, &measurer, &style),
+        );
+
+        assert_eq!(
+            out,
+            r#"<text y="-10.1" style=""><tspan class="text-outer-tspan" x="0" y="-0.1em" dy="1.1em"><tspan font-style="normal" class="text-inner-tspan" font-weight="normal">Service</tspan><tspan font-style="normal" class="text-inner-tspan" font-weight="normal"> Farm</tspan></tspan></text>"#
+        );
+        assert_eq!(out, wrapped);
+    }
+
+    #[test]
+    fn plain_ascii_words_single_line_width_reuses_svg_measurement() {
+        let measurer = crate::text::VendoredFontMetricsTextMeasurer::default();
+        let style = text_style();
+        let title = "Service Farm";
+        let expected = measurer.measure(title, &style).width;
+
+        assert_eq!(
+            plain_ascii_words_single_line_width(title, expected + 1.0, &measurer, &style),
+            Some(expected)
+        );
+        assert_eq!(
+            plain_ascii_words_single_line_width(title, expected - 1.0, &measurer, &style),
+            None
+        );
+    }
 }

--- a/crates/merman-render/src/svg/parity/architecture/nodes.rs
+++ b/crates/merman-render/src/svg/parity/architecture/nodes.rs
@@ -4,15 +4,17 @@ use crate::architecture_metrics::ARCHITECTURE_SERVICE_LABEL_BOTTOM_EXTENSION_PX;
 use crate::model::Bounds;
 use crate::text::{TextMeasurer, VendoredFontMetricsTextMeasurer, WrapMode};
 
-use super::super::{escape_xml, fmt};
+use super::super::{escape_xml_into, fmt};
 use super::foreign_object::{
     escape_xml_ampersands_preserving_xml_entities, normalize_xhtml_fragment_for_foreign_object,
 };
 use super::geometry::{GroupRect, extend_bounds};
-use super::icons::{arch_icon_svg, arch_icon_svg_with_registry};
+use super::icons::{
+    arch_icon_needs_id_scope, write_arch_icon_svg, write_arch_icon_svg_with_registry,
+};
 use super::labels::{
-    svg_line_plain_text, wrap_svg_words_to_lines, write_architecture_service_title,
-    write_svg_text_lines,
+    plain_ascii_words_single_line_width, svg_line_plain_text, wrap_svg_words_to_lines,
+    write_architecture_service_title, write_svg_plain_ascii_words_text_line, write_svg_text_lines,
 };
 use super::model::ArchitectureModelAccess;
 use super::settings::ArchitectureRenderSettings;
@@ -28,6 +30,18 @@ pub(super) struct ArchitectureNodeRenderContext<'a, M: ArchitectureModelAccess> 
     pub(super) icon_registry: Option<&'a crate::svg::IconRegistry>,
     pub(super) content_bounds: &'a mut Option<Bounds>,
     pub(super) singleton_icon_text_service_id: Option<&'a str>,
+}
+
+fn write_diagram_service_id(out: &mut String, diagram_id: &str, service_id: &str) {
+    escape_xml_into(out, diagram_id);
+    out.push_str("-service-");
+    escape_xml_into(out, service_id);
+}
+
+fn write_diagram_node_id(out: &mut String, diagram_id: &str, node_id: &str) {
+    escape_xml_into(out, diagram_id);
+    out.push_str("-node-");
+    escape_xml_into(out, node_id);
 }
 
 pub(super) fn push_architecture_services_and_junctions<M: ArchitectureModelAccess>(
@@ -52,13 +66,12 @@ pub(super) fn push_architecture_services_and_junctions<M: ArchitectureModelAcces
         for svc in model.services() {
             let (x, y) = node_xy.get(svc.id).copied().unwrap_or((0.0, 0.0));
             let y = y + singleton_icon_text_offset_y(singleton_icon_text_service_id, svc.id);
-            let service_id_esc = escape_xml(&format!("{diagram_id}-service-{}", svc.id));
-            let node_id_esc = escape_xml(&format!("{diagram_id}-node-{}", svc.id));
 
+            out.push_str(r#"<g id=""#);
+            write_diagram_service_id(out, diagram_id, svc.id);
             let _ = write!(
                 out,
-                r#"<g id="{id}" class="architecture-service" transform="translate({x},{y})">"#,
-                id = service_id_esc,
+                r#"" class="architecture-service" transform="translate({x},{y})">"#,
                 x = fmt(x),
                 y = fmt(y)
             );
@@ -78,22 +91,24 @@ pub(super) fn push_architecture_services_and_junctions<M: ArchitectureModelAcces
             out.push_str("<g>");
             match (svc.icon, svc.icon_text) {
                 (Some(icon), _) => {
-                    let id_scope = format!("{diagram_id}-service-{}-icon", svc.id);
-                    let svg = arch_icon_svg_with_registry(
-                        icon,
-                        settings.icon_size_px,
-                        ctx.icon_registry,
-                        &id_scope,
-                    );
                     out.push_str("<g>");
-                    out.push_str(&svg);
+                    if arch_icon_needs_id_scope(icon, ctx.icon_registry.is_some()) {
+                        let id_scope = format!("{diagram_id}-service-{}-icon", svc.id);
+                        write_arch_icon_svg_with_registry(
+                            out,
+                            icon,
+                            settings.icon_size_px,
+                            ctx.icon_registry,
+                            &id_scope,
+                        );
+                    } else {
+                        write_arch_icon_svg(out, icon, settings.icon_size_px, "");
+                    }
                     out.push_str("</g>");
                 }
                 (None, Some(icon_text)) => {
-                    let id_scope = format!("{diagram_id}-service-{}-icon", svc.id);
-                    let svg = arch_icon_svg("blank", settings.icon_size_px, &id_scope);
                     out.push_str("<g>");
-                    out.push_str(&svg);
+                    write_arch_icon_svg(out, "blank", settings.icon_size_px, "");
                     out.push_str("</g>");
 
                     // Mermaid computes `iconText` clamp from the DOM `font-size` applied to the
@@ -117,10 +132,11 @@ pub(super) fn push_architecture_services_and_junctions<M: ArchitectureModelAcces
                     );
                 }
                 (None, None) => {
+                    out.push_str(r#"<path class="node-bkg" id=""#);
+                    write_diagram_node_id(out, diagram_id, svc.id);
                     let _ = write!(
                         out,
-                        r#"<path class="node-bkg" id="{id}" d="M0,{s} V5 Q0,0 5,0 H{inner_s} Q{s},0 {s},5 V{s} Z"/>"#,
-                        id = node_id_esc,
+                        r#"" d="M0,{s} V5 Q0,0 5,0 H{inner_s} Q{s},0 {s},5 V{s} Z"/>"#,
                         s = fmt(settings.icon_size_px),
                         inner_s = fmt(settings.icon_size_px - 5.0)
                     );
@@ -133,14 +149,17 @@ pub(super) fn push_architecture_services_and_junctions<M: ArchitectureModelAcces
 
         for junction in model.junctions() {
             let (x, y) = node_xy.get(junction.id).copied().unwrap_or((0.0, 0.0));
-            let id_esc = escape_xml(&format!("{diagram_id}-node-{}", junction.id));
 
             let _ = write!(
                 out,
-                r#"<g class="architecture-junction" transform="translate({x},{y})"><g><rect id="{id}" fill-opacity="0" width="{s}" height="{s}"/></g></g>"#,
+                r#"<g class="architecture-junction" transform="translate({x},{y})"><g><rect id=""#,
                 x = fmt(x),
                 y = fmt(y),
-                id = id_esc,
+            );
+            write_diagram_node_id(out, diagram_id, junction.id);
+            let _ = write!(
+                out,
+                r#"" fill-opacity="0" width="{s}" height="{s}"/></g></g>"#,
                 s = fmt(settings.icon_size_px)
             );
         }
@@ -163,7 +182,6 @@ pub(super) fn push_architecture_groups<'a, M: ArchitectureModelAccess>(
         out.push_str(r#"<g class="architecture-groups">"#);
 
         for grp in group_rects {
-            let group_id_esc = escape_xml(&format!("{}-group-{}", ctx.diagram_id, grp.id));
             let x = grp.x;
             let y = grp.y;
             let w = grp.w;
@@ -172,10 +190,13 @@ pub(super) fn push_architecture_groups<'a, M: ArchitectureModelAccess>(
             let x1 = x - settings.half_icon;
             let y1 = y - settings.half_icon;
 
+            out.push_str(r#"<rect id=""#);
+            escape_xml_into(out, ctx.diagram_id);
+            out.push_str("-group-");
+            escape_xml_into(out, grp.id);
             let _ = write!(
                 out,
-                r#"<rect id="{id}" x="{x}" y="{y}" width="{w}" height="{h}" class="node-bkg"/>"#,
-                id = group_id_esc,
+                r#"" x="{x}" y="{y}" width="{w}" height="{h}" class="node-bkg"/>"#,
                 x = fmt(x),
                 y = fmt(y),
                 w = fmt(w.max(1.0)),
@@ -187,20 +208,25 @@ pub(super) fn push_architecture_groups<'a, M: ArchitectureModelAccess>(
             let mut shifted_x1 = x1;
             let mut shifted_y1 = y1;
             if let Some(icon) = grp.icon.map(str::trim).filter(|t| !t.is_empty()) {
-                let id_scope = format!("{}-group-{}-icon", ctx.diagram_id, grp.id);
-                let svg = arch_icon_svg_with_registry(
-                    icon,
-                    group_icon_size_px,
-                    ctx.icon_registry,
-                    &id_scope,
-                );
                 let _ = write!(
                     out,
-                    r#"<g transform="translate({x}, {y})"><g>{svg}</g></g>"#,
+                    r#"<g transform="translate({x}, {y})"><g>"#,
                     x = fmt(shifted_x1 + settings.half_icon + 1.0),
-                    y = fmt(shifted_y1 + settings.half_icon + 1.0),
-                    svg = svg
+                    y = fmt(shifted_y1 + settings.half_icon + 1.0)
                 );
+                if arch_icon_needs_id_scope(icon, ctx.icon_registry.is_some()) {
+                    let id_scope = format!("{}-group-{}-icon", ctx.diagram_id, grp.id);
+                    write_arch_icon_svg_with_registry(
+                        out,
+                        icon,
+                        group_icon_size_px,
+                        ctx.icon_registry,
+                        &id_scope,
+                    );
+                } else {
+                    write_arch_icon_svg(out, icon, group_icon_size_px, "");
+                }
+                out.push_str("</g></g>");
                 shifted_x1 += group_icon_size_px;
                 // Mermaid uses `architecture.fontSize` for this alignment tweak (not the global SVG
                 // font size used for label rendering).
@@ -208,31 +234,53 @@ pub(super) fn push_architecture_groups<'a, M: ArchitectureModelAccess>(
             }
 
             if let Some(title) = grp.title.map(str::trim).filter(|t| !t.is_empty()) {
-                let lines = wrap_svg_words_to_lines(title, w, text_measurer, &settings.text_style);
+                let plain_title_width = plain_ascii_words_single_line_width(
+                    title,
+                    w,
+                    text_measurer,
+                    &settings.text_style,
+                );
+                let lines = if plain_title_width.is_some() {
+                    None
+                } else {
+                    Some(wrap_svg_words_to_lines(
+                        title,
+                        w,
+                        text_measurer,
+                        &settings.text_style,
+                    ))
+                };
+
                 // Group titles are SVG `<text>` (no explicit bbox geometry), so our SVG bbox pass
                 // cannot "see" their extents. Union a conservative horizontal bbox so
                 // `setupGraphViewbox(svg.getBBox() + padding)` matches upstream in parity-root.
-                let mut title_bbox_w = 0.0f64;
-                let has_multiline_title = lines.len() > 1;
-                for line in &lines {
-                    let s = svg_line_plain_text(line);
-                    let m = text_measurer.measure_wrapped(
-                        s.as_str(),
-                        &settings.text_style,
-                        None,
-                        WrapMode::SvgLike,
-                    );
-                    // Chromium's SVG `getBBox()` reports multi-`tspan` title rows on an integer
-                    // pixel boundary in upstream Architecture roots; keep this limited to wrapped
-                    // group titles so ordinary service labels and one-line group titles retain the
-                    // existing fractional text metric model.
-                    let width = if has_multiline_title {
-                        m.width.ceil()
-                    } else {
-                        m.width
-                    };
-                    title_bbox_w = title_bbox_w.max(width);
-                }
+                let title_bbox_w = if let Some(width) = plain_title_width {
+                    width
+                } else {
+                    let lines = lines.as_ref().expect("group title lines");
+                    let mut title_bbox_w = 0.0f64;
+                    let has_multiline_title = lines.len() > 1;
+                    for line in lines {
+                        let s = svg_line_plain_text(line);
+                        let m = text_measurer.measure_wrapped(
+                            s.as_str(),
+                            &settings.text_style,
+                            None,
+                            WrapMode::SvgLike,
+                        );
+                        // Chromium's SVG `getBBox()` reports multi-`tspan` title rows on an integer
+                        // pixel boundary in upstream Architecture roots; keep this limited to wrapped
+                        // group titles so ordinary service labels and one-line group titles retain the
+                        // existing fractional text metric model.
+                        let width = if has_multiline_title {
+                            m.width.ceil()
+                        } else {
+                            m.width
+                        };
+                        title_bbox_w = title_bbox_w.max(width);
+                    }
+                    title_bbox_w
+                };
                 if title_bbox_w.is_finite() && title_bbox_w > 0.0 {
                     let title_x = shifted_x1 + settings.half_icon + 4.0;
                     // Keep Y extents within the group rect; we only need this to expand X.
@@ -250,7 +298,11 @@ pub(super) fn push_architecture_groups<'a, M: ArchitectureModelAccess>(
                     x = fmt(shifted_x1 + settings.half_icon + 4.0),
                     y = fmt(shifted_y1 + settings.half_icon + 2.0)
                 );
-                write_svg_text_lines(out, &lines);
+                if plain_title_width.is_some() {
+                    write_svg_plain_ascii_words_text_line(out, title);
+                } else if let Some(lines) = lines.as_ref() {
+                    write_svg_text_lines(out, lines);
+                }
                 out.push_str("</g></g>");
             }
 

--- a/crates/merman-render/src/svg/parity/architecture/render.rs
+++ b/crates/merman-render/src/svg/parity/architecture/render.rs
@@ -3,11 +3,12 @@ use crate::architecture_metrics::{
     ARCHITECTURE_SERVICE_LABEL_BOTTOM_EXTENSION_PX, architecture_estimate_service_bounds,
     architecture_top_level_service_root_bounds,
 };
+use crate::model::ArchitectureCytoscapeServiceBounds;
 
 use super::edges::{ArchitectureEdgeRenderContext, push_architecture_edges};
 use super::geometry::{GroupRect, GroupRectComputer, bounds_from_rect, extend_bounds};
 use super::labels::{svg_line_plain_text, wrap_svg_words_to_lines};
-use super::model::{ArchitectureModel, ArchitectureModelAccess};
+use super::model::{ArchitectureModel, ArchitectureModelAccess, ArchitectureServiceRef};
 use super::nodes::{
     ArchitectureNodeRenderContext, push_architecture_groups,
     push_architecture_services_and_junctions,
@@ -25,6 +26,49 @@ fn timing_section<'a>(
     dst: &'a mut web_time::Duration,
 ) -> Option<super::super::timing::TimingGuard<'a>> {
     enabled.then(|| super::super::timing::TimingGuard::new(dst))
+}
+
+fn architecture_bounds_match_icon_rect(bounds: &Bounds, x: f64, y: f64, icon_size_px: f64) -> bool {
+    const EPSILON: f64 = 1e-6;
+    (bounds.min_x - x).abs() <= EPSILON
+        && (bounds.min_y - y).abs() <= EPSILON
+        && (bounds.max_x - (x + icon_size_px)).abs() <= EPSILON
+        && (bounds.max_y - (y + icon_size_px)).abs() <= EPSILON
+}
+
+fn architecture_cached_service_child_bounds<'a>(
+    service_bounds_by_id: &'a rustc_hash::FxHashMap<&str, &'a ArchitectureCytoscapeServiceBounds>,
+    service: ArchitectureServiceRef<'_>,
+    x: f64,
+    y: f64,
+    icon_size_px: f64,
+) -> Option<&'a ArchitectureCytoscapeServiceBounds> {
+    let cached = service_bounds_by_id.get(service.id).copied()?;
+    if cached.in_group.as_deref() != service.in_group {
+        return None;
+    }
+    if !architecture_bounds_match_icon_rect(&cached.body_bounds, x, y, icon_size_px) {
+        return None;
+    }
+    Some(cached)
+}
+
+fn architecture_svg_output_capacity<M: ArchitectureModelAccess>(
+    model: &M,
+    css_len: usize,
+    a11y_len: usize,
+) -> usize {
+    let service_count = model.services().count();
+    let junction_count = model.junctions().count();
+    let group_count = model.groups_len();
+    let edge_count = model.edges_len();
+    1024usize
+        .saturating_add(css_len)
+        .saturating_add(a11y_len)
+        .saturating_add(service_count.saturating_mul(900))
+        .saturating_add(junction_count.saturating_mul(180))
+        .saturating_add(group_count.saturating_mul(700))
+        .saturating_add(edge_count.saturating_mul(650))
 }
 
 struct ArchitectureRenderRequest<'a, M: ArchitectureModelAccess> {
@@ -153,17 +197,15 @@ fn render_architecture_diagram_svg_with_model<M: ArchitectureModelAccess>(
 
     let diagram_id = options.diagram_id.as_deref().unwrap_or("architecture");
     let settings = ArchitectureRenderSettings::from_config(diagram_id, effective_config);
-    let ArchitectureRenderSettings {
-        css,
-        icon_size_px,
-        half_icon,
-        padding_px,
-        arch_font_size_px,
-        svg_font_size_px,
-        use_max_width,
-        text_style,
-        compound_text_style,
-    } = settings.clone();
+    let css = settings.css.as_str();
+    let icon_size_px = settings.icon_size_px;
+    let half_icon = settings.half_icon;
+    let padding_px = settings.padding_px;
+    let arch_font_size_px = settings.arch_font_size_px;
+    let svg_font_size_px = settings.svg_font_size_px;
+    let use_max_width = settings.use_max_width;
+    let text_style = &settings.text_style;
+    let compound_text_style = &settings.compound_text_style;
     let sanitize_config_owned: merman_core::MermaidConfig;
     let sanitize_config = match sanitize_config_opt {
         Some(cfg) => cfg,
@@ -246,10 +288,33 @@ fn render_architecture_diagram_svg_with_model<M: ArchitectureModelAccess>(
         services_with_edges.insert(edge.rhs_id);
     }
 
+    let mut cached_service_bounds_by_id: rustc_hash::FxHashMap<
+        &str,
+        &ArchitectureCytoscapeServiceBounds,
+    > = rustc_hash::FxHashMap::default();
+    cached_service_bounds_by_id.reserve(layout.cytoscape_service_bounds.len());
+    for bounds in &layout.cytoscape_service_bounds {
+        cached_service_bounds_by_id.insert(bounds.id.as_str(), bounds);
+    }
+
     let mut service_bounds: rustc_hash::FxHashMap<&str, Bounds> = rustc_hash::FxHashMap::default();
     for svc in model.services() {
         let (x, y) = node_xy.get(svc.id).copied().unwrap_or((0.0, 0.0));
         let y = y + singleton_icon_text_offset_y(svc.id);
+        if svc.in_group.is_some()
+            && let Some(cached) = architecture_cached_service_child_bounds(
+                &cached_service_bounds_by_id,
+                svc,
+                x,
+                y,
+                icon_size_px,
+            )
+        {
+            service_bounds.insert(svc.id, cached.union_bounds.clone());
+            extend_bounds(&mut content_bounds, cached.body_bounds.clone());
+            continue;
+        }
+
         let estimate = architecture_estimate_service_bounds(
             x,
             y,
@@ -258,8 +323,8 @@ fn render_architecture_diagram_svg_with_model<M: ArchitectureModelAccess>(
             svg_font_size_px,
             svc.title,
             &text_measurer,
-            &text_style,
-            &compound_text_style,
+            text_style,
+            compound_text_style,
             wrap_svg_words_to_lines,
             |line| svg_line_plain_text(line.as_slice()),
             |line, style| text_measurer.measure_svg_text_bbox_x(line, style),
@@ -374,11 +439,15 @@ fn render_architecture_diagram_svg_with_model<M: ArchitectureModelAccess>(
         && model.groups_len() == 0
         && model.edges_len() == 0;
 
-    let mut out = String::new();
-    push_architecture_root_open(ArchitectureRootOpenContext {
+    let mut out = String::with_capacity(architecture_svg_output_capacity(
+        model,
+        settings.css.len(),
+        a11y.nodes.len(),
+    ));
+    let root_open = push_architecture_root_open(ArchitectureRootOpenContext {
         out: &mut out,
         diagram_id,
-        css: css.as_str(),
+        css,
         a11y: &a11y,
         is_empty,
         use_max_width,
@@ -426,11 +495,13 @@ fn render_architecture_diagram_svg_with_model<M: ArchitectureModelAccess>(
             out,
             diagram_id,
             model,
+            root_open: root_open.expect("architecture root placeholders missing"),
             content_bounds,
             padding_px,
             icon_size_px,
             use_max_width,
             apply_root_overrides: options.apply_root_overrides,
+            trust_content_bounds: options.icon_registry.is_none(),
         });
     }
 

--- a/crates/merman-render/src/svg/parity/architecture/root.rs
+++ b/crates/merman-render/src/svg/parity/architecture/root.rs
@@ -1,9 +1,15 @@
 use std::fmt::Write as _;
+use std::ops::Range;
 
 use super::super::{escape_xml_display, fmt, root_svg};
 
 pub(super) const VIEWBOX_PLACEHOLDER: &str = "__MERMAID_VIEWBOX__";
 pub(super) const MAX_WIDTH_PLACEHOLDER: &str = "__MERMAID_MAX_WIDTH__";
+
+pub(super) struct ArchitectureRootOpen {
+    pub(super) viewbox_placeholder_range: Range<usize>,
+    pub(super) max_width_placeholder_range: Option<Range<usize>>,
+}
 
 pub(super) struct ArchitectureA11y {
     pub(super) aria_labelledby: Option<String>,
@@ -62,7 +68,9 @@ pub(super) struct ArchitectureRootOpenContext<'a> {
     pub(super) icon_size_px: f64,
 }
 
-pub(super) fn push_architecture_root_open(ctx: ArchitectureRootOpenContext<'_>) {
+pub(super) fn push_architecture_root_open(
+    ctx: ArchitectureRootOpenContext<'_>,
+) -> Option<ArchitectureRootOpen> {
     let ArchitectureRootOpenContext {
         out,
         diagram_id,
@@ -139,4 +147,26 @@ pub(super) fn push_architecture_root_open(ctx: ArchitectureRootOpenContext<'_>) 
     out.push_str(a11y.nodes.as_str());
     let _ = write!(out, "<style>{}</style>", css);
     out.push_str("<g/><g class=\"architecture-edges\">");
+
+    if is_empty {
+        return None;
+    }
+
+    let viewbox_pos = out
+        .find(VIEWBOX_PLACEHOLDER)
+        .expect("architecture svg root missing viewBox placeholder");
+    let viewbox_placeholder_range = viewbox_pos..(viewbox_pos + VIEWBOX_PLACEHOLDER.len());
+    let max_width_placeholder_range = if use_max_width {
+        let max_width_pos = out
+            .find(MAX_WIDTH_PLACEHOLDER)
+            .expect("architecture svg root missing max-width placeholder");
+        Some(max_width_pos..(max_width_pos + MAX_WIDTH_PLACEHOLDER.len()))
+    } else {
+        None
+    };
+
+    Some(ArchitectureRootOpen {
+        viewbox_placeholder_range,
+        max_width_placeholder_range,
+    })
 }

--- a/crates/merman-render/src/svg/parity/architecture/settings.rs
+++ b/crates/merman-render/src/svg/parity/architecture/settings.rs
@@ -1,6 +1,6 @@
 use crate::text::TextStyle;
 
-use super::super::{SvgTheme, config_f64};
+use super::super::config_f64;
 
 #[derive(Clone)]
 pub(super) struct ArchitectureRenderSettings {
@@ -17,7 +17,8 @@ pub(super) struct ArchitectureRenderSettings {
 
 impl ArchitectureRenderSettings {
     pub(super) fn from_config(diagram_id: &str, effective_config: &serde_json::Value) -> Self {
-        let css = super::super::css::architecture_css_with_config(diagram_id, effective_config);
+        let css_parts =
+            super::super::css::architecture_css_parts_with_config(diagram_id, effective_config);
 
         let icon_size_px = config_f64(effective_config, &["architecture", "iconSize"])
             .unwrap_or(80.0)
@@ -42,10 +43,9 @@ impl ArchitectureRenderSettings {
             .and_then(|v| v.as_bool())
             .unwrap_or(true);
 
-        let font_family = SvgTheme::new(effective_config).font_family_css();
         let text_style = TextStyle {
-            font_family: Some(font_family),
-            font_size: svg_font_size_px,
+            font_family: Some(css_parts.font_family),
+            font_size: css_parts.font_size,
             font_weight: None,
         };
         let compound_text_style = TextStyle {
@@ -55,7 +55,7 @@ impl ArchitectureRenderSettings {
         };
 
         Self {
-            css,
+            css: css_parts.css,
             icon_size_px,
             half_icon,
             padding_px,

--- a/crates/merman-render/src/svg/parity/architecture/viewport.rs
+++ b/crates/merman-render/src/svg/parity/architecture/viewport.rs
@@ -1,18 +1,20 @@
 use crate::model::Bounds;
 
-use super::super::{apply_root_viewport_override, fmt, fmt_string, svg_emitted_bounds_from_svg};
+use super::super::{fmt, fmt_string, svg_emitted_bounds_from_svg};
 use super::model::ArchitectureModelAccess;
-use super::root::{MAX_WIDTH_PLACEHOLDER, VIEWBOX_PLACEHOLDER};
+use super::root::ArchitectureRootOpen;
 
 pub(super) struct ArchitectureRootViewportContext<'a, M: ArchitectureModelAccess> {
     pub(super) out: String,
     pub(super) diagram_id: &'a str,
     pub(super) model: &'a M,
+    pub(super) root_open: ArchitectureRootOpen,
     pub(super) content_bounds: Option<Bounds>,
     pub(super) padding_px: f64,
     pub(super) icon_size_px: f64,
     pub(super) use_max_width: bool,
     pub(super) apply_root_overrides: bool,
+    pub(super) trust_content_bounds: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -79,6 +81,7 @@ fn architecture_root_bbox_from_svg(
     out: &str,
     content_bounds: Option<Bounds>,
     icon_size_px: f64,
+    trust_content_bounds: bool,
 ) -> Bounds {
     let content_bounds_fallback = content_bounds.as_ref().cloned().unwrap_or(Bounds {
         min_x: 0.0,
@@ -86,6 +89,10 @@ fn architecture_root_bbox_from_svg(
         max_x: icon_size_px,
         max_y: icon_size_px,
     });
+
+    if trust_content_bounds && content_bounds.is_some() {
+        return content_bounds_fallback;
+    }
 
     let mut bounds = svg_emitted_bounds_from_svg(out).unwrap_or(content_bounds_fallback);
 
@@ -139,35 +146,46 @@ pub(super) fn finalize_architecture_root_viewport<M: ArchitectureModelAccess>(
         mut out,
         diagram_id,
         model,
+        root_open,
         content_bounds,
         padding_px,
         icon_size_px,
         use_max_width,
         apply_root_overrides,
+        trust_content_bounds,
     } = ctx;
 
-    let b = architecture_root_bbox_from_svg(&out, content_bounds, icon_size_px);
+    let b =
+        architecture_root_bbox_from_svg(&out, content_bounds, icon_size_px, trust_content_bounds);
     let profile = ArchitectureRootViewportProfile::from_model(model);
     let viewport = architecture_root_viewport_from_bbox(&b, padding_px, profile);
 
     let mut view_box_attr = viewport.view_box_attr();
     let mut max_w_attr = fmt_string(viewport.width);
-    let mut w_attr = fmt_string(viewport.width);
-    let mut h_attr = fmt_string(viewport.height);
     if apply_root_overrides {
-        apply_root_viewport_override(
-            diagram_id,
-            &mut view_box_attr,
-            &mut w_attr,
-            &mut h_attr,
-            &mut max_w_attr,
-            crate::generated::architecture_root_overrides_11_12_2::lookup_architecture_root_viewport_override,
-        );
+        if let Some((override_viewbox, override_max_w)) = crate::generated::architecture_root_overrides_11_12_2::lookup_architecture_root_viewport_override(diagram_id) {
+            if std::env::var_os("MERMAN_DISABLE_ROOT_VIEWPORT_OVERRIDES").is_none() {
+                view_box_attr = override_viewbox.to_string();
+                max_w_attr = override_max_w.to_string();
+            }
+        }
     }
 
-    out = out.replacen(VIEWBOX_PLACEHOLDER, &view_box_attr, 1);
+    let mut replacements: Vec<(usize, std::ops::Range<usize>, &str)> =
+        Vec::with_capacity(if use_max_width { 2 } else { 1 });
+    replacements.push((
+        root_open.viewbox_placeholder_range.start,
+        root_open.viewbox_placeholder_range,
+        view_box_attr.as_str(),
+    ));
     if use_max_width {
-        out = out.replacen(MAX_WIDTH_PLACEHOLDER, &max_w_attr, 1);
+        if let Some(range) = root_open.max_width_placeholder_range {
+            replacements.push((range.start, range, max_w_attr.as_str()));
+        }
+    }
+    replacements.sort_by_key(|(start, _, _)| std::cmp::Reverse(*start));
+    for (_, range, replacement) in replacements {
+        out.replace_range(range, replacement);
     }
     out
 }
@@ -251,11 +269,37 @@ mod tests {
     fn architecture_root_bbox_uses_content_bounds_when_svg_bbox_is_unavailable() {
         let content = bounds(-10.0, -20.0, 30.0, 40.0);
 
-        let b = architecture_root_bbox_from_svg("<not-svg", Some(content.clone()), 80.0);
+        let b = architecture_root_bbox_from_svg("<not-svg", Some(content.clone()), 80.0, false);
 
         assert_eq!(b.min_x, content.min_x);
         assert_eq!(b.min_y, content.min_y);
         assert_eq!(b.max_x, content.max_x);
         assert_eq!(b.max_y, content.max_y);
+    }
+
+    #[test]
+    fn architecture_root_bbox_can_trust_accumulated_content_bounds() {
+        let content = bounds(1.0, 2.0, 3.0, 4.0);
+        let svg = r#"<svg><rect x="-100" y="-200" width="300" height="400"/></svg>"#;
+
+        let b = architecture_root_bbox_from_svg(svg, Some(content.clone()), 80.0, true);
+
+        assert_eq!(b.min_x, content.min_x);
+        assert_eq!(b.min_y, content.min_y);
+        assert_eq!(b.max_x, content.max_x);
+        assert_eq!(b.max_y, content.max_y);
+    }
+
+    #[test]
+    fn architecture_root_bbox_scans_svg_when_content_bounds_are_not_trusted() {
+        let content = bounds(1.0, 2.0, 3.0, 4.0);
+        let svg = r#"<svg><rect x="-100" y="-200" width="300" height="400"/></svg>"#;
+
+        let b = architecture_root_bbox_from_svg(svg, Some(content), 80.0, false);
+
+        assert_eq!(b.min_x, -100.0);
+        assert_eq!(b.min_y, -200.0);
+        assert_eq!(b.max_x, 200.0);
+        assert_eq!(b.max_y, 200.0);
     }
 }

--- a/crates/merman-render/src/svg/parity/css.rs
+++ b/crates/merman-render/src/svg/parity/css.rs
@@ -174,10 +174,17 @@ pub(super) fn info_css_with_config(
 }
 
 #[cfg(feature = "cytoscape-layout")]
-pub(super) fn architecture_css_with_config(
+pub(super) struct ArchitectureCssParts {
+    pub(super) css: String,
+    pub(super) font_family: String,
+    pub(super) font_size: f64,
+}
+
+#[cfg(feature = "cytoscape-layout")]
+pub(super) fn architecture_css_parts_with_config(
     diagram_id: &str,
     effective_config: &serde_json::Value,
-) -> String {
+) -> ArchitectureCssParts {
     // Architecture uses the same "info-like" base stylesheet as Mermaid, but should honor
     // user-configured `fontFamily` / `fontSize` and theme variable colors.
     let id = escape_xml(diagram_id);
@@ -254,7 +261,20 @@ pub(super) fn architecture_css_with_config(
 
     // Keep `:root` last (matches upstream Mermaid SVG baselines).
     out.push_str(&mermaid_base_css_root_rule(&id, &font_family));
-    out
+    ArchitectureCssParts {
+        css: out,
+        font_family,
+        font_size,
+    }
+}
+
+#[cfg(feature = "cytoscape-layout")]
+#[cfg_attr(not(test), allow(dead_code))]
+pub(super) fn architecture_css_with_config(
+    diagram_id: &str,
+    effective_config: &serde_json::Value,
+) -> String {
+    architecture_css_parts_with_config(diagram_id, effective_config).css
 }
 
 pub(super) fn requirement_css(diagram_id: &str, effective_config: &serde_json::Value) -> String {

--- a/crates/merman-render/src/svg/parity/util.rs
+++ b/crates/merman-render/src/svg/parity/util.rs
@@ -244,6 +244,12 @@ pub(super) fn fmt(v: f64) -> FmtDisplay {
     FmtDisplay(v)
 }
 
+const MAX_SAFE_INTEGER_F64: f64 = 9_007_199_254_740_991.0;
+
+fn fmt_fast_integer(v: f64) -> Option<i64> {
+    (v.fract() == 0.0 && v.abs() <= MAX_SAFE_INTEGER_F64).then_some(v as i64)
+}
+
 #[derive(Debug, Clone, Copy)]
 pub(super) struct FmtDisplay(f64);
 
@@ -263,6 +269,9 @@ impl std::fmt::Display for FmtDisplay {
         }
         if v == -0.0 {
             v = 0.0;
+        }
+        if let Some(i) = fmt_fast_integer(v) {
+            return write!(f, "{i}");
         }
 
         write!(f, "{v}")
@@ -285,6 +294,10 @@ pub(super) fn fmt_into(out: &mut String, v: f64) {
     }
     if v == -0.0 {
         v = 0.0;
+    }
+    if let Some(i) = fmt_fast_integer(v) {
+        let _ = write!(out, "{i}");
+        return;
     }
 
     let _ = write!(out, "{v}");
@@ -415,19 +428,21 @@ pub(super) fn apply_root_viewport_override(
     max_width_style: &mut String,
     lookup: fn(&str) -> Option<(&'static str, &'static str)>,
 ) {
+    let Some((viewbox, max_w)) = lookup(diagram_id) else {
+        return;
+    };
+
     if std::env::var_os("MERMAN_DISABLE_ROOT_VIEWPORT_OVERRIDES").is_some() {
         return;
     }
 
-    if let Some((viewbox, max_w)) = lookup(diagram_id) {
-        *viewbox_attr = viewbox.to_string();
-        let mut it = viewbox.split_whitespace();
-        let _ = it.next(); // min-x
-        let _ = it.next(); // min-y
-        *width_attr = it.next().unwrap_or("0").to_string();
-        *height_attr = it.next().unwrap_or("0").to_string();
-        *max_width_style = max_w.to_string();
-    }
+    *viewbox_attr = viewbox.to_string();
+    let mut it = viewbox.split_whitespace();
+    let _ = it.next(); // min-x
+    let _ = it.next(); // min-y
+    *width_attr = it.next().unwrap_or("0").to_string();
+    *height_attr = it.next().unwrap_or("0").to_string();
+    *max_width_style = max_w.to_string();
 }
 
 pub(super) fn fmt_max_width_px_into(out: &mut String, v: f64) {
@@ -498,7 +513,17 @@ pub(super) fn decode_mermaid_entities_for_render_text(text: &str) -> Cow<'_, str
     merman_core::entities::decode_mermaid_entities_to_unicode(text)
 }
 
+fn xml_text_is_plain_ascii(text: &str) -> bool {
+    text.bytes()
+        .all(|b| matches!(b, 0x00..=0x7f) && !matches!(b, b'&' | b'<' | b'"' | b'\'' | b'#'))
+}
+
 pub(super) fn escape_xml_into(out: &mut String, text: &str) {
+    if xml_text_is_plain_ascii(text) {
+        out.push_str(text);
+        return;
+    }
+
     let decoded = decode_mermaid_entities_for_render_text(text);
     let text = decoded.as_ref();
     let bytes = text.as_bytes();
@@ -533,6 +558,10 @@ pub(super) struct EscapeXmlDisplay<'a>(&'a str);
 
 impl std::fmt::Display for EscapeXmlDisplay<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if xml_text_is_plain_ascii(self.0) {
+            return f.write_str(self.0);
+        }
+
         let decoded = decode_mermaid_entities_for_render_text(self.0);
         let text = decoded.as_ref();
         let bytes = text.as_bytes();
@@ -714,6 +743,32 @@ mod tests {
         for v in samples {
             assert_eq!(fmt_display(v).to_string(), fmt_string(v));
             assert_eq!(fmt(v).to_string(), fmt_string(v));
+        }
+    }
+
+    #[test]
+    fn escape_xml_into_fast_path_matches_display_and_preserves_slow_paths() {
+        fn escaped_into(text: &str) -> String {
+            let mut out = String::new();
+            escape_xml_into(&mut out, text);
+            out
+        }
+
+        let samples = [
+            ("plain-id_123", "plain-id_123"),
+            (
+                "x < y & \"z\" 'q'",
+                "x &lt; y &amp; &quot;z&quot; &#39;q&#39;",
+            ),
+            ("#quot;", "&quot;"),
+            ("ﬂ°quot¶ß", "&quot;"),
+            ("café", "café"),
+        ];
+
+        for (src, expected) in samples {
+            assert_eq!(escaped_into(src), expected);
+            assert_eq!(escape_xml_display(src).to_string(), expected);
+            assert_eq!(escape_xml(src), expected);
         }
     }
 

--- a/crates/merman-render/src/svg/parity/xychart/render.rs
+++ b/crates/merman-render/src/svg/parity/xychart/render.rs
@@ -8,7 +8,8 @@ pub(crate) fn render_xychart_diagram_svg(
     _effective_config: &serde_json::Value,
     options: &SvgRenderOptions,
 ) -> Result<String> {
-    use std::collections::{HashMap, hash_map::Entry};
+    use rustc_hash::FxHashMap;
+    use std::collections::hash_map::Entry;
 
     struct Node {
         tag: &'static str,
@@ -26,9 +27,9 @@ pub(crate) fn render_xychart_diagram_svg(
     fn node(tag: &'static str) -> Node {
         Node {
             tag,
-            attrs: Vec::new(),
+            attrs: Vec::with_capacity(6),
             text: None,
-            children: Vec::new(),
+            children: Vec::with_capacity(2),
         }
     }
 
@@ -68,18 +69,19 @@ pub(crate) fn render_xychart_diagram_svg(
         }
     }
 
-    fn ensure_group_path(
+    fn ensure_group_path<'a>(
         arena: &mut Vec<Node>,
-        groups_by_path: &mut HashMap<(usize, String), usize>,
-        group_texts: &[String],
+        groups_by_path: &mut FxHashMap<(usize, &'a str), usize>,
+        group_texts: &'a [String],
     ) -> usize {
         let mut parent = 0usize;
         for seg in group_texts {
-            let gid = match groups_by_path.entry((parent, seg.clone())) {
+            let class = seg.as_str();
+            let gid = match groups_by_path.entry((parent, class)) {
                 Entry::Occupied(entry) => *entry.get(),
                 Entry::Vacant(entry) => {
                     let mut g = node("g");
-                    g.attr("class", seg.as_str());
+                    g.attr("class", class);
                     let id = push_child(arena, parent, g);
                     entry.insert(id);
                     id
@@ -119,9 +121,15 @@ pub(crate) fn render_xychart_diagram_svg(
     }
 
     let diagram_id = options.diagram_id.as_deref().unwrap_or("xychart");
-    let show_data_label_outside_bar =
-        config_bool(_effective_config, &["xyChart", "showDataLabelOutsideBar"]).unwrap_or(false);
-    let data_label_color = data_label_color(_effective_config);
+    let data_label_config = if layout.show_data_label {
+        Some((
+            config_bool(_effective_config, &["xyChart", "showDataLabelOutsideBar"])
+                .unwrap_or(false),
+            data_label_color(_effective_config),
+        ))
+    } else {
+        None
+    };
 
     let mut out = String::new();
     let w_attr = fmt(layout.width.max(1.0)).to_string();
@@ -148,7 +156,7 @@ pub(crate) fn render_xychart_diagram_svg(
     out.push_str(r#"<g/>"#);
 
     // Build the `.main` group as an ordered DOM tree, matching Mermaid's D3 `getGroup()` behavior.
-    let mut arena: Vec<Node> = Vec::new();
+    let mut arena: Vec<Node> = Vec::with_capacity(layout.drawables.len().saturating_mul(4) + 2);
     arena.push(node("g"));
     arena[0].attr("class", "main");
 
@@ -160,7 +168,10 @@ pub(crate) fn render_xychart_diagram_svg(
     bg.attr("fill", escape_xml(&layout.background_color));
     push_child(&mut arena, 0, bg);
 
-    let mut groups_by_path: HashMap<(usize, String), usize> = HashMap::new();
+    let mut groups_by_path: FxHashMap<(usize, &str), usize> = FxHashMap::with_capacity_and_hasher(
+        layout.drawables.len().saturating_mul(2) + 4,
+        Default::default(),
+    );
 
     for shape in &layout.drawables {
         match shape {
@@ -186,7 +197,7 @@ pub(crate) fn render_xychart_diagram_svg(
                 }
 
                 // Optional bar data labels (Mermaid emits these in the renderer, not the DB).
-                if layout.show_data_label {
+                if let Some((show_data_label_outside_bar, data_label_color)) = &data_label_config {
                     let bar_data_label_scale_factor = 0.7;
                     let bar_data_label_inset_px = 10.0;
 
@@ -196,7 +207,7 @@ pub(crate) fn render_xychart_diagram_svg(
                         label: &'a str,
                     }
 
-                    let mut valid_items: Vec<BarItem<'_>> = Vec::new();
+                    let mut valid_items: Vec<BarItem<'_>> = Vec::with_capacity(data.len());
                     for (idx, r) in data.iter().enumerate() {
                         let Some(label) = layout.label_data.get(idx) else {
                             continue;
@@ -237,7 +248,7 @@ pub(crate) fn render_xychart_diagram_svg(
                             let uniform = min_font.floor().max(0.0);
                             for item in &valid_items {
                                 let mut t = node("text");
-                                let x = if show_data_label_outside_bar {
+                                let x = if *show_data_label_outside_bar {
                                     item.rect.x + item.rect.width + bar_data_label_inset_px
                                 } else {
                                     item.rect.x + item.rect.width - bar_data_label_inset_px
@@ -246,14 +257,14 @@ pub(crate) fn render_xychart_diagram_svg(
                                 t.attr("y", fmt_xy(item.rect.y + item.rect.height / 2.0));
                                 t.attr(
                                     "text-anchor",
-                                    if show_data_label_outside_bar {
+                                    if *show_data_label_outside_bar {
                                         "start"
                                     } else {
                                         "end"
                                     },
                                 );
                                 t.attr("dominant-baseline", "middle");
-                                t.attr("fill", escape_xml(&data_label_color));
+                                t.attr("fill", escape_xml(data_label_color));
                                 t.attr("font-size", format!("{}px", fmt_xy(uniform)));
                                 t.text = Some(escape_xml(item.label));
                                 push_child(&mut arena, parent, t);
@@ -299,7 +310,7 @@ pub(crate) fn render_xychart_diagram_svg(
                             for item in &valid_items {
                                 let mut t = node("text");
                                 t.attr("x", fmt_xy(item.rect.x + item.rect.width / 2.0));
-                                let y = if show_data_label_outside_bar {
+                                let y = if *show_data_label_outside_bar {
                                     item.rect.y - y_offset
                                 } else {
                                     item.rect.y + y_offset
@@ -308,13 +319,13 @@ pub(crate) fn render_xychart_diagram_svg(
                                 t.attr("text-anchor", "middle");
                                 t.attr(
                                     "dominant-baseline",
-                                    if show_data_label_outside_bar {
+                                    if *show_data_label_outside_bar {
                                         "auto"
                                     } else {
                                         "hanging"
                                     },
                                 );
-                                t.attr("fill", escape_xml(&data_label_color));
+                                t.attr("fill", escape_xml(data_label_color));
                                 t.attr("font-size", format!("{}px", fmt_xy(uniform)));
                                 t.text = Some(escape_xml(item.label));
                                 push_child(&mut arena, parent, t);

--- a/crates/merman-render/src/text/tests.rs
+++ b/crates/merman-render/src/text/tests.rs
@@ -725,6 +725,23 @@ fn flowchart_svg_cluster_title_precise_width_matches_upstream_wrapped_text() {
 }
 
 #[test]
+fn svg_wrapped_width_uses_widest_emitted_line_bbox() {
+    let measurer = VendoredFontMetricsTextMeasurer::default();
+    let style = TextStyle {
+        font_family: Some("\"trebuchet ms\", verdana, arial, sans-serif".to_string()),
+        font_size: 16.0,
+        font_weight: None,
+    };
+
+    let text = "A very long cluster title with punctuation: (a/b/c)";
+    let metrics = measurer.measure_wrapped(text, &style, Some(120.0), WrapMode::SvgLike);
+
+    assert_eq!(metrics.width, 91.9140625);
+    assert_eq!(metrics.height, 89.4);
+    assert_eq!(metrics.line_count, 5);
+}
+
+#[test]
 fn flowchart_html_subgraph_title_punctuation_wraps_at_spaces_like_upstream() {
     let measurer = VendoredFontMetricsTextMeasurer::default();
     let style = TextStyle {

--- a/crates/merman-render/src/xychart.rs
+++ b/crates/merman-render/src/xychart.rs
@@ -10,6 +10,7 @@ use merman_core::diagrams::xychart::{
     XyChartAxisRenderModel, XyChartDiagramRenderModel, XyChartPlotType,
 };
 use serde_json::Value;
+use std::fmt::Write as _;
 
 #[derive(Debug, Clone)]
 struct AxisThemeConfig {
@@ -189,6 +190,20 @@ fn max_text_dimension(texts: &[String], font_size: f64, measurer: &dyn TextMeasu
     }
 }
 
+fn single_text_height(text: &str, font_size: f64, measurer: &dyn TextMeasurer) -> f64 {
+    if text.trim().is_empty() {
+        return 0.0;
+    }
+    if text.contains('\n') || text.contains("<br") {
+        return max_text_dimension(&[text.to_string()], font_size, measurer).height;
+    }
+    let style = TextStyle {
+        font_size,
+        ..Default::default()
+    };
+    measurer.measure_svg_simple_text_bbox_height_px(text, &style)
+}
+
 fn d3_ticks(start: f64, stop: f64, count: usize) -> Vec<f64> {
     fn tick_spec(start: f64, stop: f64, count: f64) -> Option<(i64, i64, f64)> {
         if count <= 0.0 {
@@ -349,13 +364,12 @@ impl Axis {
         axis_theme: AxisThemeConfig,
         title: String,
     ) -> Self {
-        let tick_values = build_tick_values(&kind, AxisPosition::Left);
         Self {
             kind,
             axis_config,
             axis_theme,
             axis_position: AxisPosition::Left,
-            tick_values,
+            tick_values: Vec::new(),
             bounding_rect: BoundingRect {
                 x: 0.0,
                 y: 0.0,
@@ -450,6 +464,31 @@ impl Axis {
         }
     }
 
+    fn get_scale_number(&self, value: Option<f64>) -> f64 {
+        let Some(value) = value else {
+            return self.get_scale_value("NaN");
+        };
+
+        match &self.kind {
+            AxisKind::Linear { domain } => {
+                if value.is_nan() {
+                    return f64::NAN;
+                }
+                let (mut d0, mut d1) = *domain;
+                if matches!(self.axis_position, AxisPosition::Left) {
+                    std::mem::swap(&mut d0, &mut d1);
+                }
+                let (r0, r1) = self.get_range();
+                if d0 == d1 {
+                    return r0 + (r1 - r0) * 0.5;
+                }
+                let t = (value - d0) / (d1 - d0);
+                r0 + t * (r1 - r0)
+            }
+            AxisKind::Band { .. } => self.get_scale_value(&format!("{value}")),
+        }
+    }
+
     fn recalculate_outer_padding_to_draw_bar(&mut self) {
         const BAR_WIDTH_TO_TICK_WIDTH_RATIO: f64 = 0.7;
         let target = BAR_WIDTH_TO_TICK_WIDTH_RATIO * self.tick_distance();
@@ -493,13 +532,10 @@ impl Axis {
             }
 
             if self.axis_config.show_title && !self.title.is_empty() {
-                let dim = max_text_dimension(
-                    std::slice::from_ref(&self.title),
-                    self.axis_config.title_font_size,
-                    measurer,
-                );
-                let width_required = dim.height + self.axis_config.title_padding * 2.0;
-                self.title_text_height = dim.height;
+                let title_height =
+                    single_text_height(&self.title, self.axis_config.title_font_size, measurer);
+                let width_required = title_height + self.axis_config.title_padding * 2.0;
+                self.title_text_height = title_height;
                 if width_required <= available_width {
                     available_width -= width_required;
                     self.show_title = true;
@@ -540,13 +576,10 @@ impl Axis {
             }
 
             if self.axis_config.show_title && !self.title.is_empty() {
-                let dim = max_text_dimension(
-                    std::slice::from_ref(&self.title),
-                    self.axis_config.title_font_size,
-                    measurer,
-                );
-                let height_required = dim.height + self.axis_config.title_padding * 2.0;
-                self.title_text_height = dim.height;
+                let title_height =
+                    single_text_height(&self.title, self.axis_config.title_font_size, measurer);
+                let height_required = title_height + self.axis_config.title_padding * 2.0;
+                self.title_text_height = title_height;
                 if height_required <= available_height {
                     available_height -= height_required;
                     self.show_title = true;
@@ -855,12 +888,14 @@ impl Axis {
 
 fn line_path(points: &[(f64, f64)]) -> Option<String> {
     let (first, rest) = points.split_first()?;
+    let mut out = String::with_capacity(points.len().saturating_mul(24).max(24));
+    let _ = write!(&mut out, "M{},{}", first.0, first.1);
     if rest.is_empty() {
-        return Some(format!("M{},{}Z", first.0, first.1));
+        out.push('Z');
+        return Some(out);
     }
-    let mut out = format!("M{},{}", first.0, first.1);
     for p in rest {
-        out.push_str(&format!("L{},{}", p.0, p.1));
+        let _ = write!(&mut out, "L{},{}", p.0, p.1);
     }
     Some(out)
 }
@@ -896,16 +931,13 @@ pub(crate) fn layout_xychart_diagram_typed(
     let theme_cfg = PresentationTheme::new(effective_config).xychart();
 
     let title = model.title.clone().unwrap_or_default();
-    let title_dim = max_text_dimension(
-        std::slice::from_ref(&title),
-        chart_cfg.title_font_size,
-        text_measurer,
-    );
-    let title_height = title_dim.height + 2.0 * chart_cfg.title_padding;
+    let title_height = single_text_height(&title, chart_cfg.title_font_size, text_measurer)
+        + 2.0 * chart_cfg.title_padding;
     let show_chart_title =
         chart_cfg.show_title && !title.is_empty() && title_height <= chart_cfg.height;
 
-    let mut drawables: Vec<XyChartDrawableElem> = Vec::new();
+    let mut drawables: Vec<XyChartDrawableElem> =
+        Vec::with_capacity(model.plots.len().saturating_mul(2).saturating_add(4));
     if show_chart_title {
         drawables.push(XyChartDrawableElem::Text {
             group_texts: vec!["chart-title".to_string()],
@@ -1093,13 +1125,10 @@ pub(crate) fn layout_xychart_diagram_typed(
                     * (1.0 - bar_padding_percent);
                 let bar_width_half = bar_width / 2.0;
 
-                let mut rects: Vec<XyChartRectData> = Vec::new();
+                let mut rects: Vec<XyChartRectData> = Vec::with_capacity(plot.data.len());
                 for (cat, value) in &plot.data {
                     let x = x_axis.get_scale_value(cat);
-                    let y = match value {
-                        Some(v) => y_axis.get_scale_value(&format!("{v}")),
-                        None => y_axis.get_scale_value("NaN"),
-                    };
+                    let y = y_axis.get_scale_number(*value);
                     if chart_cfg.chart_orientation == "horizontal" {
                         rects.push(XyChartRectData {
                             x: plot_rect.x,
@@ -1129,13 +1158,10 @@ pub(crate) fn layout_xychart_diagram_typed(
                 });
             }
             XyChartPlotType::Line => {
-                let mut points: Vec<(f64, f64)> = Vec::new();
+                let mut points: Vec<(f64, f64)> = Vec::with_capacity(plot.data.len());
                 for (cat, value) in &plot.data {
                     let x = x_axis.get_scale_value(cat);
-                    let y = match value {
-                        Some(v) => y_axis.get_scale_value(&format!("{v}")),
-                        None => y_axis.get_scale_value("NaN"),
-                    };
+                    let y = y_axis.get_scale_number(*value);
                     points.push(if chart_cfg.chart_orientation == "horizontal" {
                         (y, x)
                     } else {
@@ -1160,19 +1186,23 @@ pub(crate) fn layout_xychart_diagram_typed(
     drawables.extend(x_axis.drawable_elements());
     drawables.extend(y_axis.drawable_elements());
 
-    let label_data = model
-        .plots
-        .first()
-        .map(|p| {
-            p.data
-                .iter()
-                .map(|(_, y)| {
-                    y.map(|v| format!("{v}"))
-                        .unwrap_or_else(|| "null".to_string())
-                })
-                .collect()
-        })
-        .unwrap_or_default();
+    let label_data = if chart_cfg.show_data_label {
+        model
+            .plots
+            .first()
+            .map(|p| {
+                p.data
+                    .iter()
+                    .map(|(_, y)| {
+                        y.map(|v| format!("{v}"))
+                            .unwrap_or_else(|| "null".to_string())
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
 
     Ok(XyChartDiagramLayout {
         width: chart_cfg.width,

--- a/crates/merman-render/tests/architecture_svg_test.rs
+++ b/crates/merman-render/tests/architecture_svg_test.rs
@@ -1,4 +1,5 @@
 use merman_core::{Engine, ParseOptions};
+use merman_render::model::LayoutDiagram;
 use merman_render::svg::{SvgRenderOptions, render_layout_svg_parts_for_render_model_with_config};
 use merman_render::{LayoutOptions, layout_parsed_render_layout_only};
 use regex::Regex;
@@ -395,6 +396,57 @@ fn architecture_long_title_group_rect_uses_narrower_long_label_canvas_approximat
         "unexpected pipeline group width regression for long-title architecture fixture after the narrower long-label canvas approximation: {}",
         pipeline.2
     );
+}
+
+#[test]
+fn architecture_cached_service_child_bounds_preserve_svg_output() {
+    let text = r#"architecture-beta
+  group app(cloud)[Application]
+  service gateway(server)[A very long gateway label for group sizing] in app
+  service cache(server)[Cache] in app
+  gateway:R -- L:cache
+"#;
+    let engine = Engine::new();
+    let parsed = engine
+        .parse_diagram_for_render_model_sync(text, ParseOptions::strict())
+        .expect("parse ok")
+        .expect("diagram detected");
+    let layout_options = LayoutOptions::headless_svg_defaults();
+    let layout = layout_parsed_render_layout_only(&parsed, &layout_options).expect("layout ok");
+    let mut layout_without_cached_bounds = layout.clone();
+    let LayoutDiagram::ArchitectureDiagram(arch_layout) = &mut layout_without_cached_bounds else {
+        panic!("expected architecture layout");
+    };
+    assert!(
+        !arch_layout.cytoscape_service_bounds.is_empty(),
+        "expected layout to expose Architecture service child bounds"
+    );
+    arch_layout.cytoscape_service_bounds.clear();
+
+    let options = SvgRenderOptions {
+        diagram_id: Some("architecture-cache-parity".to_string()),
+        ..Default::default()
+    };
+    let with_cached_bounds = render_layout_svg_parts_for_render_model_with_config(
+        &layout,
+        &parsed.model,
+        &parsed.meta.effective_config,
+        parsed.meta.title.as_deref(),
+        layout_options.text_measurer.as_ref(),
+        &options,
+    )
+    .expect("render SVG with cached service child bounds");
+    let without_cached_bounds = render_layout_svg_parts_for_render_model_with_config(
+        &layout_without_cached_bounds,
+        &parsed.model,
+        &parsed.meta.effective_config,
+        parsed.meta.title.as_deref(),
+        layout_options.text_measurer.as_ref(),
+        &options,
+    )
+    .expect("render SVG without cached service child bounds");
+
+    assert_eq!(with_cached_bounds, without_cached_bounds);
 }
 
 #[test]

--- a/crates/merman-render/tests/svg_internal_id_test.rs
+++ b/crates/merman-render/tests/svg_internal_id_test.rs
@@ -238,6 +238,24 @@ fn architecture_builtin_icon_internal_ids_are_scoped_per_node() {
     assert_eq!(unique.len(), ids.len(), "{svg}");
 }
 
+#[test]
+fn architecture_builtin_icons_without_internal_ids_skip_iconify_id_scoping() {
+    let svg = render_svg_from_text(
+        r#"architecture-beta
+  service a(server)[A]
+  service b(server)[B]
+  a:R --> L:b"#,
+        "m15-architecture-server-icons",
+    );
+
+    assert_eq!(internal_iconify_ids(&svg).len(), 0, "{svg}");
+    assert_eq!(
+        svg.matches(r#"<rect x="17.5" y="17.5""#).count(),
+        2,
+        "{svg}"
+    );
+}
+
 fn internal_iconify_ids(svg: &str) -> Vec<String> {
     let mut ids = Vec::new();
     let mut index = 0;

--- a/crates/merman/Cargo.toml
+++ b/crates/merman/Cargo.toml
@@ -139,3 +139,7 @@ required-features = ["render"]
 [[example]]
 name = "example_13_stylized_theme_showcase"
 required-features = ["render"]
+
+[[example]]
+name = "profile_render"
+required-features = ["render"]

--- a/crates/merman/benches/pipeline.rs
+++ b/crates/merman/benches/pipeline.rs
@@ -269,6 +269,38 @@ fn bench_parse_known_type(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_parse_cold_engine(c: &mut Criterion) {
+    let parse_opts = ParseOptions::strict();
+
+    let mut group = c.benchmark_group("parse_cold_engine");
+    for (name, input) in fixtures() {
+        // Tracks request-style usage that constructs a fresh Engine per parse, so parse wins are
+        // not accidentally attributed only to the hot shared-engine benchmark shape.
+        let engine = Engine::new();
+        if engine
+            .parse_diagram_for_render_model_sync(input, parse_opts)
+            .is_err()
+        {
+            eprintln!("[bench][skip][parse_cold_engine] {name}: parse error");
+            continue;
+        }
+
+        group.bench_with_input(BenchmarkId::from_parameter(name), input, |b, data| {
+            b.iter(|| {
+                let engine = Engine::new();
+                let parsed =
+                    engine.parse_diagram_for_render_model_sync(black_box(data), parse_opts);
+                let parsed = match parsed {
+                    Ok(v) => v,
+                    Err(_) => return,
+                };
+                black_box(parsed.is_some());
+            })
+        });
+    }
+    group.finish();
+}
+
 fn bench_layout(c: &mut Criterion) {
     let engine = Engine::new();
     let parse_opts = ParseOptions::strict();
@@ -547,6 +579,7 @@ criterion_group!(
     benches,
     bench_parse,
     bench_parse_known_type,
+    bench_parse_cold_engine,
     bench_parse_typed,
     bench_parse_typed_only,
     bench_layout,

--- a/crates/merman/examples/README.md
+++ b/crates/merman/examples/README.md
@@ -20,6 +20,7 @@ cargo run -p merman --example example_08_deterministic_gantt
 cargo run -p merman --features render --example example_09_multiple_diagrams
 cargo run -p merman --features egui-example --example example_10_integration_egui
 cargo run -p merman --features render --example example_11_custom_output_environment > host-preview.svg
+cargo run -p merman --features render --example profile_render -- --input crates/merman/benches/fixtures/architecture_medium.mmd --stage render --seconds 5
 ```
 
 ## Custom Input
@@ -55,3 +56,23 @@ printf "flowchart LR\nA --> B\n" | \
   after `--`.
 - `example_09` writes SVG files to `target/merman-multiple-diagrams/`.
 - `example_10` opens an egui desktop window.
+- `profile_render` writes a profiling summary to stderr and is intended for CPU profilers.
+
+## Profiling
+
+Use `profile_render` when a profiler needs a long, single-stage loop instead of a Criterion
+benchmark harness. The example parses and lays out the input once for `--stage render`, then keeps
+the CPU inside SVG rendering for the requested duration.
+
+```bash
+CARGO_PROFILE_BENCH_DEBUG=true cargo flamegraph \
+  --profile bench \
+  -p merman \
+  --features render \
+  --example profile_render \
+  -o target/bench/flamegraphs/profile_render_architecture_medium.svg \
+  -- \
+  --input crates/merman/benches/fixtures/architecture_medium.mmd \
+  --stage render \
+  --seconds 20
+```

--- a/crates/merman/examples/profile_render.rs
+++ b/crates/merman/examples/profile_render.rs
@@ -1,0 +1,328 @@
+use merman::render::{LayoutOptions, SvgRenderOptions, headless_layout_options, sanitize_svg_id};
+use merman_core::{Engine, ParseOptions};
+use std::env;
+use std::fs;
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Stage {
+    Parse,
+    Layout,
+    Render,
+    EndToEnd,
+}
+
+impl Stage {
+    fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "parse" => Ok(Self::Parse),
+            "layout" => Ok(Self::Layout),
+            "render" => Ok(Self::Render),
+            "end-to-end" | "end_to_end" | "e2e" => Ok(Self::EndToEnd),
+            _ => Err(format!(
+                "unknown stage `{value}`; expected parse, layout, render, or end-to-end"
+            )),
+        }
+    }
+
+    fn default_batch_size(self) -> usize {
+        match self {
+            Self::Parse | Self::Layout | Self::EndToEnd => 1,
+            Self::Render => 100,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Args {
+    input: PathBuf,
+    stage: Stage,
+    seconds: u64,
+    batch_size: Option<usize>,
+    diagram_id: Option<String>,
+}
+
+impl Args {
+    fn parse() -> Result<Self, String> {
+        let mut input = None;
+        let mut stage = Stage::Render;
+        let mut seconds = 20;
+        let mut batch_size = None;
+        let mut diagram_id = None;
+
+        let mut args = env::args().skip(1);
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--input" | "-i" => {
+                    input = Some(PathBuf::from(next_arg(&mut args, &arg)?));
+                }
+                "--stage" => {
+                    stage = Stage::parse(&next_arg(&mut args, &arg)?)?;
+                }
+                "--seconds" => {
+                    seconds = parse_u64(&next_arg(&mut args, &arg)?, "--seconds")?;
+                    if seconds == 0 {
+                        return Err("--seconds must be greater than 0".to_string());
+                    }
+                }
+                "--batch-size" => {
+                    let parsed = parse_usize(&next_arg(&mut args, &arg)?, "--batch-size")?;
+                    if parsed == 0 {
+                        return Err("--batch-size must be greater than 0".to_string());
+                    }
+                    batch_size = Some(parsed);
+                }
+                "--diagram-id" => {
+                    diagram_id = Some(next_arg(&mut args, &arg)?);
+                }
+                "--help" | "-h" => {
+                    print_usage();
+                    std::process::exit(0);
+                }
+                _ => return Err(format!("unexpected argument `{arg}`")),
+            }
+        }
+
+        let Some(input) = input else {
+            return Err("missing required --input <path>".to_string());
+        };
+
+        Ok(Self {
+            input,
+            stage,
+            seconds,
+            batch_size,
+            diagram_id,
+        })
+    }
+
+    fn batch_size(&self) -> usize {
+        self.batch_size
+            .unwrap_or_else(|| self.stage.default_batch_size())
+    }
+}
+
+fn next_arg(args: &mut impl Iterator<Item = String>, flag: &str) -> Result<String, String> {
+    args.next()
+        .ok_or_else(|| format!("missing value for {flag}"))
+}
+
+fn parse_u64(value: &str, flag: &str) -> Result<u64, String> {
+    value
+        .parse()
+        .map_err(|_| format!("{flag} expects a positive integer, got `{value}`"))
+}
+
+fn parse_usize(value: &str, flag: &str) -> Result<usize, String> {
+    value
+        .parse()
+        .map_err(|_| format!("{flag} expects a positive integer, got `{value}`"))
+}
+
+fn print_usage() {
+    eprintln!(
+        "\
+Usage:
+  profile_render --input <path> [--stage render] [--seconds 20] [--batch-size N]
+
+Stages:
+  parse       repeatedly parse Mermaid source into the render model
+  layout      parse once, then repeatedly layout the parsed render model
+  render      parse and layout once, then repeatedly render SVG
+  end-to-end  repeatedly parse, layout, and render SVG
+"
+    );
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse().map_err(|message| {
+        eprintln!("{message}");
+        print_usage();
+        message
+    })?;
+
+    let source = fs::read_to_string(&args.input)?;
+    let engine = Engine::new();
+    let parse_options = ParseOptions::strict();
+    let layout_options: LayoutOptions = headless_layout_options();
+    let svg_options = SvgRenderOptions {
+        diagram_id: Some(diagram_id_for(&args.input, args.diagram_id.as_deref())),
+        ..SvgRenderOptions::default()
+    };
+
+    let duration = Duration::from_secs(args.seconds);
+    let batch_size = args.batch_size();
+    let (iterations, checksum, elapsed) = match args.stage {
+        Stage::Parse => run_parse(&engine, &source, parse_options, duration, batch_size)?,
+        Stage::Layout => run_layout(
+            &engine,
+            &source,
+            parse_options,
+            &layout_options,
+            duration,
+            batch_size,
+        )?,
+        Stage::Render => run_render(
+            &engine,
+            &source,
+            parse_options,
+            &layout_options,
+            &svg_options,
+            duration,
+            batch_size,
+        )?,
+        Stage::EndToEnd => run_end_to_end(
+            &engine,
+            &source,
+            parse_options,
+            &layout_options,
+            &svg_options,
+            duration,
+            batch_size,
+        )?,
+    };
+
+    eprintln!(
+        "profile_render stage={:?} input={} iterations={} elapsed={:.3}s checksum={}",
+        args.stage,
+        args.input.display(),
+        iterations,
+        elapsed.as_secs_f64(),
+        checksum
+    );
+
+    Ok(())
+}
+
+fn diagram_id_for(path: &Path, explicit: Option<&str>) -> String {
+    if let Some(id) = explicit {
+        return sanitize_svg_id(id);
+    }
+
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .map(sanitize_svg_id)
+        .unwrap_or_else(|| sanitize_svg_id("profile-render"))
+}
+
+fn run_parse(
+    engine: &Engine,
+    source: &str,
+    parse_options: ParseOptions,
+    duration: Duration,
+    batch_size: usize,
+) -> Result<(u64, usize, Duration), Box<dyn std::error::Error>> {
+    engine
+        .parse_diagram_for_render_model_sync(source, parse_options)?
+        .ok_or("no Mermaid diagram detected")?;
+
+    run_for_duration(duration, batch_size, || {
+        let parsed = engine
+            .parse_diagram_for_render_model_sync(black_box(source), parse_options)?
+            .ok_or("no Mermaid diagram detected")?;
+        Ok(parsed.model.kind().len())
+    })
+}
+
+fn run_layout(
+    engine: &Engine,
+    source: &str,
+    parse_options: ParseOptions,
+    layout_options: &LayoutOptions,
+    duration: Duration,
+    batch_size: usize,
+) -> Result<(u64, usize, Duration), Box<dyn std::error::Error>> {
+    let parsed = engine
+        .parse_diagram_for_render_model_sync(source, parse_options)?
+        .ok_or("no Mermaid diagram detected")?;
+    merman_render::layout_parsed_render_layout_only(&parsed, layout_options)?;
+
+    run_for_duration(duration, batch_size, || {
+        let layouted =
+            merman_render::layout_parsed_render_layout_only(black_box(&parsed), layout_options)?;
+        black_box(layouted);
+        Ok(1)
+    })
+}
+
+fn run_render(
+    engine: &Engine,
+    source: &str,
+    parse_options: ParseOptions,
+    layout_options: &LayoutOptions,
+    svg_options: &SvgRenderOptions,
+    duration: Duration,
+    batch_size: usize,
+) -> Result<(u64, usize, Duration), Box<dyn std::error::Error>> {
+    let parsed = engine
+        .parse_diagram_for_render_model_sync(source, parse_options)?
+        .ok_or("no Mermaid diagram detected")?;
+    let layouted = merman_render::layout_parsed_render_layout_only(&parsed, layout_options)?;
+    merman_render::svg::render_layout_svg_parts_for_render_model_with_config(
+        &layouted,
+        &parsed.model,
+        &parsed.meta.effective_config,
+        parsed.meta.title.as_deref(),
+        layout_options.text_measurer.as_ref(),
+        svg_options,
+    )?;
+
+    run_for_duration(duration, batch_size, || {
+        let svg = merman_render::svg::render_layout_svg_parts_for_render_model_with_config(
+            black_box(&layouted),
+            &parsed.model,
+            &parsed.meta.effective_config,
+            parsed.meta.title.as_deref(),
+            layout_options.text_measurer.as_ref(),
+            svg_options,
+        )?;
+        Ok(svg.len())
+    })
+}
+
+fn run_end_to_end(
+    engine: &Engine,
+    source: &str,
+    parse_options: ParseOptions,
+    layout_options: &LayoutOptions,
+    svg_options: &SvgRenderOptions,
+    duration: Duration,
+    batch_size: usize,
+) -> Result<(u64, usize, Duration), Box<dyn std::error::Error>> {
+    merman::render::render_svg_sync(engine, source, parse_options, layout_options, svg_options)?
+        .ok_or("no Mermaid diagram detected")?;
+
+    run_for_duration(duration, batch_size, || {
+        let svg = merman::render::render_svg_sync(
+            engine,
+            black_box(source),
+            parse_options,
+            layout_options,
+            svg_options,
+        )?
+        .ok_or("no Mermaid diagram detected")?;
+        Ok(svg.len())
+    })
+}
+
+fn run_for_duration(
+    duration: Duration,
+    batch_size: usize,
+    mut run_once: impl FnMut() -> Result<usize, Box<dyn std::error::Error>>,
+) -> Result<(u64, usize, Duration), Box<dyn std::error::Error>> {
+    let start = Instant::now();
+    let deadline = start + duration;
+    let mut iterations = 0u64;
+    let mut checksum = 0usize;
+
+    while Instant::now() < deadline {
+        for _ in 0..batch_size {
+            checksum ^= black_box(run_once()?);
+            iterations += 1;
+        }
+    }
+
+    Ok((iterations, checksum, start.elapsed()))
+}

--- a/docs/performance/BENCHMARKING.md
+++ b/docs/performance/BENCHMARKING.md
@@ -14,6 +14,11 @@ For a one-step local workflow, use `python3 tools/bench/perf_runner.py --profile
 - Compare pipeline stages (parse vs layout vs SVG emission).
 - Keep results meaningful across machines and CI.
 
+The goal here is not to replace Mermaid.js in the browser. This work is mostly for native apps,
+text editors, CI pipelines, preview tools, and doc generators where embedding a JS engine just to
+draw a chart is heavy and awkward. Criterion stays in the toolbox for regression tracking, but
+parity and predictable headless output remain the top priorities.
+
 ## Running Criterion benches
 
 `merman` includes Criterion benchmarks for the headless pipeline.

--- a/docs/performance/BENCHMARKING.md
+++ b/docs/performance/BENCHMARKING.md
@@ -5,6 +5,8 @@ for tracking regressions.
 
 For the optimization backlog (prioritized, correctness-first), see:
 `docs/performance/FEARLESS_REFACTORING.md`.
+For the execution order, see `docs/performance/RUNBOOK.md`.
+For a one-step local workflow, use `python3 tools/bench/perf_runner.py --profile canary`.
 
 ## Goals
 
@@ -29,11 +31,20 @@ Notes:
 
 The `pipeline` bench measures:
 
-- `parse/*`: parsing Mermaid into a semantic model (no layout).
+- `parse/*`: parsing Mermaid into a semantic model (reused `Engine`, no layout).
+- `parse_cold_engine/*`: request-style parsing with a fresh `Engine` per iteration.
 - `parse_known_type/*`: parsing when the diagram type is already known (skips detection).
 - `layout/*`: computing layout (geometry + routes) from a parsed diagram.
 - `render/*`: SVG emission from an already-laid-out diagram.
 - `end_to_end/*`: full pipeline (parse + layout + SVG emission).
+
+The dedicated stress benches are separate on purpose:
+
+- `flowchart_stress`: render-only batching for flowchart fixed-cost work.
+- `architecture_layout_stress`: layout-only batching for architecture FCoSE/manatee work.
+- `architecture_stress`: render-only batching for architecture fixed-cost work.
+- `mindmap_layout_stress`: layout-only batching for mindmap COSE fixed-cost work.
+- `text_measure_stress`: text measurement batching for label/layout tuning.
 
 Bench fixtures live under `crates/merman/benches/fixtures/` and are intentionally small, focused
 inputs designed for regression tracking.
@@ -44,7 +55,7 @@ If you have a local checkout under `repo-ref/mermaid-rs-renderer`, you can gener
 comparison report:
 
 ```bash
-python tools/bench/compare_mermaid_renderers.py
+python3 tools/bench/compare_mermaid_renderers.py
 ```
 
 By default this runs the `quick` corpus suite, writes a Markdown report to
@@ -60,19 +71,27 @@ The helper script sets `MMDR_RUN_CRITERION_BENCHES=1` for the local mmdr checkou
 If you invoke `cargo bench --bench renderer` there by hand, set that env var yourself or the bench
 binary will only run its smoke validation path.
 
+For broader validation, prefer the named suites in `tools/bench/corpus.json`:
+
+- `standard`: routine cross-family validation.
+- `cross_family`: one medium fixture per supported family.
+- `flowchart`: flowchart-heavy routing and layout stress coverage.
+- `stress`: heavy fixtures when validating hotspot work.
+- `full`: every fixture in corpus order.
+
 Both comparison helpers add `--locked` when the target repo has `Cargo.lock`, so benchmark runs do
 not silently drift to newer registry dependencies. If the local `mermaid-rs-renderer` checkout needs
 a newer Rust toolchain than this workspace's `rust-toolchain.toml`, pass it explicitly, for example:
 
 ```bash
-python tools/bench/compare_mermaid_renderers.py --mmdr-toolchain 1.92.0
+python3 tools/bench/compare_mermaid_renderers.py --mmdr-toolchain 1.92.0
 ```
 
 If you prefer keeping comparison artifacts out of the docs tree, pass `--out` and `--json-out`
 explicitly, e.g.:
 
 ```bash
-python tools/bench/compare_mermaid_renderers.py \
+python3 tools/bench/compare_mermaid_renderers.py \
   --suite standard \
   --out target/bench/COMPARISON.latest.md \
   --json-out target/bench/COMPARISON.latest.json
@@ -81,20 +100,20 @@ python tools/bench/compare_mermaid_renderers.py \
 For lower-noise results (recommended when tracking canaries), use the `long` preset:
 
 ```bash
-python tools/bench/compare_mermaid_renderers.py --preset long
+python3 tools/bench/compare_mermaid_renderers.py --preset long
 ```
 
 If you want to avoid the optional upstream Mermaid JS (puppeteer) run (which can be noisy and slow),
 add `--skip-mermaid-js`:
 
 ```bash
-python tools/bench/compare_mermaid_renderers.py --preset long --skip-mermaid-js
+python3 tools/bench/compare_mermaid_renderers.py --preset long --skip-mermaid-js
 ```
 
 To see the available corpus suites:
 
 ```bash
-python tools/bench/compare_mermaid_renderers.py --list-suites
+python3 tools/bench/compare_mermaid_renderers.py --list-suites
 ```
 
 The main suites are:
@@ -110,7 +129,7 @@ The legacy `--filter` path is still available for ad-hoc exact selections. When 
 `--suite` is ignored:
 
 ```bash
-python tools/bench/compare_mermaid_renderers.py \
+python3 tools/bench/compare_mermaid_renderers.py \
   --filter 'end_to_end/(flowchart_medium|class_medium)' \
   --out target/bench/filter.md \
   --json-out target/bench/filter.json
@@ -163,7 +182,7 @@ Mermaid JS results without mixing unlike measurements.
 For interactive visual comparison rather than timed measurement, see
 `docs/workstreams/web-wasm-playground/MERMAID_COMPARE_MODE.md`.
 
-See `docs/performance/PERF_PLAYBOOK.md` for the recommended default canary filter and report naming.
+See `docs/performance/PERF_PLAYBOOK.md` for the recommended default canary suite and report naming.
 
 ## Stage spot-check (recommended for triage)
 
@@ -171,7 +190,7 @@ When you want to attribute a performance change to a specific pipeline stage qui
 layout vs SVG emission), use the stage spot-check script:
 
 ```bash
-python tools/bench/stage_spotcheck.py --fixtures flowchart_medium,class_medium --out target/bench/stage_spotcheck.md
+python3 tools/bench/stage_spotcheck.py --fixtures flowchart_medium,class_medium --out target/bench/stage_spotcheck.md
 ```
 
 This runs a small set of `--exact` Criterion benchmarks for both `merman` and
@@ -183,7 +202,7 @@ automatically.
 For lower-noise spotchecks, use the `long` preset:
 
 ```bash
-python tools/bench/stage_spotcheck.py --preset long --fixtures flowchart_medium,class_medium
+python3 tools/bench/stage_spotcheck.py --preset long --fixtures flowchart_medium,class_medium
 ```
 
 The stage spot-check helper accepts the same `--mmdr-toolchain` option when the reference checkout
@@ -203,7 +222,10 @@ stabilize A/B comparisons.
 
 ```bash
 cargo bench -p merman --features render --bench flowchart_stress -- --noplot --sample-size 50 --warm-up-time 2 --measurement-time 3
+cargo bench -p merman --features render --bench architecture_layout_stress -- --noplot --sample-size 50 --warm-up-time 2 --measurement-time 3
 cargo bench -p merman --features render --bench architecture_stress -- --noplot --sample-size 50 --warm-up-time 2 --measurement-time 3
+cargo bench -p merman --features render --bench mindmap_layout_stress -- --noplot --sample-size 50 --warm-up-time 2 --measurement-time 3
+cargo bench -p merman --features render --bench text_measure_stress -- --noplot --sample-size 50 --warm-up-time 2 --measurement-time 3
 ```
 
 ## Future work

--- a/docs/performance/FEARLESS_REFACTORING.md
+++ b/docs/performance/FEARLESS_REFACTORING.md
@@ -44,7 +44,7 @@ and use the latest numbers in:
 
 For a quick local stage attribution spotcheck (mid estimates):
 
-- `python tools/bench/stage_spotcheck.py --fixtures flowchart_medium,class_medium,sequence_medium --sample-size 20 --warm-up 1 --measurement 1`
+- `python3 tools/bench/stage_spotcheck.py --fixtures flowchart_medium,class_medium,sequence_medium --sample-size 20 --warm-up 1 --measurement 1`
 
 Typical current interpretation on this fixture set:
 

--- a/docs/performance/PERF_PLAN.md
+++ b/docs/performance/PERF_PLAN.md
@@ -3,8 +3,8 @@
 This document is the actionable performance plan for `merman`.
 It is fixture-driven and stage-attributed (parse/layout/render/end-to-end).
 
-For the day-to-day workflow (commands, presets, and reporting conventions), see:
-`docs/performance/PERF_PLAYBOOK.md`.
+For the day-to-day workflow and execution order, see:
+`docs/performance/RUNBOOK.md` and `docs/performance/PERF_PLAYBOOK.md`.
 
 ## Baseline (2026-02-17)
 
@@ -12,7 +12,8 @@ We track two complementary views against `repo-ref/mermaid-rs-renderer` (mmdr):
 
 1) **End-to-end canaries** (throughput view)
 - Report: `docs/performance/COMPARISON.md`
-- Filter used in the latest report: `end_to_end/(flowchart_medium|class_medium|mindmap_medium|architecture_medium)`
+- Default corpus suite: `canary`
+  (`flowchart_medium`, `class_medium`, `mindmap_medium`, `architecture_medium`)
 - Observed ratios (`merman / mmdr`, mid estimate):
   - `end_to_end/flowchart_medium`: `0.9x` (faster)
   - `end_to_end/class_medium`: `0.4x` (faster)

--- a/docs/performance/PERF_PLAYBOOK.md
+++ b/docs/performance/PERF_PLAYBOOK.md
@@ -3,6 +3,7 @@
 This doc is a practical checklist for continuing performance work on `merman` without losing context.
 It complements:
 
+- `docs/performance/RUNBOOK.md` (the default execution order)
 - `docs/performance/PERF_PLAN.md` (targets and prioritized backlog)
 - `docs/performance/PERF_MILESTONES.md` (what shipped)
 - `docs/performance/BENCHMARKING.md` (benchmark mechanics)
@@ -14,6 +15,17 @@ Performance changes are only accepted if:
 1) `cargo nextest run -p merman-render` stays green, and
 2) we can explain *which stage moved* and *why* (parse/layout/render/end_to_end), and
 3) results are recorded in a report under `docs/performance/`.
+
+## Default loop
+
+Follow `docs/performance/RUNBOOK.md` in this order:
+
+1. correctness gate,
+2. stage spotcheck on the four standard canaries,
+3. cross-repo comparison only when the checkpoint is meant to become durable,
+4. hot-vs-cold parse sanity when parse numbers are surprising,
+5. stress benches when the suspected hotspot is microsecond-scale,
+6. record the result in `docs/performance/`.
 
 ## Standard canaries
 
@@ -36,7 +48,7 @@ tracking canaries or making “did it improve?” calls.
 ### Stage spot-check (triage)
 
 ```bash
-python tools/bench/stage_spotcheck.py --preset long --fixtures flowchart_medium,class_medium,mindmap_medium,architecture_medium --out docs/performance/spotcheck_YYYY-MM-DD.md
+python3 tools/bench/stage_spotcheck.py --preset long --fixtures flowchart_medium,class_medium,mindmap_medium,architecture_medium --out docs/performance/spotcheck_YYYY-MM-DD.md
 ```
 
 Interpretation:
@@ -44,11 +56,12 @@ Interpretation:
 - Use `render/*` to guide “SVG emission” work.
 - Use `layout/*` to guide graph/layout work.
 - Use `end_to_end/*` as the “real” canary, but only after you’re confident the harness is fair.
+- Use `parse_cold_engine/*` to separate hot-engine cache wins from request-style parse wins.
 
 ### End-to-end comparison vs mmdr
 
 ```bash
-python tools/bench/compare_mermaid_renderers.py --preset long --skip-mermaid-js --filter "end_to_end/(flowchart_medium|class_medium|mindmap_medium|architecture_medium)" --out docs/performance/COMPARISON.md
+python3 tools/bench/compare_mermaid_renderers.py --preset long --skip-mermaid-js --suite canary --out docs/performance/COMPARISON.md
 ```
 
 Notes:
@@ -82,7 +95,16 @@ Create one report per meaningful checkpoint:
 - `docs/performance/COMPARISON.md` (end-to-end canaries)
 
 When a checkpoint is “in the middle of refactoring” and not ready to become the new baseline, write
-to `target/bench/*.md` instead.
+to `target/bench/perf-runner/*.md` instead.
+
+For durable one-step checkpoints, prefer:
+
+```bash
+python3 tools/bench/perf_runner.py --profile full --write-docs
+```
+
+This writes Markdown reports under `docs/performance/` while keeping structured JSON artifacts
+under `target/bench/perf-runner/`.
 
 ## Current focus (as of 2026-02-17)
 
@@ -107,5 +129,6 @@ When starting a new optimization round:
    a meaningful checkpoint.
 3) Run end-to-end canaries vs mmdr (`--preset long --skip-mermaid-js`) and refresh
    `docs/performance/COMPARISON.md` only when you intend to update the baseline.
-4) If numbers look contradictory, re-run the same command once (noise happens) and prioritize the
+4) If parse looks suspicious, run `parse_cold_engine/*` before attributing the gain to parser work.
+5) If numbers look contradictory, re-run the same command once (noise happens) and prioritize the
    longer preset results.

--- a/docs/performance/RUNBOOK.md
+++ b/docs/performance/RUNBOOK.md
@@ -1,0 +1,77 @@
+# Performance Runbook
+
+This is the default operating procedure for performance work in `merman`.
+Use it whenever you want to decide whether a change is actually faster, and at what stage.
+
+## One-step entrypoints
+
+- `python3 tools/bench/perf_runner.py --profile canary` for the default hot-path workflow.
+- `python3 tools/bench/perf_runner.py --profile full` for broader validation plus stress benches.
+
+By default the one-step runner writes local Markdown and JSON artifacts under
+`target/bench/perf-runner/`. Add `--write-docs` when a checkpoint should be durable in
+`docs/performance/`; Markdown reports move to the docs tree while structured JSON artifacts stay
+under `target/bench/perf-runner/`.
+
+Use flamegraphs after a benchmark identifies a suspicious stage, not as the first measurement.
+Broad Criterion harnesses such as `pipeline` can include fixture setup and prechecks in the
+profiler output. For CPU attribution, prefer the dedicated single-stage runner:
+
+```bash
+CARGO_PROFILE_BENCH_DEBUG=true cargo flamegraph --profile bench \
+  -p merman --features render --example profile_render \
+  -o target/bench/flamegraphs/profile_render_architecture_medium.svg -- \
+  --input crates/merman/benches/fixtures/architecture_medium.mmd \
+  --stage render --seconds 20
+```
+
+## 1. Choose the question
+
+- **Did the reused hot path get faster?** Use the standard stage spotcheck.
+- **Did request-style parsing improve too?** Use `parse_cold_engine/*`.
+- **Did SVG emission or layout fixed-cost move?** Use the relevant stress bench plus timing toggles.
+- **Did the change hold across more of Mermaid?** Use the `standard`, `cross_family`, or `full`
+  comparison suites.
+
+## 2. Measure in this order
+
+1. Correctness gate:
+   - `cargo nextest run -p merman-render`
+2. Stage attribution for the standard canaries:
+   - `python3 tools/bench/stage_spotcheck.py --preset long --fixtures flowchart_medium,class_medium,mindmap_medium,architecture_medium --out target/bench/perf-runner/stage_standard_canaries_latest.md`
+3. Cross-repo throughput comparison when the checkpoint matters:
+   - `python3 tools/bench/compare_mermaid_renderers.py --preset long --skip-mermaid-js --suite canary --out docs/performance/COMPARISON.md`
+4. Hot vs cold parse sanity:
+   - `parse/*` measures a reused `Engine`
+   - `parse_cold_engine/*` measures a fresh `Engine` per iteration
+5. Micro-hotspot validation:
+   - `cargo bench -p merman --features render --bench flowchart_stress -- --noplot --sample-size 50 --warm-up-time 2 --measurement-time 3`
+   - `cargo bench -p merman --features render --bench architecture_layout_stress -- --noplot --sample-size 50 --warm-up-time 2 --measurement-time 3`
+   - `cargo bench -p merman --features render --bench architecture_stress -- --noplot --sample-size 50 --warm-up-time 2 --measurement-time 3`
+   - `cargo bench -p merman --features render --bench mindmap_layout_stress -- --noplot --sample-size 50 --warm-up-time 2 --measurement-time 3`
+   - `cargo bench -p merman --features render --bench text_measure_stress -- --noplot --sample-size 50 --warm-up-time 2 --measurement-time 3`
+
+## 3. Use the right report location
+
+- In-flight work: `target/bench/perf-runner/*.md`
+- Meaningful checkpoint: `docs/performance/spotcheck_YYYY-MM-DD*.md`
+- End-to-end baseline refresh: `docs/performance/COMPARISON.md`
+
+## 4. Interpretation rules
+
+- Prefer the long preset for decisions.
+- Re-run once if results conflict; prioritize the longer run.
+- Do not accept a change unless the stage movement is clear and parity still holds.
+- For microsecond-scale work, prefer batched stress benches over single-shot micro changes.
+
+## 5. Validation suite choice
+
+- `--suite canary`: the four standard hotspot sentinels.
+- `--suite standard`: routine validation across the main cross-family canaries.
+- `--suite cross_family`: shared code-path changes that should be checked across families.
+- `--suite full`: framework, corpus, or infrastructure changes where broad coverage matters.
+
+## 6. Harness contract tests
+
+- `python3 tools/bench/test_perf_contracts.py` checks the canary suite and `perf_runner` dry-run
+  command contract.

--- a/fixtures/xychart/stress_xychart_theme_default_vs_base_base_002.layout.golden.json
+++ b/fixtures/xychart/stress_xychart_theme_default_vs_base_base_002.layout.golden.json
@@ -7,11 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "#f4f4f4",
-      "labelData": [
-        "2",
-        "5",
-        "8"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/stress_xychart_theme_default_vs_base_default_001.layout.golden.json
+++ b/fixtures/xychart/stress_xychart_theme_default_vs_base_default_001.layout.golden.json
@@ -7,11 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "2",
-        "5",
-        "8"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_cypress_xychart_spec_decimals_and_negative_numbers_are_supported_009.layout.golden.json
+++ b/fixtures/xychart/upstream_cypress_xychart_spec_decimals_and_negative_numbers_are_supported_009.layout.golden.json
@@ -7,12 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "1.3",
-        "0.6",
-        "2.4",
-        "-0.34"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "path",

--- a/fixtures/xychart/upstream_cypress_xychart_spec_multiple_plots_can_be_rendered_008.layout.golden.json
+++ b/fixtures/xychart/upstream_cypress_xychart_spec_multiple_plots_can_be_rendered_008.layout.golden.json
@@ -7,12 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "23",
-        "46",
-        "77",
-        "34"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "path",

--- a/fixtures/xychart/upstream_cypress_xychart_spec_render_all_the_theme_color_018.layout.golden.json
+++ b/fixtures/xychart/upstream_cypress_xychart_spec_render_all_the_theme_color_018.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "#f0f8ff",
-      "labelData": [
-        "5000",
-        "6000",
-        "7500",
-        "8200",
-        "9500",
-        "10500",
-        "11000",
-        "10200",
-        "9200",
-        "8500",
-        "7000",
-        "6000"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_cypress_xychart_spec_render_spark_bar_without_displaying_other_property_011.layout.golden.json
+++ b/fixtures/xychart/upstream_cypress_xychart_spec_render_spark_bar_without_displaying_other_property_011.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "#333",
-      "labelData": [
-        "5000",
-        "9000",
-        "7500",
-        "6200",
-        "9500",
-        "5500",
-        "11000",
-        "8200",
-        "9200",
-        "9500",
-        "7000",
-        "8800"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "rect",

--- a/fixtures/xychart/upstream_cypress_xychart_spec_render_spark_line_with_plotreservedspacepercent_010.layout.golden.json
+++ b/fixtures/xychart/upstream_cypress_xychart_spec_render_spark_line_with_plotreservedspacepercent_010.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "#333",
-      "labelData": [
-        "5000",
-        "9000",
-        "7500",
-        "6200",
-        "9500",
-        "5500",
-        "11000",
-        "8200",
-        "9200",
-        "9500",
-        "7000",
-        "8800"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "path",

--- a/fixtures/xychart/upstream_cypress_xychart_spec_render_with_show_axis_label_false_015.layout.golden.json
+++ b/fixtures/xychart/upstream_cypress_xychart_spec_render_with_show_axis_label_false_015.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "5000",
-        "6000",
-        "7500",
-        "8200",
-        "9500",
-        "10500",
-        "11000",
-        "10200",
-        "9200",
-        "8500",
-        "7000",
-        "6000"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_cypress_xychart_spec_render_with_show_axis_line_false_017.layout.golden.json
+++ b/fixtures/xychart/upstream_cypress_xychart_spec_render_with_show_axis_line_false_017.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "5000",
-        "6000",
-        "7500",
-        "8200",
-        "9500",
-        "10500",
-        "11000",
-        "10200",
-        "9200",
-        "8500",
-        "7000",
-        "6000"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_cypress_xychart_spec_render_with_show_axis_tick_false_016.layout.golden.json
+++ b/fixtures/xychart/upstream_cypress_xychart_spec_render_with_show_axis_tick_false_016.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "5000",
-        "6000",
-        "7500",
-        "8200",
-        "9500",
-        "10500",
-        "11000",
-        "10200",
-        "9200",
-        "8500",
-        "7000",
-        "6000"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_cypress_xychart_spec_render_with_show_axis_title_false_014.layout.golden.json
+++ b/fixtures/xychart/upstream_cypress_xychart_spec_render_with_show_axis_title_false_014.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "5000",
-        "6000",
-        "7500",
-        "8200",
-        "9500",
-        "10500",
-        "11000",
-        "10200",
-        "9200",
-        "8500",
-        "7000",
-        "6000"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_cypress_xychart_spec_should_render_a_chart_without_title_004.layout.golden.json
+++ b/fixtures/xychart/upstream_cypress_xychart_spec_should_render_a_chart_without_title_004.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "5000",
-        "6000",
-        "7500",
-        "8200",
-        "9500",
-        "10500",
-        "11000",
-        "10200",
-        "9200",
-        "8500",
-        "7000",
-        "6000"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "rect",

--- a/fixtures/xychart/upstream_cypress_xychart_spec_should_render_a_chart_without_y_axis_with_different_range_006.layout.golden.json
+++ b/fixtures/xychart/upstream_cypress_xychart_spec_should_render_a_chart_without_y_axis_with_different_range_006.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "5000",
-        "6000",
-        "7500",
-        "8200",
-        "9500",
-        "10500",
-        "14000",
-        "3200",
-        "9200",
-        "9900",
-        "3400",
-        "6000"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "rect",

--- a/fixtures/xychart/upstream_cypress_xychart_spec_should_render_a_complete_chart_003.layout.golden.json
+++ b/fixtures/xychart/upstream_cypress_xychart_spec_should_render_a_complete_chart_003.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "5000",
-        "6000",
-        "7500",
-        "8200",
-        "9500",
-        "10500",
-        "11000",
-        "10200",
-        "9200",
-        "8500",
-        "7000",
-        "6000"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_cypress_xychart_spec_should_render_horizontal_bar_chart_without_labels_by_default_023.layout.golden.json
+++ b/fixtures/xychart/upstream_cypress_xychart_spec_should_render_horizontal_bar_chart_without_labels_by_default_023.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "horizontal",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "5000",
-        "6000",
-        "7500",
-        "8200",
-        "9500",
-        "10500",
-        "11000",
-        "10200",
-        "9200",
-        "8500",
-        "7000",
-        "6000"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_cypress_xychart_spec_should_render_the_simplest_possible_xy_beta_chart_001.layout.golden.json
+++ b/fixtures/xychart/upstream_cypress_xychart_spec_should_render_the_simplest_possible_xy_beta_chart_001.layout.golden.json
@@ -7,11 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "10",
-        "30",
-        "20"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "path",

--- a/fixtures/xychart/upstream_cypress_xychart_spec_should_render_the_simplest_possible_xy_chart_002.layout.golden.json
+++ b/fixtures/xychart/upstream_cypress_xychart_spec_should_render_the_simplest_possible_xy_chart_002.layout.golden.json
@@ -7,11 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "10",
-        "30",
-        "20"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "path",

--- a/fixtures/xychart/upstream_cypress_xychart_spec_should_render_vertical_bar_chart_without_labels_by_default_022.layout.golden.json
+++ b/fixtures/xychart/upstream_cypress_xychart_spec_should_render_vertical_bar_chart_without_labels_by_default_022.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "5000",
-        "6000",
-        "7500",
-        "8200",
-        "9500",
-        "10500",
-        "11000",
-        "10200",
-        "9200",
-        "8500",
-        "7000",
-        "6000"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_cypress_xychart_spec_should_use_all_the_config_from_directive_012.layout.golden.json
+++ b/fixtures/xychart/upstream_cypress_xychart_spec_should_use_all_the_config_from_directive_012.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "horizontal",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "5000",
-        "6000",
-        "7500",
-        "8200",
-        "9500",
-        "10500",
-        "11000",
-        "10200",
-        "9200",
-        "8500",
-        "7000",
-        "6000"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_cypress_xychart_spec_should_use_the_correct_distances_between_data_points_019.layout.golden.json
+++ b/fixtures/xychart/upstream_cypress_xychart_spec_should_use_the_correct_distances_between_data_points_019.layout.golden.json
@@ -7,12 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "0",
-        "1",
-        "0",
-        "1"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "path",

--- a/fixtures/xychart/upstream_cypress_xychart_spec_x_axis_title_not_required_007.layout.golden.json
+++ b/fixtures/xychart/upstream_cypress_xychart_spec_x_axis_title_not_required_007.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "5000",
-        "6000",
-        "7500",
-        "8200",
-        "9500",
-        "10500",
-        "14000",
-        "3200",
-        "9200",
-        "9900",
-        "3400",
-        "6000"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "rect",

--- a/fixtures/xychart/upstream_cypress_xychart_spec_y_axis_title_not_required_005.layout.golden.json
+++ b/fixtures/xychart/upstream_cypress_xychart_spec_y_axis_title_not_required_005.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "5000",
-        "6000",
-        "7500",
-        "8200",
-        "9500",
-        "10500",
-        "11000",
-        "10200",
-        "9200",
-        "8500",
-        "7000",
-        "6000"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "rect",

--- a/fixtures/xychart/upstream_docs_examples_xy_chart_syntax_xychart_md_009.layout.golden.json
+++ b/fixtures/xychart/upstream_docs_examples_xy_chart_syntax_xychart_md_009.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "5000",
-        "6000",
-        "7500",
-        "8200",
-        "9500",
-        "10500",
-        "11000",
-        "10200",
-        "9200",
-        "8500",
-        "7000",
-        "6000"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_docs_xychart_example_001.layout.golden.json
+++ b/fixtures/xychart/upstream_docs_xychart_example_001.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "5000",
-        "6000",
-        "7500",
-        "8200",
-        "9500",
-        "10500",
-        "11000",
-        "10200",
-        "9200",
-        "8500",
-        "7000",
-        "6000"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_docs_xychart_setting_colors_for_lines_and_bars_008.layout.golden.json
+++ b/fixtures/xychart/upstream_docs_xychart_setting_colors_for_lines_and_bars_008.layout.golden.json
@@ -7,12 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "10",
-        "20",
-        "30",
-        "40"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_docs_xychart_simplest_example_005.layout.golden.json
+++ b/fixtures/xychart/upstream_docs_xychart_simplest_example_005.layout.golden.json
@@ -7,12 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "1.3",
-        "0.6",
-        "2.4",
-        "-0.34"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "path",

--- a/fixtures/xychart/upstream_examples_xychart_sales_revenue_001.layout.golden.json
+++ b/fixtures/xychart/upstream_examples_xychart_sales_revenue_001.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "5000",
-        "6000",
-        "7500",
-        "8200",
-        "9500",
-        "10500",
-        "11000",
-        "10200",
-        "9200",
-        "8500",
-        "7000",
-        "6000"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_html_demos_xychart_sparkbar_demo_009.layout.golden.json
+++ b/fixtures/xychart/upstream_html_demos_xychart_sparkbar_demo_009.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "#333",
-      "labelData": [
-        "5000",
-        "9000",
-        "7500",
-        "6200",
-        "9500",
-        "5500",
-        "11000",
-        "8200",
-        "9200",
-        "9500",
-        "7000",
-        "8800"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "rect",

--- a/fixtures/xychart/upstream_html_demos_xychart_sparkline_demo_008.layout.golden.json
+++ b/fixtures/xychart/upstream_html_demos_xychart_sparkline_demo_008.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "#333",
-      "labelData": [
-        "5000",
-        "9000",
-        "7500",
-        "6200",
-        "9500",
-        "5500",
-        "11000",
-        "8200",
-        "9200",
-        "9500",
-        "7000",
-        "8800"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "path",

--- a/fixtures/xychart/upstream_html_demos_xychart_xy_charts_bar_with_multiple_category_005.layout.golden.json
+++ b/fixtures/xychart/upstream_html_demos_xychart_xy_charts_bar_with_multiple_category_005.layout.golden.json
@@ -7,15 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "52",
-        "96",
-        "35",
-        "10",
-        "87",
-        "34",
-        "67"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_html_demos_xychart_xy_charts_category_with_large_text_007.layout.golden.json
+++ b/fixtures/xychart/upstream_html_demos_xychart_xy_charts_category_with_large_text_007.layout.golden.json
@@ -7,15 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "52",
-        "96",
-        "35",
-        "10",
-        "87",
-        "34",
-        "67"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_html_demos_xychart_xy_charts_demos_001.layout.golden.json
+++ b/fixtures/xychart/upstream_html_demos_xychart_xy_charts_demos_001.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "5000",
-        "6000",
-        "7500",
-        "8200",
-        "9500",
-        "10500",
-        "11000",
-        "10200",
-        "9200",
-        "8500",
-        "7000",
-        "6000"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_html_demos_xychart_xy_charts_demos_with_all_configs_010.layout.golden.json
+++ b/fixtures/xychart/upstream_html_demos_xychart_xy_charts_demos_with_all_configs_010.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "horizontal",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "5000",
-        "6000",
-        "7500",
-        "8200",
-        "9500",
-        "10500",
-        "11000",
-        "10200",
-        "9200",
-        "8500",
-        "7000",
-        "6000"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_html_demos_xychart_xy_charts_demos_with_all_theme_config_011.layout.golden.json
+++ b/fixtures/xychart/upstream_html_demos_xychart_xy_charts_demos_with_all_theme_config_011.layout.golden.json
@@ -7,20 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "#f0f8ff",
-      "labelData": [
-        "5000",
-        "6000",
-        "7500",
-        "8200",
-        "9500",
-        "10500",
-        "11000",
-        "10200",
-        "9200",
-        "8500",
-        "7000",
-        "6000"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_html_demos_xychart_xy_charts_horizontal_002.layout.golden.json
+++ b/fixtures/xychart/upstream_html_demos_xychart_xy_charts_horizontal_002.layout.golden.json
@@ -7,12 +7,7 @@
       "chartOrientation": "horizontal",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "52",
-        "96",
-        "35",
-        "10"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_html_demos_xychart_xy_charts_line_with_multiple_category_006.layout.golden.json
+++ b/fixtures/xychart/upstream_html_demos_xychart_xy_charts_line_with_multiple_category_006.layout.golden.json
@@ -7,15 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "52",
-        "96",
-        "35",
-        "10",
-        "87",
-        "34",
-        "67"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_html_demos_xychart_xy_charts_only_lines_and_bar_003.layout.golden.json
+++ b/fixtures/xychart/upstream_html_demos_xychart_xy_charts_only_lines_and_bar_003.layout.golden.json
@@ -7,12 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "23",
-        "46",
-        "77",
-        "34"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "path",

--- a/fixtures/xychart/upstream_html_demos_xychart_xy_charts_with_ve_and_ve_numbers_004.layout.golden.json
+++ b/fixtures/xychart/upstream_html_demos_xychart_xy_charts_with_ve_and_ve_numbers_004.layout.golden.json
@@ -7,12 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "1.3",
-        "0.6",
-        "2.4",
-        "-0.34"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "path",

--- a/fixtures/xychart/upstream_pkgtests_xychart_jison_spec_002.layout.golden.json
+++ b/fixtures/xychart/upstream_pkgtests_xychart_jison_spec_002.layout.golden.json
@@ -7,11 +7,7 @@
       "chartOrientation": "horizontal",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "23",
-        "45",
-        "56.6"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_pkgtests_xychart_jison_spec_141.layout.golden.json
+++ b/fixtures/xychart/upstream_pkgtests_xychart_jison_spec_141.layout.golden.json
@@ -7,11 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "23",
-        "45",
-        "56.6"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "path",

--- a/fixtures/xychart/upstream_pkgtests_xychart_jison_spec_149.layout.golden.json
+++ b/fixtures/xychart/upstream_pkgtests_xychart_jison_spec_149.layout.golden.json
@@ -7,11 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "23",
-        "-45",
-        "56.6"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "path",

--- a/fixtures/xychart/upstream_pkgtests_xychart_jison_spec_157.layout.golden.json
+++ b/fixtures/xychart/upstream_pkgtests_xychart_jison_spec_157.layout.golden.json
@@ -7,12 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "23",
-        "-45",
-        "56.6",
-        "0.33"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "path",

--- a/fixtures/xychart/upstream_pkgtests_xychart_jison_spec_176.layout.golden.json
+++ b/fixtures/xychart/upstream_pkgtests_xychart_jison_spec_176.layout.golden.json
@@ -7,12 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "23",
-        "45",
-        "56.6",
-        "0.22"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "rect",

--- a/fixtures/xychart/upstream_pkgtests_xychart_jison_spec_192.layout.golden.json
+++ b/fixtures/xychart/upstream_pkgtests_xychart_jison_spec_192.layout.golden.json
@@ -7,11 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "23",
-        "-45",
-        "56.6"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "rect",

--- a/fixtures/xychart/upstream_pkgtests_xychart_jison_spec_213.layout.golden.json
+++ b/fixtures/xychart/upstream_pkgtests_xychart_jison_spec_213.layout.golden.json
@@ -7,11 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "23",
-        "45",
-        "56.6"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "rect",

--- a/fixtures/xychart/upstream_xychart_autoderive_axes_db.layout.golden.json
+++ b/fixtures/xychart/upstream_xychart_autoderive_axes_db.layout.golden.json
@@ -7,11 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "1",
-        "2",
-        "3"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "path",

--- a/fixtures/xychart/upstream_xychart_axes_titles_only_then_plots_jison_spec.layout.golden.json
+++ b/fixtures/xychart/upstream_xychart_axes_titles_only_then_plots_jison_spec.layout.golden.json
@@ -7,11 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "23",
-        "45",
-        "56.6"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "path",

--- a/fixtures/xychart/upstream_xychart_band_mismatch_db.layout.golden.json
+++ b/fixtures/xychart/upstream_xychart_band_mismatch_db.layout.golden.json
@@ -7,11 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "10",
-        "20",
-        "null"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "rect",

--- a/fixtures/xychart/upstream_xychart_orientation_and_axes_jison_spec.layout.golden.json
+++ b/fixtures/xychart/upstream_xychart_orientation_and_axes_jison_spec.layout.golden.json
@@ -7,11 +7,7 @@
       "chartOrientation": "horizontal",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "23",
-        "45",
-        "56.6"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "text",

--- a/fixtures/xychart/upstream_xychart_plot_numbers_and_titles_jison_spec.layout.golden.json
+++ b/fixtures/xychart/upstream_xychart_plot_numbers_and_titles_jison_spec.layout.golden.json
@@ -7,11 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "23",
-        "-45",
-        "56.6"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "path",

--- a/fixtures/xychart/upstream_xychart_xaxis_band_cat2asdf_jison_spec.layout.golden.json
+++ b/fixtures/xychart/upstream_xychart_xaxis_band_cat2asdf_jison_spec.layout.golden.json
@@ -7,11 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "1",
-        "null",
-        "null"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "rect",

--- a/fixtures/xychart/upstream_xychart_xaxis_quoted_title_with_spaces_jison_spec.layout.golden.json
+++ b/fixtures/xychart/upstream_xychart_xaxis_quoted_title_with_spaces_jison_spec.layout.golden.json
@@ -7,9 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "1"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "rect",

--- a/fixtures/xychart/upstream_xychart_yaxis_quoted_title_with_spaces_jison_spec.layout.golden.json
+++ b/fixtures/xychart/upstream_xychart_yaxis_quoted_title_with_spaces_jison_spec.layout.golden.json
@@ -7,9 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "1"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "path",

--- a/fixtures/xychart/upstream_xychart_yaxis_range_without_title_jison_spec.layout.golden.json
+++ b/fixtures/xychart/upstream_xychart_yaxis_range_without_title_jison_spec.layout.golden.json
@@ -7,9 +7,7 @@
       "chartOrientation": "vertical",
       "showDataLabel": false,
       "backgroundColor": "white",
-      "labelData": [
-        "1"
-      ],
+      "labelData": [],
       "drawables": [
         {
           "type": "rect",

--- a/fixtures/xychart/zed_pr_57644_xychart.layout.golden.json
+++ b/fixtures/xychart/zed_pr_57644_xychart.layout.golden.json
@@ -10,6 +10,24 @@
       "labelData": [],
       "drawables": [
         {
+          "type": "text",
+          "groupTexts": [
+            "chart-title"
+          ],
+          "data": [
+            {
+              "text": "Monthly Active Users (thousands)",
+              "x": 350.0,
+              "y": 21.0,
+              "fill": "#131300",
+              "fontSize": 20.0,
+              "rotation": 0.0,
+              "verticalPos": "middle",
+              "horizontalPos": "center"
+            }
+          ]
+        },
+        {
           "type": "rect",
           "groupTexts": [
             "plot",
@@ -17,31 +35,127 @@
           ],
           "data": [
             {
-              "x": 65.85,
-              "y": 148.119,
-              "width": 36.1,
-              "height": 291.881,
+              "x": 68.97,
+              "y": 418.88,
+              "width": 32.3,
+              "height": 48.72,
               "fill": "#ECECFF",
               "strokeFill": "#ECECFF",
               "strokeWidth": 0.0
             },
             {
-              "x": 364.4,
-              "y": 432.3,
-              "width": 36.1,
-              "height": 7.7,
+              "x": 123.323,
+              "y": 398.37,
+              "width": 32.3,
+              "height": 69.23,
               "fill": "#ECECFF",
               "strokeFill": "#ECECFF",
               "strokeWidth": 0.0
             },
             {
-              "x": 662.95,
-              "y": 7.7,
-              "width": 36.1,
-              "height": 432.3,
+              "x": 177.675,
+              "y": 360.768,
+              "width": 32.3,
+              "height": 106.832,
               "fill": "#ECECFF",
               "strokeFill": "#ECECFF",
               "strokeWidth": 0.0
+            },
+            {
+              "x": 232.028,
+              "y": 340.258,
+              "width": 32.3,
+              "height": 127.342,
+              "fill": "#ECECFF",
+              "strokeFill": "#ECECFF",
+              "strokeWidth": 0.0
+            },
+            {
+              "x": 286.381,
+              "y": 295.82,
+              "width": 32.3,
+              "height": 171.78,
+              "fill": "#ECECFF",
+              "strokeFill": "#ECECFF",
+              "strokeWidth": 0.0
+            },
+            {
+              "x": 340.734,
+              "y": 247.963,
+              "width": 32.3,
+              "height": 219.637,
+              "fill": "#ECECFF",
+              "strokeFill": "#ECECFF",
+              "strokeWidth": 0.0
+            },
+            {
+              "x": 395.086,
+              "y": 271.892,
+              "width": 32.3,
+              "height": 195.708,
+              "fill": "#ECECFF",
+              "strokeFill": "#ECECFF",
+              "strokeWidth": 0.0
+            },
+            {
+              "x": 449.439,
+              "y": 217.198,
+              "width": 32.3,
+              "height": 250.402,
+              "fill": "#ECECFF",
+              "strokeFill": "#ECECFF",
+              "strokeWidth": 0.0
+            },
+            {
+              "x": 503.792,
+              "y": 176.178,
+              "width": 32.3,
+              "height": 291.422,
+              "fill": "#ECECFF",
+              "strokeFill": "#ECECFF",
+              "strokeWidth": 0.0
+            },
+            {
+              "x": 558.145,
+              "y": 138.577,
+              "width": 32.3,
+              "height": 329.023,
+              "fill": "#ECECFF",
+              "strokeFill": "#ECECFF",
+              "strokeWidth": 0.0
+            },
+            {
+              "x": 612.497,
+              "y": 111.23,
+              "width": 32.3,
+              "height": 356.37,
+              "fill": "#ECECFF",
+              "strokeFill": "#ECECFF",
+              "strokeWidth": 0.0
+            },
+            {
+              "x": 666.85,
+              "y": 66.792,
+              "width": 32.3,
+              "height": 400.808,
+              "fill": "#ECECFF",
+              "strokeFill": "#ECECFF",
+              "strokeWidth": 0.0
+            }
+          ]
+        },
+        {
+          "type": "path",
+          "groupTexts": [
+            "plot",
+            "line-plot-1"
+          ],
+          "data": [
+            {
+              "path": "M85.12,418.88000000000005L139.47272727272727,398.37L193.82545454545453,360.7683333333333L248.17818181818183,340.2583333333334L302.53090909090906,295.82L356.88363636363636,247.96333333333337L411.23636363636365,271.89166666666665L465.5890909090909,217.19833333333332L519.9418181818182,176.17833333333334L574.2945454545454,138.57666666666668L628.6472727272727,111.23L683,66.79166666666667",
+              "fill": null,
+              "strokeFill": "#8493A6",
+              "strokeWidth": 2.0
             }
           ]
         },
@@ -53,7 +167,7 @@
           ],
           "data": [
             {
-              "path": "M 64.90000000000003,441 L 700,441",
+              "path": "M 68.12,468.6 L 700,468.6",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
@@ -68,9 +182,9 @@
           ],
           "data": [
             {
-              "text": "1",
-              "x": 83.9,
-              "y": 452.0,
+              "text": "Jan",
+              "x": 85.12,
+              "y": 479.6,
               "fill": "#131300",
               "fontSize": 14.0,
               "rotation": 0.0,
@@ -78,9 +192,9 @@
               "horizontalPos": "center"
             },
             {
-              "text": "1.2",
-              "x": 143.61,
-              "y": 452.0,
+              "text": "Feb",
+              "x": 139.473,
+              "y": 479.6,
               "fill": "#131300",
               "fontSize": 14.0,
               "rotation": 0.0,
@@ -88,9 +202,9 @@
               "horizontalPos": "center"
             },
             {
-              "text": "1.4",
-              "x": 203.32,
-              "y": 452.0,
+              "text": "Mar",
+              "x": 193.825,
+              "y": 479.6,
               "fill": "#131300",
               "fontSize": 14.0,
               "rotation": 0.0,
@@ -98,9 +212,9 @@
               "horizontalPos": "center"
             },
             {
-              "text": "1.6",
-              "x": 263.03,
-              "y": 452.0,
+              "text": "Apr",
+              "x": 248.178,
+              "y": 479.6,
               "fill": "#131300",
               "fontSize": 14.0,
               "rotation": 0.0,
@@ -108,9 +222,9 @@
               "horizontalPos": "center"
             },
             {
-              "text": "1.8",
-              "x": 322.74,
-              "y": 452.0,
+              "text": "May",
+              "x": 302.531,
+              "y": 479.6,
               "fill": "#131300",
               "fontSize": 14.0,
               "rotation": 0.0,
@@ -118,9 +232,9 @@
               "horizontalPos": "center"
             },
             {
-              "text": "2",
-              "x": 382.45,
-              "y": 452.0,
+              "text": "Jun",
+              "x": 356.884,
+              "y": 479.6,
               "fill": "#131300",
               "fontSize": 14.0,
               "rotation": 0.0,
@@ -128,9 +242,9 @@
               "horizontalPos": "center"
             },
             {
-              "text": "2.2",
-              "x": 442.16,
-              "y": 452.0,
+              "text": "Jul",
+              "x": 411.236,
+              "y": 479.6,
               "fill": "#131300",
               "fontSize": 14.0,
               "rotation": 0.0,
@@ -138,9 +252,9 @@
               "horizontalPos": "center"
             },
             {
-              "text": "2.4",
-              "x": 501.87,
-              "y": 452.0,
+              "text": "Aug",
+              "x": 465.589,
+              "y": 479.6,
               "fill": "#131300",
               "fontSize": 14.0,
               "rotation": 0.0,
@@ -148,9 +262,9 @@
               "horizontalPos": "center"
             },
             {
-              "text": "2.6",
-              "x": 561.58,
-              "y": 452.0,
+              "text": "Sep",
+              "x": 519.942,
+              "y": 479.6,
               "fill": "#131300",
               "fontSize": 14.0,
               "rotation": 0.0,
@@ -158,9 +272,9 @@
               "horizontalPos": "center"
             },
             {
-              "text": "2.8",
-              "x": 621.29,
-              "y": 452.0,
+              "text": "Oct",
+              "x": 574.295,
+              "y": 479.6,
               "fill": "#131300",
               "fontSize": 14.0,
               "rotation": 0.0,
@@ -168,9 +282,19 @@
               "horizontalPos": "center"
             },
             {
-              "text": "3",
-              "x": 681.0,
-              "y": 452.0,
+              "text": "Nov",
+              "x": 628.647,
+              "y": 479.6,
+              "fill": "#131300",
+              "fontSize": 14.0,
+              "rotation": 0.0,
+              "verticalPos": "top",
+              "horizontalPos": "center"
+            },
+            {
+              "text": "Dec",
+              "x": 683.0,
+              "y": 479.6,
               "fill": "#131300",
               "fontSize": 14.0,
               "rotation": 0.0,
@@ -187,89 +311,76 @@
           ],
           "data": [
             {
-              "path": "M 83.90000000000003,442 L 83.90000000000003,447",
+              "path": "M 85.12,469.6 L 85.12,474.6",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
             },
             {
-              "path": "M 143.61,442 L 143.61,447",
+              "path": "M 139.47272727272727,469.6 L 139.47272727272727,474.6",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
             },
             {
-              "path": "M 203.32,442 L 203.32,447",
+              "path": "M 193.82545454545453,469.6 L 193.82545454545453,474.6",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
             },
             {
-              "path": "M 263.03000000000003,442 L 263.03000000000003,447",
+              "path": "M 248.17818181818183,469.6 L 248.17818181818183,474.6",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
             },
             {
-              "path": "M 322.74,442 L 322.74,447",
+              "path": "M 302.53090909090906,469.6 L 302.53090909090906,474.6",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
             },
             {
-              "path": "M 382.45,442 L 382.45,447",
+              "path": "M 356.88363636363636,469.6 L 356.88363636363636,474.6",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
             },
             {
-              "path": "M 442.16,442 L 442.16,447",
+              "path": "M 411.23636363636365,469.6 L 411.23636363636365,474.6",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
             },
             {
-              "path": "M 501.86999999999995,442 L 501.86999999999995,447",
+              "path": "M 465.5890909090909,469.6 L 465.5890909090909,474.6",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
             },
             {
-              "path": "M 561.5799999999999,442 L 561.5799999999999,447",
+              "path": "M 519.9418181818182,469.6 L 519.9418181818182,474.6",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
             },
             {
-              "path": "M 621.29,442 L 621.29,447",
+              "path": "M 574.2945454545454,469.6 L 574.2945454545454,474.6",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
             },
             {
-              "path": "M 681,442 L 681,447",
+              "path": "M 628.6472727272727,469.6 L 628.6472727272727,474.6",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
-            }
-          ]
-        },
-        {
-          "type": "text",
-          "groupTexts": [
-            "bottom-axis",
-            "title"
-          ],
-          "data": [
+            },
             {
-              "text": "xAxisName",
-              "x": 382.45,
-              "y": 477.4,
-              "fill": "#131300",
-              "fontSize": 16.0,
-              "rotation": 0.0,
-              "verticalPos": "top",
-              "horizontalPos": "center"
+              "path": "M 683,469.6 L 683,474.6",
+              "fill": null,
+              "strokeFill": "#131300",
+              "strokeWidth": 2.0
             }
           ]
         },
@@ -281,7 +392,7 @@
           ],
           "data": [
             {
-              "path": "M 63.900000000000034,0 L 63.900000000000034,440 ",
+              "path": "M 67.12,42 L 67.12,467.6 ",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
@@ -296,9 +407,79 @@
           ],
           "data": [
             {
+              "text": "120",
+              "x": 56.12,
+              "y": 49.7,
+              "fill": "#131300",
+              "fontSize": 14.0,
+              "rotation": 0.0,
+              "verticalPos": "middle",
+              "horizontalPos": "right"
+            },
+            {
+              "text": "110",
+              "x": 56.12,
+              "y": 83.883,
+              "fill": "#131300",
+              "fontSize": 14.0,
+              "rotation": 0.0,
+              "verticalPos": "middle",
+              "horizontalPos": "right"
+            },
+            {
+              "text": "100",
+              "x": 56.12,
+              "y": 118.067,
+              "fill": "#131300",
+              "fontSize": 14.0,
+              "rotation": 0.0,
+              "verticalPos": "middle",
+              "horizontalPos": "right"
+            },
+            {
+              "text": "90",
+              "x": 56.12,
+              "y": 152.25,
+              "fill": "#131300",
+              "fontSize": 14.0,
+              "rotation": 0.0,
+              "verticalPos": "middle",
+              "horizontalPos": "right"
+            },
+            {
+              "text": "80",
+              "x": 56.12,
+              "y": 186.433,
+              "fill": "#131300",
+              "fontSize": 14.0,
+              "rotation": 0.0,
+              "verticalPos": "middle",
+              "horizontalPos": "right"
+            },
+            {
+              "text": "70",
+              "x": 56.12,
+              "y": 220.617,
+              "fill": "#131300",
+              "fontSize": 14.0,
+              "rotation": 0.0,
+              "verticalPos": "middle",
+              "horizontalPos": "right"
+            },
+            {
+              "text": "60",
+              "x": 56.12,
+              "y": 254.8,
+              "fill": "#131300",
+              "fontSize": 14.0,
+              "rotation": 0.0,
+              "verticalPos": "middle",
+              "horizontalPos": "right"
+            },
+            {
               "text": "50",
-              "x": 52.9,
-              "y": 35.282,
+              "x": 56.12,
+              "y": 288.983,
               "fill": "#131300",
               "fontSize": 14.0,
               "rotation": 0.0,
@@ -307,8 +488,8 @@
             },
             {
               "text": "40",
-              "x": 52.9,
-              "y": 77.074,
+              "x": 56.12,
+              "y": 323.167,
               "fill": "#131300",
               "fontSize": 14.0,
               "rotation": 0.0,
@@ -317,8 +498,8 @@
             },
             {
               "text": "30",
-              "x": 52.9,
-              "y": 118.865,
+              "x": 56.12,
+              "y": 357.35,
               "fill": "#131300",
               "fontSize": 14.0,
               "rotation": 0.0,
@@ -327,8 +508,8 @@
             },
             {
               "text": "20",
-              "x": 52.9,
-              "y": 160.656,
+              "x": 56.12,
+              "y": 391.533,
               "fill": "#131300",
               "fontSize": 14.0,
               "rotation": 0.0,
@@ -337,8 +518,8 @@
             },
             {
               "text": "10",
-              "x": 52.9,
-              "y": 202.448,
+              "x": 56.12,
+              "y": 425.717,
               "fill": "#131300",
               "fontSize": 14.0,
               "rotation": 0.0,
@@ -347,48 +528,8 @@
             },
             {
               "text": "0",
-              "x": 52.9,
-              "y": 244.239,
-              "fill": "#131300",
-              "fontSize": 14.0,
-              "rotation": 0.0,
-              "verticalPos": "middle",
-              "horizontalPos": "right"
-            },
-            {
-              "text": "-10",
-              "x": 52.9,
-              "y": 286.03,
-              "fill": "#131300",
-              "fontSize": 14.0,
-              "rotation": 0.0,
-              "verticalPos": "middle",
-              "horizontalPos": "right"
-            },
-            {
-              "text": "-20",
-              "x": 52.9,
-              "y": 327.822,
-              "fill": "#131300",
-              "fontSize": 14.0,
-              "rotation": 0.0,
-              "verticalPos": "middle",
-              "horizontalPos": "right"
-            },
-            {
-              "text": "-30",
-              "x": 52.9,
-              "y": 369.613,
-              "fill": "#131300",
-              "fontSize": 14.0,
-              "rotation": 0.0,
-              "verticalPos": "middle",
-              "horizontalPos": "right"
-            },
-            {
-              "text": "-40",
-              "x": 52.9,
-              "y": 411.404,
+              "x": 56.12,
+              "y": 459.9,
               "fill": "#131300",
               "fontSize": 14.0,
               "rotation": 0.0,
@@ -405,61 +546,79 @@
           ],
           "data": [
             {
-              "path": "M 62.900000000000034,35.282283464566945 L 57.900000000000034,35.282283464566945",
+              "path": "M 66.12,49.7 L 61.120000000000005,49.7",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
             },
             {
-              "path": "M 62.900000000000034,77.0736220472441 L 57.900000000000034,77.0736220472441",
+              "path": "M 66.12,83.88333333333334 L 61.120000000000005,83.88333333333334",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
             },
             {
-              "path": "M 62.900000000000034,118.86496062992128 L 57.900000000000034,118.86496062992128",
+              "path": "M 66.12,118.06666666666668 L 61.120000000000005,118.06666666666668",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
             },
             {
-              "path": "M 62.900000000000034,160.65629921259844 L 57.900000000000034,160.65629921259844",
+              "path": "M 66.12,152.25 L 61.120000000000005,152.25",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
             },
             {
-              "path": "M 62.900000000000034,202.4476377952756 L 57.900000000000034,202.4476377952756",
+              "path": "M 66.12,186.43333333333334 L 61.120000000000005,186.43333333333334",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
             },
             {
-              "path": "M 62.900000000000034,244.23897637795275 L 57.900000000000034,244.23897637795275",
+              "path": "M 66.12,220.61666666666667 L 61.120000000000005,220.61666666666667",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
             },
             {
-              "path": "M 62.900000000000034,286.0303149606299 L 57.900000000000034,286.0303149606299",
+              "path": "M 66.12,254.8 L 61.120000000000005,254.8",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
             },
             {
-              "path": "M 62.900000000000034,327.8216535433071 L 57.900000000000034,327.8216535433071",
+              "path": "M 66.12,288.9833333333334 L 61.120000000000005,288.9833333333334",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
             },
             {
-              "path": "M 62.900000000000034,369.61299212598425 L 57.900000000000034,369.61299212598425",
+              "path": "M 66.12,323.1666666666667 L 61.120000000000005,323.1666666666667",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
             },
             {
-              "path": "M 62.900000000000034,411.4043307086614 L 57.900000000000034,411.4043307086614",
+              "path": "M 66.12,357.35 L 61.120000000000005,357.35",
+              "fill": null,
+              "strokeFill": "#131300",
+              "strokeWidth": 2.0
+            },
+            {
+              "path": "M 66.12,391.53333333333336 L 61.120000000000005,391.53333333333336",
+              "fill": null,
+              "strokeFill": "#131300",
+              "strokeWidth": 2.0
+            },
+            {
+              "path": "M 66.12,425.7166666666667 L 61.120000000000005,425.7166666666667",
+              "fill": null,
+              "strokeFill": "#131300",
+              "strokeWidth": 2.0
+            },
+            {
+              "path": "M 66.12,459.90000000000003 L 61.120000000000005,459.90000000000003",
               "fill": null,
               "strokeFill": "#131300",
               "strokeWidth": 2.0
@@ -474,9 +633,9 @@
           ],
           "data": [
             {
-              "text": "yAxisName",
+              "text": "Users (k)",
               "x": 5.0,
-              "y": 220.0,
+              "y": 254.8,
               "fill": "#131300",
               "fontSize": 16.0,
               "rotation": 270.0,

--- a/playground/src/lib/mermaid-renderer.ts
+++ b/playground/src/lib/mermaid-renderer.ts
@@ -6,6 +6,7 @@ import {
 import { normalizeThemeName } from "@mermanjs/web";
 
 export const MERMAID_JS_VERSION = "11.15.0";
+export const MERMAID_ZENUML_VERSION = "0.2.2";
 export const MERMAID_CDN_URL =
   import.meta.env.VITE_MERMAID_CDN_URL?.trim() ||
   `https://cdn.jsdelivr.net/npm/mermaid@${MERMAID_JS_VERSION}/dist/mermaid.esm.min.mjs`;
@@ -13,6 +14,12 @@ export const MERMAID_CDN_LOAD_ERROR = "__mermaid_cdn_load_failed__";
 const MERMAID_FALLBACK_CDN_URL =
   import.meta.env.VITE_MERMAID_FALLBACK_CDN_URL?.trim() ||
   `https://unpkg.com/mermaid@${MERMAID_JS_VERSION}/dist/mermaid.esm.min.mjs`;
+const MERMAID_ZENUML_CDN_URL =
+  import.meta.env.VITE_MERMAID_ZENUML_CDN_URL?.trim() ||
+  `https://cdn.jsdelivr.net/npm/@mermaid-js/mermaid-zenuml@${MERMAID_ZENUML_VERSION}/dist/mermaid-zenuml.core.mjs`;
+const MERMAID_ZENUML_FALLBACK_CDN_URL =
+  import.meta.env.VITE_MERMAID_ZENUML_FALLBACK_CDN_URL?.trim() ||
+  `https://unpkg.com/@mermaid-js/mermaid-zenuml@${MERMAID_ZENUML_VERSION}/dist/mermaid-zenuml.core.mjs`;
 
 export interface MermaidRenderResult {
   svg: string | null;
@@ -24,6 +31,10 @@ export interface MermaidRenderResult {
 interface MermaidApi {
   initialize(config: MermaidConfig): void;
   render(id: string, source: string): Promise<{ svg: string }> | { svg: string };
+  registerExternalDiagrams?(
+    diagrams: unknown[],
+    options?: { lazyLoad?: boolean }
+  ): Promise<void>;
 }
 
 interface MermaidConfig {
@@ -40,6 +51,8 @@ let renderSerial = 0;
 let initializedConfigSignature: string | null = null;
 let warmupConfigSignature: string | null = null;
 let warmupPromise: Promise<void> | null = null;
+let zenumlPromise: Promise<unknown> | null = null;
+let zenumlRegisteredMermaid: MermaidApi | null = null;
 
 const WARMUP_SOURCE = "flowchart TD\n  warmupA[Warmup] --> warmupB[Ready]";
 const CDN_ENABLED = import.meta.env.VITE_MERMAID_CDN !== "false";
@@ -52,7 +65,10 @@ export async function renderMermaidSvg(
   const prepareStartTime = performance.now();
 
   try {
-    const prepared = await prepareMermaid(theme, configJson, { warmup: true });
+    const prepared = await prepareMermaid(theme, configJson, {
+      warmup: true,
+      zenuml: isZenUmlSource(source),
+    });
     const prepareTime = performance.now() - prepareStartTime;
     const preparedSource = sourceWithConfig(
       source,
@@ -152,13 +168,16 @@ async function loadMermaidModule(): Promise<MermaidApi> {
 async function prepareMermaid(
   theme: string,
   configJson: string,
-  options: { warmup: boolean }
+  options: { warmup: boolean; zenuml?: boolean }
 ): Promise<{
   mermaid: MermaidApi;
   normalizedTheme: string;
   configSignature: string;
 }> {
   const mermaid = await loadMermaid();
+  if (options.zenuml) {
+    await ensureZenUmlRegistered(mermaid);
+  }
   const normalizedTheme = normalizeThemeName(theme);
   const effectiveConfig = buildMermaidConfig(configJson, normalizedTheme);
   const runtimeConfig: MermaidConfig = {
@@ -182,6 +201,53 @@ async function prepareMermaid(
   }
 
   return { mermaid, normalizedTheme, configSignature };
+}
+
+async function ensureZenUmlRegistered(mermaid: MermaidApi): Promise<void> {
+  if (zenumlRegisteredMermaid === mermaid) return;
+  if (typeof mermaid.registerExternalDiagrams !== "function") {
+    throw new Error("Loaded Mermaid runtime does not support external diagrams.");
+  }
+
+  const zenuml = await loadZenUmlDiagram();
+  await mermaid.registerExternalDiagrams([zenuml], { lazyLoad: false });
+  zenumlRegisteredMermaid = mermaid;
+}
+
+async function loadZenUmlDiagram(): Promise<unknown> {
+  if (zenumlPromise) return zenumlPromise;
+
+  zenumlPromise = loadZenUmlModule().catch((error) => {
+    zenumlPromise = null;
+    throw error;
+  });
+  return zenumlPromise;
+}
+
+async function loadZenUmlModule(): Promise<unknown> {
+  const urls = Array.from(
+    new Set([MERMAID_ZENUML_CDN_URL, MERMAID_ZENUML_FALLBACK_CDN_URL])
+  );
+  let lastError: unknown = null;
+
+  for (const url of urls) {
+    try {
+      const module = await import(/* @vite-ignore */ url);
+      return module.default;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw new Error(
+    `${MERMAID_CDN_LOAD_ERROR}: ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`
+  );
+}
+
+function isZenUmlSource(source: string): boolean {
+  return /^\s*zenuml\b/i.test(source);
 }
 
 async function warmupMermaid(

--- a/tools/bench/compare_mermaid_renderers.py
+++ b/tools/bench/compare_mermaid_renderers.py
@@ -25,6 +25,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
 
+from corpus_utils import Corpus, CorpusFixture, load_corpus, select_corpus_fixtures
+
 
 DEFAULT_CORPUS = "tools/bench/corpus.json"
 DEFAULT_MARKDOWN_OUT = "docs/performance/COMPARISON.md"
@@ -58,26 +60,6 @@ class TimeEstimate:
         if u == "s":
             return self.value * 1e9
         raise ValueError(f"unknown time unit: {self.unit!r}")
-
-
-@dataclass(frozen=True)
-class CorpusFixture:
-    name: str
-    family: str
-    size: str
-    category: str
-    source: str
-    suites: tuple[str, ...]
-    features: tuple[str, ...]
-    quality: tuple[str, ...]
-
-
-@dataclass(frozen=True)
-class Corpus:
-    schema_version: int
-    default_group: str
-    suites: dict[str, str]
-    fixtures: tuple[CorpusFixture, ...]
 
 
 @dataclass(frozen=True)
@@ -348,75 +330,6 @@ def list_criterion_benches(
             continue
         benches.add(m.group("bench"))
     return CriterionBenchList(benches=benches, skipped=parse_skip_lines(out))
-
-
-def load_corpus(path: Path) -> Corpus:
-    data = json.loads(path.read_text(encoding="utf-8"))
-    if not isinstance(data, dict):
-        raise ValueError(f"corpus must be a JSON object: {path}")
-    schema_version = int(data.get("schema_version", 0))
-    if schema_version != 1:
-        raise ValueError(f"unsupported corpus schema_version: {schema_version}")
-
-    suites_raw = data.get("suites") or {}
-    if not isinstance(suites_raw, dict):
-        raise ValueError("corpus.suites must be an object")
-    suites = {str(k): str(v) for k, v in suites_raw.items()}
-    suites.setdefault("full", "All fixtures in corpus order.")
-
-    fixtures_raw = data.get("fixtures") or []
-    if not isinstance(fixtures_raw, list):
-        raise ValueError("corpus.fixtures must be a list")
-
-    seen: set[str] = set()
-    fixtures: list[CorpusFixture] = []
-    for idx, item in enumerate(fixtures_raw):
-        if not isinstance(item, dict):
-            raise ValueError(f"fixture entry {idx} must be an object")
-        name = str(item.get("name") or "").strip()
-        if not name:
-            raise ValueError(f"fixture entry {idx} is missing name")
-        if name in seen:
-            raise ValueError(f"duplicate fixture in corpus: {name}")
-        seen.add(name)
-
-        def str_tuple(key: str) -> tuple[str, ...]:
-            value = item.get(key) or []
-            if isinstance(value, str):
-                return (value,)
-            if not isinstance(value, list):
-                raise ValueError(f"fixture {name}.{key} must be a string or list")
-            return tuple(str(v) for v in value)
-
-        fixtures.append(
-            CorpusFixture(
-                name=name,
-                family=str(item.get("family") or "unknown"),
-                size=str(item.get("size") or "unknown"),
-                category=str(item.get("category") or "standard"),
-                source=str(item.get("source") or f"crates/merman/benches/fixtures/{name}.mmd"),
-                suites=str_tuple("suites"),
-                features=str_tuple("features"),
-                quality=str_tuple("quality"),
-            )
-        )
-
-    return Corpus(
-        schema_version=schema_version,
-        default_group=str(data.get("default_group") or "end_to_end"),
-        suites=suites,
-        fixtures=tuple(fixtures),
-    )
-
-
-def select_corpus_fixtures(corpus: Corpus, suite: str) -> list[CorpusFixture]:
-    if suite == "full":
-        return list(corpus.fixtures)
-    fixtures = [f for f in corpus.fixtures if suite in f.suites]
-    if not fixtures:
-        available = ", ".join(sorted(corpus.suites))
-        raise ValueError(f"unknown or empty suite {suite!r}; available suites: {available}")
-    return fixtures
 
 
 def split_exact_bench(exact: str) -> tuple[str, str]:

--- a/tools/bench/corpus.json
+++ b/tools/bench/corpus.json
@@ -2,6 +2,7 @@
   "schema_version": 1,
   "default_group": "end_to_end",
   "suites": {
+    "canary": "The four benchmark sentinels used for the default hotspot workflow.",
     "quick": "Small smoke set for local iteration; mirrors the historical comparison filter.",
     "standard": "Balanced cross-family set for routine comparison reports.",
     "cross_family": "One representative medium fixture per supported diagram family.",
@@ -36,7 +37,7 @@
       "size": "medium",
       "category": "standard",
       "source": "crates/merman/benches/fixtures/flowchart_medium.mmd",
-      "suites": ["quick", "standard", "cross_family", "flowchart"],
+      "suites": ["canary", "quick", "standard", "cross_family", "flowchart"],
       "features": ["nodes", "edges", "labels"],
       "quality": ["svg_sanity", "dom_compare", "raster_compare"]
     },
@@ -226,7 +227,7 @@
       "size": "medium",
       "category": "standard",
       "source": "crates/merman/benches/fixtures/class_medium.mmd",
-      "suites": ["quick", "standard", "cross_family"],
+      "suites": ["canary", "quick", "standard", "cross_family"],
       "features": ["classes", "relations", "members"],
       "quality": ["svg_sanity", "dom_compare", "raster_compare"]
     },
@@ -316,7 +317,7 @@
       "size": "medium",
       "category": "standard",
       "source": "crates/merman/benches/fixtures/mindmap_medium.mmd",
-      "suites": ["standard", "cross_family"],
+      "suites": ["canary", "standard", "cross_family"],
       "features": ["tree", "markdown_labels"],
       "quality": ["svg_sanity", "dom_compare", "raster_compare"]
     },
@@ -446,7 +447,7 @@
       "size": "medium",
       "category": "standard",
       "source": "crates/merman/benches/fixtures/architecture_medium.mmd",
-      "suites": ["standard", "cross_family"],
+      "suites": ["canary", "standard", "cross_family"],
       "features": ["groups", "services", "edges"],
       "quality": ["svg_sanity", "dom_compare", "raster_compare"]
     },

--- a/tools/bench/corpus_utils.py
+++ b/tools/bench/corpus_utils.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Shared helpers for the corpus-driven benchmark scripts.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class CorpusFixture:
+    name: str
+    family: str
+    size: str
+    category: str
+    source: str
+    suites: tuple[str, ...]
+    features: tuple[str, ...]
+    quality: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Corpus:
+    schema_version: int
+    default_group: str
+    suites: dict[str, str]
+    fixtures: tuple[CorpusFixture, ...]
+
+
+def load_corpus(path: Path) -> Corpus:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"corpus must be a JSON object: {path}")
+    schema_version = int(data.get("schema_version", 0))
+    if schema_version != 1:
+        raise ValueError(f"unsupported corpus schema_version: {schema_version}")
+
+    suites_raw = data.get("suites") or {}
+    if not isinstance(suites_raw, dict):
+        raise ValueError("corpus.suites must be an object")
+    suites = {str(k): str(v) for k, v in suites_raw.items()}
+    suites.setdefault("full", "All fixtures in corpus order.")
+
+    fixtures_raw = data.get("fixtures") or []
+    if not isinstance(fixtures_raw, list):
+        raise ValueError("corpus.fixtures must be a list")
+
+    seen: set[str] = set()
+    fixtures: list[CorpusFixture] = []
+    for idx, item in enumerate(fixtures_raw):
+        if not isinstance(item, dict):
+            raise ValueError(f"fixture entry {idx} must be an object")
+        name = str(item.get("name") or "").strip()
+        if not name:
+            raise ValueError(f"fixture entry {idx} is missing name")
+        if name in seen:
+            raise ValueError(f"duplicate fixture in corpus: {name}")
+        seen.add(name)
+
+        def str_tuple(key: str) -> tuple[str, ...]:
+            value = item.get(key) or []
+            if isinstance(value, str):
+                return (value,)
+            if not isinstance(value, list):
+                raise ValueError(f"fixture {name}.{key} must be a string or list")
+            return tuple(str(v) for v in value)
+
+        fixtures.append(
+            CorpusFixture(
+                name=name,
+                family=str(item.get("family") or "unknown"),
+                size=str(item.get("size") or "unknown"),
+                category=str(item.get("category") or "standard"),
+                source=str(item.get("source") or f"crates/merman/benches/fixtures/{name}.mmd"),
+                suites=str_tuple("suites"),
+                features=str_tuple("features"),
+                quality=str_tuple("quality"),
+            )
+        )
+
+    return Corpus(
+        schema_version=schema_version,
+        default_group=str(data.get("default_group") or "end_to_end"),
+        suites=suites,
+        fixtures=tuple(fixtures),
+    )
+
+
+def select_corpus_fixtures(corpus: Corpus, suite: str) -> list[CorpusFixture]:
+    if suite == "full":
+        return list(corpus.fixtures)
+    fixtures = [f for f in corpus.fixtures if suite in f.suites]
+    if not fixtures:
+        available = ", ".join(sorted(corpus.suites))
+        raise ValueError(f"unknown or empty suite {suite!r}; available suites: {available}")
+    return fixtures
+
+
+def fixture_names_for_suite(corpus: Corpus, suite: str) -> tuple[str, ...]:
+    return tuple(f.name for f in select_corpus_fixtures(corpus, suite))

--- a/tools/bench/mermaid_js_bench.cjs
+++ b/tools/bench/mermaid_js_bench.cjs
@@ -98,6 +98,14 @@ async function main() {
     "dist",
     "mermaid.js"
   );
+  const zenumlIifePath = path.join(
+    cliRoot,
+    "node_modules",
+    "@mermaid-js",
+    "mermaid-zenuml",
+    "dist",
+    "mermaid-zenuml.js"
+  );
 
   try {
     meta.mermaid = require(path.join(cliRoot, "node_modules", "mermaid", "package.json")).version;
@@ -107,6 +115,13 @@ async function main() {
   try {
     meta.mermaid_cli = require(
       path.join(cliRoot, "node_modules", "@mermaid-js", "mermaid-cli", "package.json")
+    ).version;
+  } catch {
+    // ignore
+  }
+  try {
+    meta.mermaid_zenuml = require(
+      path.join(cliRoot, "node_modules", "@mermaid-js", "mermaid-zenuml", "package.json")
     ).version;
   } catch {
     // ignore
@@ -206,6 +221,17 @@ async function main() {
   });
   await page.goto("file://" + mermaidHtmlPath.replace(/\\/g, "/"));
   await page.addScriptTag({ path: mermaidIifePath });
+  if (Object.values(fixtures).some((code) => /^\s*zenuml\b/.test(String(code)))) {
+    await page.addScriptTag({ path: zenumlIifePath });
+    await page.evaluate(async () => {
+      const mermaid = globalThis.mermaid;
+      const zenuml = globalThis["mermaid-zenuml"];
+      if (!mermaid || !zenuml) {
+        throw new Error("Mermaid ZenUML plugin failed to load");
+      }
+      await mermaid.registerExternalDiagrams([zenuml], { lazyLoad: false });
+    });
+  }
 
   const results = {};
   for (const [name, code] of Object.entries(fixtures)) {

--- a/tools/bench/perf_runner.py
+++ b/tools/bench/perf_runner.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+"""
+One-step performance runner for the standard `merman` optimization workflow.
+
+Profiles:
+- triage: correctness gate + stage spotcheck
+- canary: triage + canary end-to-end comparison
+- full: canary + broader suite comparison + stress benches
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import os
+import shlex
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from corpus_utils import fixture_names_for_suite, load_corpus
+
+
+DEFAULT_CORPUS_PATH = Path(__file__).resolve().with_name("corpus.json")
+STANDARD_CANARY_FIXTURES = ",".join(
+    fixture_names_for_suite(load_corpus(DEFAULT_CORPUS_PATH), "canary")
+)
+STANDARD_CANARY_SUITE = "canary"
+DEFAULT_COMPARE_SUITE = "standard"
+STRESS_BENCHES = [
+    "flowchart_stress",
+    "architecture_layout_stress",
+    "architecture_stress",
+    "mindmap_layout_stress",
+    "text_measure_stress",
+]
+
+
+@dataclass(frozen=True)
+class Step:
+    label: str
+    cmd: list[str]
+    cwd: Path
+    env: dict[str, str] | None = None
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def today_stamp() -> str:
+    return dt.date.today().isoformat()
+
+
+def python_cmd(root: Path, script: str, extra_args: list[str]) -> list[str]:
+    return [sys.executable, str(root / "tools" / "bench" / script), *extra_args]
+
+
+def cli_path(root: Path, path: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def stage_bench_params(preset: str) -> tuple[int, int, int]:
+    if preset == "long":
+        return 30, 2, 3
+    return 20, 1, 1
+
+
+def cargo_bench_cmd(
+    *,
+    bench: str,
+    exact: str | None,
+    sample_size: int,
+    warm_up: int,
+    measurement: int,
+    package: str = "merman",
+    features: str = "render",
+) -> list[str]:
+    cmd = ["cargo", "bench", "--locked"]
+    if package:
+        cmd.extend(["-p", package])
+    if features:
+        cmd.extend(["--features", features])
+    cmd.extend(
+        [
+            "--bench",
+            bench,
+            "--",
+            "--noplot",
+            "--sample-size",
+            str(sample_size),
+            "--warm-up-time",
+            str(warm_up),
+            "--measurement-time",
+            str(measurement),
+            "--discard-baseline",
+        ]
+    )
+    if exact is not None:
+        cmd.extend(["--exact", exact])
+    return cmd
+
+
+def render_target_path(
+    *,
+    report_root: Path,
+    docs: bool,
+    profile: str,
+    kind: str,
+    suffix: str,
+) -> Path:
+    stamp = today_stamp()
+    if docs:
+        if kind == "spotcheck":
+            name = f"spotcheck_{stamp}_perf-runner_{profile}.{suffix}"
+        else:
+            name = f"COMPARISON.perf-runner_{stamp}_{profile}.{suffix}"
+        return repo_root() / "docs" / "performance" / name
+    return report_root / f"{stamp}_{profile}_{kind}.{suffix}"
+
+
+def suite_target_path(
+    *,
+    report_root: Path,
+    docs: bool,
+    profile: str,
+    suite: str,
+    suffix: str,
+) -> Path:
+    stamp = today_stamp()
+    if docs:
+        name = f"COMPARISON.perf-runner_{stamp}_{profile}_suite_{suite}.{suffix}"
+        return repo_root() / "docs" / "performance" / name
+    return report_root / f"{stamp}_{profile}_suite_{suite}.{suffix}"
+
+
+def build_steps(args: argparse.Namespace) -> list[Step]:
+    root = repo_root()
+    report_root = (root / args.report_root).resolve() if not Path(args.report_root).is_absolute() else Path(args.report_root)
+    docs = args.write_docs
+
+    steps: list[Step] = []
+
+    steps.append(
+        Step(
+            label="correctness gate",
+            cmd=["cargo", "nextest", "run", "-p", "merman-render"],
+            cwd=root,
+        )
+    )
+
+    if args.profile in {"triage", "canary", "full"}:
+        stage_out = render_target_path(
+            report_root=report_root,
+            docs=docs,
+            profile=args.profile,
+            kind="spotcheck",
+            suffix="md",
+        )
+        stage_cmd = python_cmd(
+            root,
+            "stage_spotcheck.py",
+            [
+                "--preset",
+                args.preset,
+                "--fixtures",
+                args.stage_fixtures,
+                "--out",
+                cli_path(root, stage_out),
+                "--mmdr-dir",
+                args.mmdr_dir,
+            ]
+            + (["--mmdr-toolchain", args.mmdr_toolchain] if args.mmdr_toolchain else []),
+        )
+        steps.append(
+            Step(
+                label=f"stage spotcheck ({args.stage_fixtures})",
+                cmd=stage_cmd,
+                cwd=root,
+            )
+        )
+
+        if args.include_cold_parse:
+            sample_size, warm_up, measurement = stage_bench_params(args.preset)
+            for fixture in [x.strip() for x in args.cold_parse_fixtures.split(",") if x.strip()]:
+                exact = f"parse_cold_engine/{fixture}"
+                steps.append(
+                    Step(
+                        label=f"cold parse ({fixture})",
+                        cmd=cargo_bench_cmd(
+                            bench="pipeline",
+                            exact=exact,
+                            sample_size=sample_size,
+                            warm_up=warm_up,
+                            measurement=measurement,
+                        ),
+                        cwd=root,
+                    )
+                )
+
+    if args.profile in {"canary", "full"}:
+        compare_out = render_target_path(
+            report_root=report_root,
+            docs=docs,
+            profile=args.profile,
+            kind="comparison",
+            suffix="md",
+        )
+        compare_json = render_target_path(
+            report_root=report_root,
+            docs=False,
+            profile=args.profile,
+            kind="comparison",
+            suffix="json",
+        )
+        compare_cmd = python_cmd(
+            root,
+            "compare_mermaid_renderers.py",
+            [
+                "--preset",
+                args.preset,
+            ]
+            + (
+                ["--filter", args.compare_filter]
+                if args.compare_filter
+                else ["--suite", args.canary_suite]
+            )
+            + [
+                "--out",
+                cli_path(root, compare_out),
+                "--json-out",
+                cli_path(root, compare_json),
+                "--mmdr-dir",
+                args.mmdr_dir,
+            ]
+            + (["--mmdr-toolchain", args.mmdr_toolchain] if args.mmdr_toolchain else [])
+            + ([] if args.include_mermaid_js else ["--skip-mermaid-js"]),
+        )
+        steps.append(
+            Step(
+                label="canary compare vs mmdr",
+                cmd=compare_cmd,
+                cwd=root,
+            )
+        )
+
+    if args.profile == "full":
+        suite_compare_out = suite_target_path(
+            report_root=report_root,
+            docs=docs,
+            profile=args.profile,
+            suite=args.compare_suite,
+            suffix="md",
+        )
+        suite_compare_json = suite_target_path(
+            report_root=report_root,
+            docs=False,
+            profile=args.profile,
+            suite=args.compare_suite,
+            suffix="json",
+        )
+        suite_cmd = python_cmd(
+            root,
+            "compare_mermaid_renderers.py",
+            [
+                "--preset",
+                args.preset,
+                "--suite",
+                args.compare_suite,
+                "--out",
+                cli_path(root, suite_compare_out),
+                "--json-out",
+                cli_path(root, suite_compare_json),
+                "--mmdr-dir",
+                args.mmdr_dir,
+            ]
+            + (["--mmdr-toolchain", args.mmdr_toolchain] if args.mmdr_toolchain else [])
+            + ([] if args.include_mermaid_js else ["--skip-mermaid-js"]),
+        )
+        steps.append(
+            Step(
+                label=f"broader compare suite ({args.compare_suite})",
+                cmd=suite_cmd,
+                cwd=root,
+            )
+        )
+
+        for bench_bin in STRESS_BENCHES:
+            steps.append(
+                Step(
+                    label=f"stress bench ({bench_bin})",
+                    cmd=cargo_bench_cmd(
+                        bench=bench_bin,
+                        exact=None,
+                        sample_size=args.stress_sample_size,
+                        warm_up=args.stress_warm_up,
+                        measurement=args.stress_measurement,
+                    ),
+                    cwd=root,
+                )
+            )
+
+    return steps
+
+
+def run_step(step: Step, *, dry_run: bool) -> None:
+    print(f"\n==> {step.label}")
+    print(f"$ {shlex.join(step.cmd)}")
+    if dry_run:
+        return
+
+    env = os.environ.copy()
+    if step.env:
+        env.update(step.env)
+
+    start = time.perf_counter()
+    proc = subprocess.run(step.cmd, cwd=str(step.cwd), env=env)
+    elapsed = time.perf_counter() - start
+    if proc.returncode != 0:
+        raise SystemExit(proc.returncode)
+    print(f"[ok] {step.label} ({elapsed:.1f}s)")
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the documented performance workflow in one pass."
+    )
+    parser.add_argument(
+        "--profile",
+        choices=["triage", "canary", "full"],
+        default="canary",
+        help="Workflow preset to run (default: canary).",
+    )
+    parser.add_argument(
+        "--preset",
+        choices=["quick", "long"],
+        default="long",
+        help="Benchmark preset passed to stage/comparison scripts (default: long).",
+    )
+    parser.add_argument(
+        "--stage-fixtures",
+        default=STANDARD_CANARY_FIXTURES,
+        help=f"Comma-separated fixtures for stage spotcheck (default: {STANDARD_CANARY_FIXTURES}).",
+    )
+    parser.add_argument(
+        "--compare-filter",
+        default="",
+        help=(
+            "Optional exact comparison filter for the canary compare step. "
+            "When omitted, the canary suite from corpus.json is used."
+        ),
+    )
+    parser.add_argument(
+        "--canary-suite",
+        default=STANDARD_CANARY_SUITE,
+        help="Corpus suite used for the canary compare step (default: canary).",
+    )
+    parser.add_argument(
+        "--compare-suite",
+        default=DEFAULT_COMPARE_SUITE,
+        help="Suite used by the broader comparison step in full profile.",
+    )
+    parser.add_argument(
+        "--cold-parse-fixtures",
+        default=STANDARD_CANARY_FIXTURES,
+        help="Comma-separated fixtures for parse_cold_engine sanity checks.",
+    )
+    parser.add_argument(
+        "--include-cold-parse",
+        action="store_true",
+        help="Include parse_cold_engine sanity checks after stage attribution.",
+    )
+    parser.add_argument(
+        "--include-mermaid-js",
+        action="store_true",
+        help="Also run the Mermaid JS comparison path (defaults to skipped).",
+    )
+    parser.add_argument(
+        "--mmdr-dir",
+        default="repo-ref/mermaid-rs-renderer",
+        help="Path to a local checkout of mermaid-rs-renderer.",
+    )
+    parser.add_argument(
+        "--mmdr-toolchain",
+        default=None,
+        help="Optional rustup toolchain for mermaid-rs-renderer cargo commands.",
+    )
+    parser.add_argument(
+        "--report-root",
+        default="target/bench/perf-runner",
+        help="Root directory for local artifacts when not writing to docs.",
+    )
+    parser.add_argument(
+        "--write-docs",
+        action="store_true",
+        help=(
+            "Write perf-runner Markdown reports under docs/performance. "
+            "Structured JSON artifacts still use --report-root."
+        ),
+    )
+    parser.add_argument(
+        "--stress-sample-size",
+        type=int,
+        default=50,
+        help="Sample size used by the stress benches (default: 50).",
+    )
+    parser.add_argument(
+        "--stress-warm-up",
+        type=int,
+        default=2,
+        help="Warm-up seconds used by the stress benches (default: 2).",
+    )
+    parser.add_argument(
+        "--stress-measurement",
+        type=int,
+        default=3,
+        help="Measurement seconds used by the stress benches (default: 3).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the planned commands without executing them.",
+    )
+    args = parser.parse_args(argv)
+
+    steps = build_steps(args)
+
+    print(f"Profile: {args.profile}")
+    print(f"Preset: {args.preset}")
+    if args.write_docs:
+        print(f"Output mode: docs/performance (Markdown), {Path(args.report_root).expanduser()} (JSON)")
+    else:
+        print(f"Output mode: {Path(args.report_root).expanduser()}")
+
+    for step in steps:
+        run_step(step, dry_run=args.dry_run)
+
+    if not args.dry_run:
+        print("\nArtifacts:")
+        root = repo_root()
+        if args.profile in {"triage", "canary", "full"}:
+            stage_out = render_target_path(
+                report_root=(root / args.report_root).resolve() if not Path(args.report_root).is_absolute() else Path(args.report_root),
+                docs=args.write_docs,
+                profile=args.profile,
+                kind="spotcheck",
+                suffix="md",
+            )
+            print(f"- {stage_out}")
+        if args.profile in {"canary", "full"}:
+            compare_out = render_target_path(
+                report_root=(root / args.report_root).resolve() if not Path(args.report_root).is_absolute() else Path(args.report_root),
+                docs=args.write_docs,
+                profile=args.profile,
+                kind="comparison",
+                suffix="md",
+            )
+            print(f"- {compare_out}")
+        if args.profile == "full":
+            suite_out = suite_target_path(
+                report_root=(root / args.report_root).resolve() if not Path(args.report_root).is_absolute() else Path(args.report_root),
+                docs=args.write_docs,
+                profile=args.profile,
+                suite=args.compare_suite,
+                suffix="md",
+            )
+            print(f"- {suite_out}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/bench/test_perf_contracts.py
+++ b/tools/bench/test_perf_contracts.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Contract tests for the corpus-driven performance helper scripts."""
+
+from __future__ import annotations
+
+import io
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import perf_runner
+from corpus_utils import fixture_names_for_suite, load_corpus, select_corpus_fixtures
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CORPUS_PATH = ROOT / "tools" / "bench" / "corpus.json"
+
+
+class CorpusContractsTest(unittest.TestCase):
+    def test_canary_suite_is_standard_hotspot_set(self) -> None:
+        corpus = load_corpus(CORPUS_PATH)
+
+        self.assertEqual(
+            fixture_names_for_suite(corpus, "canary"),
+            (
+                "flowchart_medium",
+                "class_medium",
+                "mindmap_medium",
+                "architecture_medium",
+            ),
+        )
+
+    def test_full_suite_uses_all_fixtures_in_corpus_order(self) -> None:
+        corpus = load_corpus(CORPUS_PATH)
+
+        self.assertEqual(select_corpus_fixtures(corpus, "full"), list(corpus.fixtures))
+
+
+class PerfRunnerContractsTest(unittest.TestCase):
+    def test_canary_dry_run_uses_corpus_suite_for_comparison(self) -> None:
+        buf = io.StringIO()
+
+        with redirect_stdout(buf):
+            result = perf_runner.main(["--profile", "canary", "--dry-run"])
+
+        self.assertEqual(result, 0)
+        out = buf.getvalue()
+        self.assertIn(
+            "stage spotcheck (flowchart_medium,class_medium,mindmap_medium,architecture_medium)",
+            out,
+        )
+        self.assertIn("compare_mermaid_renderers.py --preset long --suite canary", out)
+        self.assertIn("--skip-mermaid-js", out)
+
+    def test_triage_dry_run_includes_cold_parse_steps(self) -> None:
+        buf = io.StringIO()
+
+        with redirect_stdout(buf):
+            result = perf_runner.main(
+                ["--profile", "triage", "--include-cold-parse", "--dry-run"]
+            )
+
+        self.assertEqual(result, 0)
+        out = buf.getvalue()
+        self.assertIn("cold parse (flowchart_medium)", out)
+        self.assertIn("parse_cold_engine/flowchart_medium", out)
+        self.assertIn("cold parse (architecture_medium)", out)
+
+    def test_full_write_docs_dry_run_writes_suite_report_to_docs(self) -> None:
+        buf = io.StringIO()
+
+        with redirect_stdout(buf):
+            result = perf_runner.main(
+                ["--profile", "full", "--write-docs", "--dry-run"]
+            )
+
+        self.assertEqual(result, 0)
+        out = buf.getvalue()
+        self.assertIn(
+            "Output mode: docs/performance (Markdown), target/bench/perf-runner (JSON)",
+            out,
+        )
+        self.assertIn("broader compare suite (standard)", out)
+        self.assertIn(
+            "docs/performance/COMPARISON.perf-runner_"
+            f"{perf_runner.today_stamp()}_full_suite_standard.md",
+            out,
+        )
+        self.assertIn(
+            f"target/bench/perf-runner/{perf_runner.today_stamp()}_full_suite_standard.json",
+            out,
+        )
+
+
+if __name__ == "__main__":
+    sys.exit(unittest.main())


### PR DESCRIPTION
## Summary
This PR turns the current performance work into a repeatable workflow, trims a few renderer hot paths, and adds lightweight GitHub templates so future bugs, regressions, and feature requests arrive with the right evidence.

## What changed
- Benchmarking now runs from a shared corpus-backed flow, with contract checks and a profiler-friendly render example.
- ZenUML is covered in the Mermaid JS benchmark path, so the comparison matrix no longer has a blind spot.
- Xychart and a few architecture/render helpers shed avoidable hot-path overhead.
- GitHub now has a PR template plus separate bug, perf regression, and feature request forms.

## Measurements
| Metric | Before | After | Result |
| --- | ---: | ---: | --- |
| `xychart_medium` end-to-end | `81.10 µs` | `73.62 µs` | about `9%` faster |
| Corpus geomean vs Mermaid JS | - | `0.016x` of Mermaid JS time | about `62x` faster overall |
| Fixtures over `100x` faster vs Mermaid JS | - | `6 / 24` | top fixture about `183x` |

## Template design
The templates are intentionally narrow:
- bug reports ask for reproduction steps, expected behavior, and evidence
- perf reports ask for baseline/current numbers and the measurement setup
- feature requests ask for the problem, proposal, and parity/performance impact

## Verification
- `cargo fmt --all --check`
- `cargo check -p merman-render --lib`
- `cargo test -p merman-render --test xychart_svg_test`
- `python3 tools/bench/test_perf_contracts.py`