### PR TITLE
Up deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,8 +8,8 @@ version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
 dependencies = [
- "ab_glyph_rasterizer",
- "owned_ttf_parser",
+    "ab_glyph_rasterizer",
+    "owned_ttf_parser",
 ]
 
 [[package]]
@@ -24,7 +24,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3b7f7f85a7e5f68090000ed7622545829afd484d210358702ae4cb97dd0c320"
 dependencies = [
- "uuid",
+    "uuid",
 ]
 
 [[package]]
@@ -39,11 +39,11 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
- "cfg-if",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
+    "cfg-if",
+    "getrandom 0.3.4",
+    "once_cell",
+    "version_check",
+    "zerocopy",
 ]
 
 [[package]]
@@ -52,7 +52,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
- "memchr",
+    "memchr",
 ]
 
 [[package]]
@@ -67,7 +67,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
- "alloc-no-stdlib",
+    "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -76,7 +76,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
 dependencies = [
- "cc",
+    "cc",
 ]
 
 [[package]]
@@ -91,17 +91,17 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
 dependencies = [
- "android-properties",
- "bitflags 2.13.0",
- "cc",
- "jni",
- "libc",
- "log",
- "ndk",
- "ndk-context",
- "ndk-sys",
- "num_enum",
- "thiserror 2.0.18",
+    "android-properties",
+    "bitflags 2.13.0",
+    "cc",
+    "jni",
+    "libc",
+    "log",
+    "ndk",
+    "ndk-context",
+    "ndk-sys",
+    "num_enum",
+    "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -116,7 +116,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
- "libc",
+    "libc",
 ]
 
 [[package]]
@@ -131,13 +131,13 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
+    "anstyle",
+    "anstyle-parse",
+    "anstyle-query",
+    "anstyle-wincon",
+    "colorchoice",
+    "is_terminal_polyfill",
+    "utf8parse",
 ]
 
 [[package]]
@@ -152,7 +152,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
- "utf8parse",
+    "utf8parse",
 ]
 
 [[package]]
@@ -161,7 +161,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+    "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -170,9 +170,9 @@ version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.61.2",
+    "anstyle",
+    "once_cell_polyfill",
+    "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -187,7 +187,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
- "num-traits",
+    "num-traits",
 ]
 
 [[package]]
@@ -196,18 +196,18 @@ version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
 dependencies = [
- "clipboard-win",
- "image",
- "log",
- "objc2 0.6.4",
- "objc2-app-kit 0.3.2",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-foundation 0.3.2",
- "parking_lot",
- "percent-encoding",
- "windows-sys 0.60.2",
- "x11rb",
+    "clipboard-win",
+    "image",
+    "log",
+    "objc2 0.6.4",
+    "objc2-app-kit 0.3.2",
+    "objc2-core-foundation",
+    "objc2-core-graphics",
+    "objc2-foundation 0.3.2",
+    "parking_lot",
+    "percent-encoding",
+    "windows-sys 0.60.2",
+    "x11rb",
 ]
 
 [[package]]
@@ -218,9 +218,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "as-raw-xcb-connection"
@@ -230,11 +230,11 @@ checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
 name = "ascii-canvas"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
 dependencies = [
- "term",
+    "term",
 ]
 
 [[package]]
@@ -243,11 +243,11 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
 dependencies = [
- "askama_derive",
- "itoa",
- "percent-encoding",
- "serde",
- "serde_json",
+    "askama_derive",
+    "itoa",
+    "percent-encoding",
+    "serde",
+    "serde_json",
 ]
 
 [[package]]
@@ -256,15 +256,15 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
 dependencies = [
- "askama_parser",
- "basic-toml",
- "memchr",
- "proc-macro2",
- "quote",
- "rustc-hash 2.1.2",
- "serde",
- "serde_derive",
- "syn",
+    "askama_parser",
+    "basic-toml",
+    "memchr",
+    "proc-macro2",
+    "quote",
+    "rustc-hash 2.1.2",
+    "serde",
+    "serde_derive",
+    "syn",
 ]
 
 [[package]]
@@ -273,10 +273,10 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
 dependencies = [
- "memchr",
- "serde",
- "serde_derive",
- "winnow 0.7.15",
+    "memchr",
+    "serde",
+    "serde_derive",
+    "winnow 0.7.15",
 ]
 
 [[package]]
@@ -285,13 +285,13 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
- "anstyle",
- "bstr",
- "libc",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "wait-timeout",
+    "anstyle",
+    "bstr",
+    "libc",
+    "predicates",
+    "predicates-core",
+    "predicates-tree",
+    "wait-timeout",
 ]
 
 [[package]]
@@ -318,22 +318,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "beef"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec 0.6.3",
+    "serde",
 ]
 
 [[package]]
@@ -342,7 +327,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+    "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -351,14 +336,8 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
 dependencies = [
- "bit-vec 0.9.1",
+    "bit-vec 0.9.1",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -390,7 +369,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+    "generic-array",
 ]
 
 [[package]]
@@ -399,7 +378,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "objc2 0.5.2",
+    "objc2 0.5.2",
 ]
 
 [[package]]
@@ -408,7 +387,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2 0.6.4",
+    "objc2 0.6.4",
 ]
 
 [[package]]
@@ -417,9 +396,9 @@ version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
+    "alloc-no-stdlib",
+    "alloc-stdlib",
+    "brotli-decompressor",
 ]
 
 [[package]]
@@ -428,8 +407,8 @@ version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
+    "alloc-no-stdlib",
+    "alloc-stdlib",
 ]
 
 [[package]]
@@ -438,9 +417,9 @@ version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
- "memchr",
- "regex-automata",
- "serde",
+    "memchr",
+    "regex-automata",
+    "serde",
 ]
 
 [[package]]
@@ -461,7 +440,7 @@ version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 dependencies = [
- "bytemuck_derive",
+    "bytemuck_derive",
 ]
 
 [[package]]
@@ -470,9 +449,9 @@ version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+    "proc-macro2",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -483,9 +462,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "calloop"
@@ -493,12 +472,12 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.13.0",
- "log",
- "polling",
- "rustix 0.38.44",
- "slab",
- "thiserror 1.0.69",
+    "bitflags 2.13.0",
+    "log",
+    "polling",
+    "rustix 0.38.44",
+    "slab",
+    "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -507,11 +486,11 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
 dependencies = [
- "bitflags 2.13.0",
- "polling",
- "rustix 1.1.4",
- "slab",
- "tracing",
+    "bitflags 2.13.0",
+    "polling",
+    "rustix 1.1.4",
+    "slab",
+    "tracing",
 ]
 
 [[package]]
@@ -520,10 +499,10 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
- "calloop 0.13.0",
- "rustix 0.38.44",
- "wayland-backend",
- "wayland-client",
+    "calloop 0.13.0",
+    "rustix 0.38.44",
+    "wayland-backend",
+    "wayland-client",
 ]
 
 [[package]]
@@ -532,19 +511,19 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
 dependencies = [
- "calloop 0.14.4",
- "rustix 1.1.4",
- "wayland-backend",
- "wayland-client",
+    "calloop 0.14.4",
+    "rustix 1.1.4",
+    "wayland-backend",
+    "wayland-client",
 ]
 
 [[package]]
 name = "camino"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+checksum = "b4ce8d3bd5823c7504d3f579f13e7b2f3da252fcb938c594d5680ee508bf846f"
 dependencies = [
- "serde_core",
+    "serde_core",
 ]
 
 [[package]]
@@ -553,7 +532,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
 dependencies = [
- "serde",
+    "serde",
 ]
 
 [[package]]
@@ -562,12 +541,12 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
+    "camino",
+    "cargo-platform",
+    "semver",
+    "serde",
+    "serde_json",
+    "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -578,14 +557,14 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
- "find-msvc-tools",
- "jobserver",
- "libc",
- "shlex",
+    "find-msvc-tools",
+    "jobserver",
+    "libc",
+    "shlex",
 ]
 
 [[package]]
@@ -606,7 +585,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
 dependencies = [
- "libc",
+    "libc",
 ]
 
 [[package]]
@@ -615,9 +594,9 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "rand_core 0.10.1",
+    "cfg-if",
+    "cpufeatures 0.3.0",
+    "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -626,11 +605,11 @@ version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "wasm-bindgen",
- "windows-link",
+    "iana-time-zone",
+    "js-sys",
+    "num-traits",
+    "wasm-bindgen",
+    "windows-link",
 ]
 
 [[package]]
@@ -639,9 +618,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
 dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
+    "ciborium-io",
+    "ciborium-ll",
+    "serde",
 ]
 
 [[package]]
@@ -656,8 +635,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
- "ciborium-io",
- "half",
+    "ciborium-io",
+    "half",
 ]
 
 [[package]]
@@ -666,8 +645,8 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
- "clap_builder",
- "clap_derive",
+    "clap_builder",
+    "clap_derive",
 ]
 
 [[package]]
@@ -676,10 +655,10 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
+    "anstream",
+    "anstyle",
+    "clap_lex",
+    "strsim",
 ]
 
 [[package]]
@@ -688,7 +667,7 @@ version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
 dependencies = [
- "clap",
+    "clap",
 ]
 
 [[package]]
@@ -697,10 +676,10 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
+    "heck",
+    "proc-macro2",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -715,7 +694,7 @@ version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
- "error-code",
+    "error-code",
 ]
 
 [[package]]
@@ -724,7 +703,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
- "unicode-width",
+    "unicode-width",
 ]
 
 [[package]]
@@ -733,7 +712,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ec7c5eb7a16992b1904d76c517d170ab353b0e0b3d5a0c81a8a0cd1037893cf"
 dependencies = [
- "bytemuck",
+    "bytemuck",
 ]
 
 [[package]]
@@ -754,8 +733,8 @@ version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
- "bytes",
- "memchr",
+    "bytes",
+    "memchr",
 ]
 
 [[package]]
@@ -764,7 +743,7 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
- "crossbeam-utils",
+    "crossbeam-utils",
 ]
 
 [[package]]
@@ -773,8 +752,8 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if",
- "wasm-bindgen",
+    "cfg-if",
+    "wasm-bindgen",
 ]
 
 [[package]]
@@ -783,8 +762,8 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
- "core-foundation-sys",
- "libc",
+    "core-foundation-sys",
+    "libc",
 ]
 
 [[package]]
@@ -793,8 +772,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
- "core-foundation-sys",
- "libc",
+    "core-foundation-sys",
+    "libc",
 ]
 
 [[package]]
@@ -809,11 +788,11 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "core-graphics-types",
- "foreign-types",
- "libc",
+    "bitflags 1.3.2",
+    "core-foundation 0.9.4",
+    "core-graphics-types",
+    "foreign-types",
+    "libc",
 ]
 
 [[package]]
@@ -822,9 +801,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "libc",
+    "bitflags 1.3.2",
+    "core-foundation 0.9.4",
+    "libc",
 ]
 
 [[package]]
@@ -833,7 +812,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
 dependencies = [
- "libm",
+    "libm",
 ]
 
 [[package]]
@@ -842,7 +821,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
- "libc",
+    "libc",
 ]
 
 [[package]]
@@ -851,7 +830,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
- "libc",
+    "libc",
 ]
 
 [[package]]
@@ -860,7 +839,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "cfg-if",
+    "cfg-if",
 ]
 
 [[package]]
@@ -869,23 +848,23 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
- "alloca",
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "itertools 0.13.0",
- "num-traits",
- "oorandom",
- "page_size",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_json",
- "tinytemplate",
- "walkdir",
+    "alloca",
+    "anes",
+    "cast",
+    "ciborium",
+    "clap",
+    "criterion-plot",
+    "itertools 0.13.0",
+    "num-traits",
+    "oorandom",
+    "page_size",
+    "plotters",
+    "rayon",
+    "regex",
+    "serde",
+    "serde_json",
+    "tinytemplate",
+    "walkdir",
 ]
 
 [[package]]
@@ -894,8 +873,8 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
- "cast",
- "itertools 0.13.0",
+    "cast",
+    "itertools 0.13.0",
 ]
 
 [[package]]
@@ -904,8 +883,8 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
+    "crossbeam-epoch",
+    "crossbeam-utils",
 ]
 
 [[package]]
@@ -914,7 +893,7 @@ version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "crossbeam-utils",
+    "crossbeam-utils",
 ]
 
 [[package]]
@@ -935,8 +914,8 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array",
- "typenum",
+    "generic-array",
+    "typenum",
 ]
 
 [[package]]
@@ -945,11 +924,11 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
 dependencies = [
- "cssparser-macros",
- "dtoa-short",
- "itoa",
- "phf 0.13.1",
- "smallvec",
+    "cssparser-macros",
+    "dtoa-short",
+    "itoa",
+    "phf 0.13.1",
+    "smallvec",
 ]
 
 [[package]]
@@ -958,8 +937,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
- "quote",
- "syn",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -974,8 +953,8 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+    "darling_core",
+    "darling_macro",
 ]
 
 [[package]]
@@ -984,12 +963,12 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
+    "fnv",
+    "ident_case",
+    "proc-macro2",
+    "quote",
+    "strsim",
+    "syn",
 ]
 
 [[package]]
@@ -998,9 +977,9 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
- "quote",
- "syn",
+    "darling_core",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -1015,7 +994,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
 dependencies = [
- "derive_builder_macro",
+    "derive_builder_macro",
 ]
 
 [[package]]
@@ -1024,10 +1003,10 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
+    "darling",
+    "proc-macro2",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -1036,8 +1015,8 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
- "derive_builder_core",
- "syn",
+    "derive_builder_core",
+    "syn",
 ]
 
 [[package]]
@@ -1046,7 +1025,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
- "derive_more-impl",
+    "derive_more-impl",
 ]
 
 [[package]]
@@ -1055,10 +1034,10 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn",
+    "proc-macro2",
+    "quote",
+    "rustc_version",
+    "syn",
 ]
 
 [[package]]
@@ -1073,29 +1052,8 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
+    "block-buffer",
+    "crypto-common",
 ]
 
 [[package]]
@@ -1110,8 +1068,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.13.0",
- "objc2 0.6.4",
+    "bitflags 2.13.0",
+    "objc2 0.6.4",
 ]
 
 [[package]]
@@ -1120,9 +1078,9 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+    "proc-macro2",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -1131,7 +1089,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.8.9",
+    "libloading 0.8.9",
 ]
 
 [[package]]
@@ -1140,7 +1098,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
- "litrs",
+    "litrs",
 ]
 
 [[package]]
@@ -1167,29 +1125,28 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
- "dtoa",
+    "dtoa",
 ]
 
 [[package]]
 name = "dugong"
 version = "0.8.0-alpha.2"
 dependencies = [
- "criterion",
- "dugong-graphlib",
- "gag",
- "rustc-hash 2.1.2",
- "serde",
- "serde_json",
+    "criterion",
+    "dugong-graphlib",
+    "rustc-hash 2.1.2",
+    "serde",
+    "serde_json",
 ]
 
 [[package]]
 name = "dugong-graphlib"
 version = "0.8.0-alpha.2"
 dependencies = [
- "hashbrown 0.16.1",
- "rustc-hash 2.1.2",
- "serde",
- "serde_json",
+    "hashbrown 0.16.1",
+    "rustc-hash 2.1.2",
+    "serde",
+    "serde_json",
 ]
 
 [[package]]
@@ -1198,8 +1155,8 @@ version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a05fbfa222ffb51989d5ccf33e5f7aebfcf96c5023413856b0c3618a7f79896e"
 dependencies = [
- "bytemuck",
- "emath",
+    "bytemuck",
+    "emath",
 ]
 
 [[package]]
@@ -1208,33 +1165,33 @@ version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98fe83b2589105b69dd25ca1e0fa2135a6e864d502fd8e08978f937e128cfef"
 dependencies = [
- "ahash",
- "bytemuck",
- "document-features",
- "egui",
- "egui-wgpu",
- "egui-winit",
- "egui_glow",
- "glow",
- "glutin",
- "glutin-winit",
- "image",
- "js-sys",
- "log",
- "objc2 0.6.4",
- "objc2-app-kit 0.3.2",
- "objc2-foundation 0.3.2",
- "parking_lot",
- "percent-encoding",
- "profiling",
- "raw-window-handle",
- "static_assertions",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "web-time",
- "windows-sys 0.61.2",
- "winit",
+    "ahash",
+    "bytemuck",
+    "document-features",
+    "egui",
+    "egui-wgpu",
+    "egui-winit",
+    "egui_glow",
+    "glow",
+    "glutin",
+    "glutin-winit",
+    "image",
+    "js-sys",
+    "log",
+    "objc2 0.6.4",
+    "objc2-app-kit 0.3.2",
+    "objc2-foundation 0.3.2",
+    "parking_lot",
+    "percent-encoding",
+    "profiling",
+    "raw-window-handle",
+    "static_assertions",
+    "wasm-bindgen",
+    "wasm-bindgen-futures",
+    "web-sys",
+    "web-time",
+    "windows-sys 0.61.2",
+    "winit",
 ]
 
 [[package]]
@@ -1243,16 +1200,16 @@ version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42112be0ae157289312b92b3dfaf20e911b5a3c4c65d4aab0e7c47fbc0ce16e3"
 dependencies = [
- "accesskit",
- "ahash",
- "bitflags 2.13.0",
- "emath",
- "epaint",
- "log",
- "nohash-hasher",
- "profiling",
- "smallvec",
- "unicode-segmentation",
+    "accesskit",
+    "ahash",
+    "bitflags 2.13.0",
+    "emath",
+    "epaint",
+    "log",
+    "nohash-hasher",
+    "profiling",
+    "smallvec",
+    "unicode-segmentation",
 ]
 
 [[package]]
@@ -1261,18 +1218,18 @@ version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f0c0559ac5598a1b887a6206dccbab7e3e6246c57cb00ae287262bd44776c9c"
 dependencies = [
- "ahash",
- "bytemuck",
- "document-features",
- "egui",
- "epaint",
- "log",
- "profiling",
- "thiserror 2.0.18",
- "type-map",
- "web-time",
- "wgpu",
- "winit",
+    "ahash",
+    "bytemuck",
+    "document-features",
+    "egui",
+    "epaint",
+    "log",
+    "profiling",
+    "thiserror 2.0.18",
+    "type-map",
+    "web-time",
+    "wgpu",
+    "winit",
 ]
 
 [[package]]
@@ -1281,19 +1238,19 @@ version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "967c5b323625d46d46a59b5daba3fef742248d27693cc18972458619858c4239"
 dependencies = [
- "arboard",
- "bytemuck",
- "egui",
- "log",
- "objc2 0.6.4",
- "objc2-foundation 0.3.2",
- "objc2-ui-kit 0.3.2",
- "profiling",
- "raw-window-handle",
- "smithay-clipboard",
- "web-time",
- "webbrowser",
- "winit",
+    "arboard",
+    "bytemuck",
+    "egui",
+    "log",
+    "objc2 0.6.4",
+    "objc2-foundation 0.3.2",
+    "objc2-ui-kit 0.3.2",
+    "profiling",
+    "raw-window-handle",
+    "smithay-clipboard",
+    "web-time",
+    "webbrowser",
+    "winit",
 ]
 
 [[package]]
@@ -1302,15 +1259,15 @@ version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b652957fa7e1ab01e8fecbfbf4e35f6e43a53fa98af8a562b50d5403cd44b9"
 dependencies = [
- "bytemuck",
- "egui",
- "glow",
- "log",
- "memoffset",
- "profiling",
- "wasm-bindgen",
- "web-sys",
- "winit",
+    "bytemuck",
+    "egui",
+    "glow",
+    "log",
+    "memoffset",
+    "profiling",
+    "wasm-bindgen",
+    "web-sys",
+    "winit",
 ]
 
 [[package]]
@@ -1325,7 +1282,7 @@ version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b53f0d33a479321da6b0caa71366c9f67e8a2c149762d90bdc0d16e601ee8ecb"
 dependencies = [
- "bytemuck",
+    "bytemuck",
 ]
 
 [[package]]
@@ -1334,7 +1291,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
 dependencies = [
- "log",
+    "log",
 ]
 
 [[package]]
@@ -1343,7 +1300,7 @@ version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "cfg-if",
+    "cfg-if",
 ]
 
 [[package]]
@@ -1352,20 +1309,20 @@ version = "0.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6675898a291ec212fc3df04f537d177fce8496120244590e6359dcaa4c25da79"
 dependencies = [
- "ahash",
- "bytemuck",
- "ecolor",
- "emath",
- "epaint_default_fonts",
- "font-types",
- "log",
- "nohash-hasher",
- "parking_lot",
- "profiling",
- "self_cell",
- "skrifa 0.40.0",
- "smallvec",
- "vello_cpu",
+    "ahash",
+    "bytemuck",
+    "ecolor",
+    "emath",
+    "epaint_default_fonts",
+    "font-types",
+    "log",
+    "nohash-hasher",
+    "parking_lot",
+    "profiling",
+    "self_cell",
+    "skrifa 0.40.0",
+    "smallvec",
+    "vello_cpu",
 ]
 
 [[package]]
@@ -1386,8 +1343,8 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
- "libc",
- "windows-sys 0.61.2",
+    "libc",
+    "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1402,7 +1359,7 @@ version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
- "num-traits",
+    "num-traits",
 ]
 
 [[package]]
@@ -1411,9 +1368,9 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
 dependencies = [
- "bit-set 0.8.0",
- "regex-automata",
- "regex-syntax",
+    "bit-set 0.8.0",
+    "regex-automata",
+    "regex-syntax",
 ]
 
 [[package]]
@@ -1440,7 +1397,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
- "simd-adler32",
+    "simd-adler32",
 ]
 
 [[package]]
@@ -1449,18 +1406,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb2907d1f08b2b316b9223ced5b0e89d87028ba8deae9764741dba8ff7f3903"
 dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "filedescriptor"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
-dependencies = [
- "libc",
- "thiserror 1.0.69",
- "winapi",
+    "bytemuck",
 ]
 
 [[package]]
@@ -1471,9 +1417,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1481,8 +1427,8 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
- "crc32fast",
- "miniz_oxide",
+    "crc32fast",
+    "miniz_oxide",
 ]
 
 [[package]]
@@ -1490,12 +1436,21 @@ name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+    "num-traits",
+]
 
 [[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1509,7 +1464,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
 dependencies = [
- "bytemuck",
+    "bytemuck",
 ]
 
 [[package]]
@@ -1518,7 +1473,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
 dependencies = [
- "roxmltree 0.20.0",
+    "roxmltree 0.20.0",
 ]
 
 [[package]]
@@ -1527,12 +1482,12 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
 dependencies = [
- "fontconfig-parser",
- "log",
- "memmap2",
- "slotmap",
- "tinyvec",
- "ttf-parser",
+    "fontconfig-parser",
+    "log",
+    "memmap2",
+    "slotmap",
+    "tinyvec",
+    "ttf-parser",
 ]
 
 [[package]]
@@ -1541,8 +1496,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
- "foreign-types-macros",
- "foreign-types-shared",
+    "foreign-types-macros",
+    "foreign-types-shared",
 ]
 
 [[package]]
@@ -1551,9 +1506,9 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+    "proc-macro2",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -1568,7 +1523,7 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
- "percent-encoding",
+    "percent-encoding",
 ]
 
 [[package]]
@@ -1577,7 +1532,7 @@ version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
- "autocfg",
+    "autocfg",
 ]
 
 [[package]]
@@ -1586,13 +1541,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
+    "futures-channel",
+    "futures-core",
+    "futures-executor",
+    "futures-io",
+    "futures-sink",
+    "futures-task",
+    "futures-util",
 ]
 
 [[package]]
@@ -1601,8 +1556,8 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
- "futures-core",
- "futures-sink",
+    "futures-core",
+    "futures-sink",
 ]
 
 [[package]]
@@ -1617,9 +1572,9 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
+    "futures-core",
+    "futures-task",
+    "futures-util",
 ]
 
 [[package]]
@@ -1634,9 +1589,9 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+    "proc-macro2",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -1657,25 +1612,15 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "gag"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a713bee13966e9fbffdf7193af71d54a6b35a0bb34997cd6c9519ebeb5005972"
-dependencies = [
- "filedescriptor",
- "tempfile",
+    "futures-channel",
+    "futures-core",
+    "futures-io",
+    "futures-macro",
+    "futures-sink",
+    "futures-task",
+    "memchr",
+    "pin-project-lite",
+    "slab",
 ]
 
 [[package]]
@@ -1684,8 +1629,8 @@ version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
- "typenum",
- "version_check",
+    "typenum",
+    "version_check",
 ]
 
 [[package]]
@@ -1694,8 +1639,8 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix 1.1.4",
- "windows-link",
+    "rustix 1.1.4",
+    "windows-link",
 ]
 
 [[package]]
@@ -1704,7 +1649,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width",
+    "unicode-width",
 ]
 
 [[package]]
@@ -1713,11 +1658,11 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "wasi",
- "wasm-bindgen",
+    "cfg-if",
+    "js-sys",
+    "libc",
+    "wasi",
+    "wasm-bindgen",
 ]
 
 [[package]]
@@ -1726,12 +1671,12 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
- "wasm-bindgen",
+    "cfg-if",
+    "js-sys",
+    "libc",
+    "r-efi 5.3.0",
+    "wasip2",
+    "wasm-bindgen",
 ]
 
 [[package]]
@@ -1740,22 +1685,12 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "r-efi 6.0.0",
- "rand_core 0.10.1",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "gif"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
-dependencies = [
- "color_quant",
- "weezl",
+    "cfg-if",
+    "js-sys",
+    "libc",
+    "r-efi 6.0.0",
+    "rand_core 0.10.1",
+    "wasm-bindgen",
 ]
 
 [[package]]
@@ -1764,8 +1699,8 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
- "color_quant",
- "weezl",
+    "color_quant",
+    "weezl",
 ]
 
 [[package]]
@@ -1774,9 +1709,9 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
 dependencies = [
- "khronos_api",
- "log",
- "xml-rs",
+    "khronos_api",
+    "log",
+    "xml-rs",
 ]
 
 [[package]]
@@ -1815,10 +1750,10 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
 dependencies = [
- "js-sys",
- "slotmap",
- "wasm-bindgen",
- "web-sys",
+    "js-sys",
+    "slotmap",
+    "wasm-bindgen",
+    "web-sys",
 ]
 
 [[package]]
@@ -1827,23 +1762,23 @@ version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
 dependencies = [
- "bitflags 2.13.0",
- "cfg_aliases",
- "cgl",
- "dispatch2",
- "glutin_egl_sys",
- "glutin_glx_sys",
- "glutin_wgl_sys",
- "libloading 0.8.9",
- "objc2 0.6.4",
- "objc2-app-kit 0.3.2",
- "objc2-core-foundation",
- "objc2-foundation 0.3.2",
- "once_cell",
- "raw-window-handle",
- "wayland-sys",
- "windows-sys 0.52.0",
- "x11-dl",
+    "bitflags 2.13.0",
+    "cfg_aliases",
+    "cgl",
+    "dispatch2",
+    "glutin_egl_sys",
+    "glutin_glx_sys",
+    "glutin_wgl_sys",
+    "libloading 0.8.9",
+    "objc2 0.6.4",
+    "objc2-app-kit 0.3.2",
+    "objc2-core-foundation",
+    "objc2-foundation 0.3.2",
+    "once_cell",
+    "raw-window-handle",
+    "wayland-sys",
+    "windows-sys 0.52.0",
+    "x11-dl",
 ]
 
 [[package]]
@@ -1852,10 +1787,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f"
 dependencies = [
- "cfg_aliases",
- "glutin",
- "raw-window-handle",
- "winit",
+    "cfg_aliases",
+    "glutin",
+    "raw-window-handle",
+    "winit",
 ]
 
 [[package]]
@@ -1864,8 +1799,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c4680ba6195f424febdc3ba46e7a42a0e58743f2edb115297b86d7f8ecc02d2"
 dependencies = [
- "gl_generator",
- "windows-sys 0.52.0",
+    "gl_generator",
+    "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1874,8 +1809,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7bb2938045a88b612499fbcba375a77198e01306f52272e692f8c1f3751185"
 dependencies = [
- "gl_generator",
- "x11-dl",
+    "gl_generator",
+    "x11-dl",
 ]
 
 [[package]]
@@ -1884,7 +1819,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
 dependencies = [
- "gl_generator",
+    "gl_generator",
 ]
 
 [[package]]
@@ -1893,9 +1828,9 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
 dependencies = [
- "log",
- "plain",
- "scroll",
+    "log",
+    "plain",
+    "scroll",
 ]
 
 [[package]]
@@ -1904,10 +1839,19 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
- "cfg-if",
- "crunchy",
- "num-traits",
- "zerocopy",
+    "cfg-if",
+    "crunchy",
+    "num-traits",
+    "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+    "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1916,9 +1860,9 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
+    "allocator-api2",
+    "equivalent",
+    "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1927,9 +1871,9 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
+    "allocator-api2",
+    "equivalent",
+    "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1956,11 +1900,11 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e815d50d9e411ba2690d730e6ec139c08260dddb756df315dbd16d01a587226"
 dependencies = [
- "memchr",
- "pastey",
- "phf 0.13.1",
- "phf_codegen",
- "serde_json",
+    "memchr",
+    "pastey",
+    "phf 0.13.1",
+    "phf_codegen",
+    "serde_json",
 ]
 
 [[package]]
@@ -1969,8 +1913,8 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
- "bytes",
- "itoa",
+    "bytes",
+    "itoa",
 ]
 
 [[package]]
@@ -1979,8 +1923,8 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
- "bytes",
- "http",
+    "bytes",
+    "http",
 ]
 
 [[package]]
@@ -1989,11 +1933,11 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "pin-project-lite",
+    "bytes",
+    "futures-core",
+    "http",
+    "http-body",
+    "pin-project-lite",
 ]
 
 [[package]]
@@ -2008,18 +1952,18 @@ version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
- "atomic-waker",
- "bytes",
- "futures-channel",
- "futures-core",
- "http",
- "http-body",
- "httparse",
- "itoa",
- "pin-project-lite",
- "smallvec",
- "tokio",
- "want",
+    "atomic-waker",
+    "bytes",
+    "futures-channel",
+    "futures-core",
+    "http",
+    "http-body",
+    "httparse",
+    "itoa",
+    "pin-project-lite",
+    "smallvec",
+    "tokio",
+    "want",
 ]
 
 [[package]]
@@ -2028,14 +1972,14 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "tokio",
- "tokio-rustls",
- "tower-service",
- "webpki-roots",
+    "http",
+    "hyper",
+    "hyper-util",
+    "rustls",
+    "tokio",
+    "tokio-rustls",
+    "tower-service",
+    "webpki-roots",
 ]
 
 [[package]]
@@ -2044,21 +1988,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "ipnet",
- "libc",
- "percent-encoding",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
+    "base64",
+    "bytes",
+    "futures-channel",
+    "futures-util",
+    "http",
+    "http-body",
+    "hyper",
+    "ipnet",
+    "libc",
+    "percent-encoding",
+    "pin-project-lite",
+    "socket2",
+    "tokio",
+    "tower-service",
+    "tracing",
 ]
 
 [[package]]
@@ -2067,13 +2011,13 @@ version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
+    "android_system_properties",
+    "core-foundation-sys",
+    "iana-time-zone-haiku",
+    "js-sys",
+    "log",
+    "wasm-bindgen",
+    "windows-core",
 ]
 
 [[package]]
@@ -2082,7 +2026,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cc",
+    "cc",
 ]
 
 [[package]]
@@ -2091,12 +2035,12 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
- "displaydoc",
- "potential_utf",
- "utf8_iter",
- "yoke",
- "zerofrom",
- "zerovec",
+    "displaydoc",
+    "potential_utf",
+    "utf8_iter",
+    "yoke",
+    "zerofrom",
+    "zerovec",
 ]
 
 [[package]]
@@ -2105,11 +2049,11 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
+    "displaydoc",
+    "litemap",
+    "tinystr",
+    "writeable",
+    "zerovec",
 ]
 
 [[package]]
@@ -2118,12 +2062,12 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
+    "icu_collections",
+    "icu_normalizer_data",
+    "icu_properties",
+    "icu_provider",
+    "smallvec",
+    "zerovec",
 ]
 
 [[package]]
@@ -2138,12 +2082,12 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
+    "icu_collections",
+    "icu_locale_core",
+    "icu_properties_data",
+    "icu_provider",
+    "zerotrie",
+    "zerovec",
 ]
 
 [[package]]
@@ -2158,13 +2102,13 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
+    "displaydoc",
+    "icu_locale_core",
+    "writeable",
+    "yoke",
+    "zerofrom",
+    "zerotrie",
+    "zerovec",
 ]
 
 [[package]]
@@ -2179,9 +2123,9 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
+    "idna_adapter",
+    "smallvec",
+    "utf8_iter",
 ]
 
 [[package]]
@@ -2190,8 +2134,8 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
- "icu_normalizer",
- "icu_properties",
+    "icu_normalizer",
+    "icu_properties",
 ]
 
 [[package]]
@@ -2200,16 +2144,14 @@ version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
- "bytemuck",
- "byteorder-lite",
- "color_quant",
- "gif 0.14.2",
- "moxcms",
- "num-traits",
- "png 0.18.1",
- "tiff",
- "zune-core 0.5.1",
- "zune-jpeg 0.5.15",
+    "bytemuck",
+    "byteorder-lite",
+    "moxcms",
+    "num-traits",
+    "png",
+    "tiff",
+    "zune-core",
+    "zune-jpeg",
 ]
 
 [[package]]
@@ -2218,15 +2160,9 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
- "byteorder-lite",
- "quick-error",
+    "byteorder-lite",
+    "quick-error",
 ]
-
-[[package]]
-name = "imagesize"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
 name = "imagesize"
@@ -2240,10 +2176,10 @@ version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
- "equivalent",
- "hashbrown 0.17.1",
- "serde",
- "serde_core",
+    "equivalent",
+    "hashbrown 0.17.1",
+    "serde",
+    "serde_core",
 ]
 
 [[package]]
@@ -2260,20 +2196,20 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
- "either",
+    "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+    "either",
 ]
 
 [[package]]
@@ -2288,15 +2224,15 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cfg-if",
- "combine",
- "jni-macros",
- "jni-sys 0.4.1",
- "log",
- "simd_cesu8",
- "thiserror 2.0.18",
- "walkdir",
- "windows-link",
+    "cfg-if",
+    "combine",
+    "jni-macros",
+    "jni-sys 0.4.1",
+    "log",
+    "simd_cesu8",
+    "thiserror 2.0.18",
+    "walkdir",
+    "windows-link",
 ]
 
 [[package]]
@@ -2305,11 +2241,11 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn",
+    "proc-macro2",
+    "quote",
+    "rustc_version",
+    "simd_cesu8",
+    "syn",
 ]
 
 [[package]]
@@ -2318,7 +2254,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
 dependencies = [
- "jni-sys 0.4.1",
+    "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -2327,7 +2263,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
 dependencies = [
- "jni-sys-macros",
+    "jni-sys-macros",
 ]
 
 [[package]]
@@ -2336,8 +2272,8 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
- "quote",
- "syn",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -2346,8 +2282,8 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.3.4",
- "libc",
+    "getrandom 0.3.4",
+    "libc",
 ]
 
 [[package]]
@@ -2356,9 +2292,9 @@ version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
- "cfg-if",
- "futures-util",
- "wasm-bindgen",
+    "cfg-if",
+    "futures-util",
+    "wasm-bindgen",
 ]
 
 [[package]]
@@ -2367,9 +2303,18 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
 dependencies = [
- "pest",
- "pest_derive",
- "serde",
+    "pest",
+    "pest_derive",
+    "serde",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+    "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -2379,14 +2324,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
-name = "kurbo"
-version = "0.11.3"
+name = "krilla"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+checksum = "27da593198b20eeba65caeb73c2bbeec3e53ab08fa549898312ce81c4fce5e33"
 dependencies = [
- "arrayvec",
- "euclid",
- "smallvec",
+    "base64",
+    "bumpalo",
+    "flate2",
+    "float-cmp",
+    "gif",
+    "image-webp",
+    "imagesize",
+    "indexmap",
+    "pdf-writer",
+    "png",
+    "rustc-hash 2.1.2",
+    "rustybuzz",
+    "siphasher",
+    "skrifa 0.42.1",
+    "smallvec",
+    "subsetter",
+    "tiny-skia-path",
+    "xmp-writer",
+    "yoke",
+    "zune-jpeg",
+]
+
+[[package]]
+name = "krilla-svg"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1237d7c37b16ca9fbc2e72dde13a10d321f9a44aceee35c062bc0a43bfc7ce16"
+dependencies = [
+    "flate2",
+    "fontdb",
+    "krilla",
+    "resvg",
+    "skrifa 0.42.1",
+    "smallvec",
+    "tiny-skia",
+    "usvg",
 ]
 
 [[package]]
@@ -2395,48 +2373,42 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
 dependencies = [
- "arrayvec",
- "euclid",
- "polycool",
- "smallvec",
+    "arrayvec",
+    "euclid",
+    "polycool",
+    "smallvec",
 ]
 
 [[package]]
 name = "lalrpop"
-version = "0.20.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+checksum = "98a80a963123205c7157323c99611bc4abb65dcbd62ef46dc4bac74a3941bc75"
 dependencies = [
- "ascii-canvas",
- "bit-set 0.5.3",
- "ena",
- "itertools 0.11.0",
- "lalrpop-util",
- "petgraph",
- "pico-args",
- "regex",
- "regex-syntax",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
- "walkdir",
+    "ascii-canvas",
+    "bit-set 0.9.1",
+    "ena",
+    "itertools 0.14.0",
+    "lalrpop-util",
+    "petgraph",
+    "pico-args",
+    "regex",
+    "regex-syntax",
+    "sha3",
+    "string_cache",
+    "term",
+    "unicode-xid",
+    "walkdir",
 ]
 
 [[package]]
 name = "lalrpop-util"
-version = "0.20.2"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+checksum = "884f3e747ed2dcee867cda1b0c31a048f9e20de2d916a248949319921a2e666e"
 dependencies = [
- "regex-automata",
+    "regex-automata",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -2450,8 +2422,8 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "cfg-if",
- "windows-link",
+    "cfg-if",
+    "windows-link",
 ]
 
 [[package]]
@@ -2460,8 +2432,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
- "cfg-if",
- "windows-link",
+    "cfg-if",
+    "windows-link",
 ]
 
 [[package]]
@@ -2476,10 +2448,10 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.13.0",
- "libc",
- "plain",
- "redox_syscall 0.8.1",
+    "bitflags 2.13.0",
+    "libc",
+    "plain",
+    "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -2518,47 +2490,14 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "scopeguard",
+    "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
-
-[[package]]
-name = "logos"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7251356ef8cb7aec833ddf598c6cb24d17b689d20b993f9d11a3d764e34e6458"
-dependencies = [
- "logos-derive",
-]
-
-[[package]]
-name = "logos-codegen"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f80069600c0d66734f5ff52cc42f2dabd6b29d205f333d61fd7832e9e9963f"
-dependencies = [
- "beef",
- "fnv",
- "lazy_static",
- "proc-macro2",
- "quote",
- "regex-syntax",
- "syn",
-]
-
-[[package]]
-name = "logos-derive"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fb722b06a9dc12adb0963ed585f19fc61dc5413e6a9be9422ef92c091e731d"
-dependencies = [
- "logos-codegen",
-]
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lol_html"
@@ -2566,17 +2505,17 @@ version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00aad58f6ec3990e795943872f13651e7a5fa59dca2c8f31a74faf8a0e0fb652"
 dependencies = [
- "bitflags 2.13.0",
- "cfg-if",
- "cssparser",
- "encoding_rs",
- "foldhash",
- "hashbrown 0.17.1",
- "memchr",
- "mime",
- "precomputed-hash",
- "selectors",
- "thiserror 2.0.18",
+    "bitflags 2.13.0",
+    "cfg-if",
+    "cssparser",
+    "encoding_rs",
+    "foldhash 0.2.0",
+    "hashbrown 0.17.1",
+    "memchr",
+    "mime",
+    "precomputed-hash",
+    "selectors",
+    "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2589,10 +2528,10 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 name = "manatee"
 version = "0.8.0-alpha.2"
 dependencies = [
- "indexmap",
- "nalgebra",
- "rustc-hash 2.1.2",
- "thiserror 2.0.18",
+    "indexmap",
+    "nalgebra",
+    "rustc-hash 2.1.2",
+    "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2601,8 +2540,8 @@ version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
- "autocfg",
- "rawpointer",
+    "autocfg",
+    "rawpointer",
 ]
 
 [[package]]
@@ -2617,7 +2556,7 @@ version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
- "libc",
+    "libc",
 ]
 
 [[package]]
@@ -2626,192 +2565,191 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
- "autocfg",
+    "autocfg",
 ]
 
 [[package]]
 name = "merman"
 version = "0.8.0-alpha.2"
 dependencies = [
- "base64",
- "chrono",
- "criterion",
- "eframe",
- "image",
- "merman-ascii",
- "merman-core",
- "merman-render",
- "png 0.17.16",
- "resvg 0.46.0",
- "roxmltree 0.20.0",
- "serde_json",
- "svg2pdf",
- "thiserror 2.0.18",
- "tiny-skia",
- "usvg 0.46.0",
+    "base64",
+    "chrono",
+    "criterion",
+    "eframe",
+    "image",
+    "krilla",
+    "krilla-svg",
+    "merman-ascii",
+    "merman-core",
+    "merman-render",
+    "png",
+    "resvg",
+    "roxmltree 0.20.0",
+    "serde_json",
+    "thiserror 2.0.18",
+    "tiny-skia",
+    "usvg",
 ]
 
 [[package]]
 name = "merman-ascii"
 version = "0.8.0-alpha.2"
 dependencies = [
- "merman-core",
- "thiserror 2.0.18",
- "unicode-width",
+    "merman-core",
+    "thiserror 2.0.18",
+    "unicode-width",
 ]
 
 [[package]]
 name = "merman-bindings-core"
 version = "0.8.0-alpha.2"
 dependencies = [
- "chrono",
- "merman",
- "merman-render",
- "serde",
- "serde_json",
+    "chrono",
+    "merman",
+    "merman-render",
+    "serde",
+    "serde_json",
 ]
 
 [[package]]
 name = "merman-cli"
 version = "0.8.0-alpha.2"
 dependencies = [
- "assert_cmd",
- "chrono",
- "clap",
- "clap_complete",
- "merman",
- "png 0.17.16",
- "rayon",
- "regex",
- "reqwest",
- "serde",
- "serde_json",
- "tempfile",
+    "assert_cmd",
+    "chrono",
+    "clap",
+    "clap_complete",
+    "merman",
+    "png",
+    "rayon",
+    "regex",
+    "reqwest",
+    "serde",
+    "serde_json",
+    "tempfile",
 ]
 
 [[package]]
 name = "merman-core"
 version = "0.8.0-alpha.2"
 dependencies = [
- "chrono",
- "euclid",
- "futures",
- "htmlize",
- "indexmap",
- "json5",
- "lalrpop",
- "lalrpop-util",
- "logos",
- "lol_html",
- "regex",
- "rustc-hash 2.1.2",
- "ryu-js",
- "serde",
- "serde_json",
- "serde_yaml",
- "thiserror 2.0.18",
- "tracing",
- "url",
- "uuid",
- "web-time",
+    "chrono",
+    "euclid",
+    "futures",
+    "htmlize",
+    "indexmap",
+    "json5",
+    "lalrpop",
+    "lalrpop-util",
+    "lol_html",
+    "regex",
+    "rustc-hash 2.1.2",
+    "ryu-js",
+    "serde",
+    "serde_json",
+    "serde_yaml",
+    "thiserror 2.0.18",
+    "url",
+    "uuid",
+    "web-time",
 ]
 
 [[package]]
 name = "merman-elk-layered"
 version = "0.8.0-alpha.2"
 dependencies = [
- "thiserror 2.0.18",
+    "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "merman-ffi"
 version = "0.8.0-alpha.2"
 dependencies = [
- "cc",
- "jni",
- "libloading 0.9.0",
- "merman-bindings-core",
- "serde_json",
+    "cc",
+    "jni",
+    "libloading 0.9.0",
+    "merman-bindings-core",
+    "serde_json",
 ]
 
 [[package]]
 name = "merman-layout-elk"
 version = "0.8.0-alpha.2"
 dependencies = [
- "merman-elk-layered",
- "thiserror 2.0.18",
+    "merman-elk-layered",
+    "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "merman-render"
 version = "0.8.0-alpha.2"
 dependencies = [
- "base64",
- "chrono",
- "dugong",
- "futures",
- "indexmap",
- "manatee",
- "merman-core",
- "merman-layout-elk",
- "pulldown-cmark",
- "ratex-layout",
- "ratex-parser",
- "ratex-svg",
- "ratex-types",
- "regex",
- "roughr-merman",
- "rustc-hash 2.1.2",
- "ryu-js",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "unicode-width",
+    "base64",
+    "chrono",
+    "dugong",
+    "futures",
+    "indexmap",
+    "manatee",
+    "merman-core",
+    "merman-layout-elk",
+    "pulldown-cmark",
+    "ratex-layout",
+    "ratex-parser",
+    "ratex-svg",
+    "ratex-types",
+    "regex",
+    "roughr-merman",
+    "rustc-hash 2.1.2",
+    "ryu-js",
+    "serde",
+    "serde_json",
+    "thiserror 2.0.18",
+    "unicode-width",
 ]
 
 [[package]]
 name = "merman-rustdoc"
 version = "0.8.0-alpha.2"
 dependencies = [
- "merman",
- "proc-macro2",
- "quote",
- "roxmltree 0.20.0",
- "serde_json",
- "syn",
+    "merman",
+    "proc-macro2",
+    "quote",
+    "roxmltree 0.20.0",
+    "serde_json",
+    "syn",
 ]
 
 [[package]]
 name = "merman-typst-plugin"
 version = "0.8.0-alpha.2"
 dependencies = [
- "merman-bindings-core",
- "serde_json",
- "wasm-minimal-protocol",
+    "merman-bindings-core",
+    "serde_json",
+    "wasm-minimal-protocol",
 ]
 
 [[package]]
 name = "merman-uniffi"
 version = "0.8.0-alpha.2"
 dependencies = [
- "merman-bindings-core",
- "serde_json",
- "tempfile",
- "thiserror 2.0.18",
- "uniffi",
+    "merman-bindings-core",
+    "serde_json",
+    "tempfile",
+    "thiserror 2.0.18",
+    "uniffi",
 ]
 
 [[package]]
 name = "merman-wasm"
 version = "0.8.0-alpha.2"
 dependencies = [
- "console_error_panic_hook",
- "js-sys",
- "merman-bindings-core",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
- "wasm-bindgen",
+    "console_error_panic_hook",
+    "js-sys",
+    "merman-bindings-core",
+    "serde",
+    "serde-wasm-bindgen",
+    "serde_json",
+    "wasm-bindgen",
 ]
 
 [[package]]
@@ -2832,8 +2770,8 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
- "adler2",
- "simd-adler32",
+    "adler2",
+    "simd-adler32",
 ]
 
 [[package]]
@@ -2842,9 +2780,9 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.61.2",
+    "libc",
+    "wasi",
+    "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2853,8 +2791,8 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
- "num-traits",
- "pxfm",
+    "num-traits",
+    "pxfm",
 ]
 
 [[package]]
@@ -2863,23 +2801,23 @@ version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
 dependencies = [
- "arrayvec",
- "bit-set 0.9.1",
- "bitflags 2.13.0",
- "cfg-if",
- "cfg_aliases",
- "codespan-reporting",
- "half",
- "hashbrown 0.16.1",
- "hexf-parse",
- "indexmap",
- "libm",
- "log",
- "num-traits",
- "once_cell",
- "rustc-hash 1.1.0",
- "thiserror 2.0.18",
- "unicode-ident",
+    "arrayvec",
+    "bit-set 0.9.1",
+    "bitflags 2.13.0",
+    "cfg-if",
+    "cfg_aliases",
+    "codespan-reporting",
+    "half",
+    "hashbrown 0.16.1",
+    "hexf-parse",
+    "indexmap",
+    "libm",
+    "log",
+    "num-traits",
+    "once_cell",
+    "rustc-hash 1.1.0",
+    "thiserror 2.0.18",
+    "unicode-ident",
 ]
 
 [[package]]
@@ -2888,17 +2826,17 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc43a60c217b0c6ff46e47f26911015ad8d2e5a8be1af668c67e370d99a4346"
 dependencies = [
- "approx",
- "glam 0.30.10",
- "glam 0.31.1",
- "glam 0.32.1",
- "glam 0.33.1",
- "matrixmultiply",
- "num-complex",
- "num-rational",
- "num-traits",
- "simba",
- "typenum",
+    "approx",
+    "glam 0.30.10",
+    "glam 0.31.1",
+    "glam 0.32.1",
+    "glam 0.33.1",
+    "matrixmultiply",
+    "num-complex",
+    "num-rational",
+    "num-traits",
+    "simba",
+    "typenum",
 ]
 
 [[package]]
@@ -2907,13 +2845,13 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.13.0",
- "jni-sys 0.3.1",
- "log",
- "ndk-sys",
- "num_enum",
- "raw-window-handle",
- "thiserror 1.0.69",
+    "bitflags 2.13.0",
+    "jni-sys 0.3.1",
+    "log",
+    "ndk-sys",
+    "num_enum",
+    "raw-window-handle",
+    "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2928,7 +2866,7 @@ version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
- "jni-sys 0.3.1",
+    "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -2949,8 +2887,8 @@ version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
- "memchr",
- "minimal-lexical",
+    "memchr",
+    "minimal-lexical",
 ]
 
 [[package]]
@@ -2959,8 +2897,8 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
- "num-integer",
- "num-traits",
+    "num-integer",
+    "num-traits",
 ]
 
 [[package]]
@@ -2969,7 +2907,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
- "num-traits",
+    "num-traits",
 ]
 
 [[package]]
@@ -2978,7 +2916,7 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "num-traits",
+    "num-traits",
 ]
 
 [[package]]
@@ -2987,9 +2925,9 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
+    "num-bigint",
+    "num-integer",
+    "num-traits",
 ]
 
 [[package]]
@@ -2998,8 +2936,8 @@ version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
- "autocfg",
- "libm",
+    "autocfg",
+    "libm",
 ]
 
 [[package]]
@@ -3008,8 +2946,8 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
- "num_enum_derive",
- "rustversion",
+    "num_enum_derive",
+    "rustversion",
 ]
 
 [[package]]
@@ -3018,10 +2956,10 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
+    "proc-macro-crate",
+    "proc-macro2",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -3036,8 +2974,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
 dependencies = [
- "objc-sys",
- "objc2-encode",
+    "objc-sys",
+    "objc2-encode",
 ]
 
 [[package]]
@@ -3046,7 +2984,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
- "objc2-encode",
+    "objc2-encode",
 ]
 
 [[package]]
@@ -3055,14 +2993,14 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.13.0",
- "block2 0.5.1",
- "libc",
- "objc2 0.5.2",
- "objc2-core-data",
- "objc2-core-image",
- "objc2-foundation 0.2.2",
- "objc2-quartz-core",
+    "bitflags 2.13.0",
+    "block2 0.5.1",
+    "libc",
+    "objc2 0.5.2",
+    "objc2-core-data",
+    "objc2-core-image",
+    "objc2-foundation 0.2.2",
+    "objc2-quartz-core",
 ]
 
 [[package]]
@@ -3071,11 +3009,11 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.13.0",
- "objc2 0.6.4",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-foundation 0.3.2",
+    "bitflags 2.13.0",
+    "objc2 0.6.4",
+    "objc2-core-foundation",
+    "objc2-core-graphics",
+    "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3084,11 +3022,11 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.13.0",
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-core-location",
- "objc2-foundation 0.2.2",
+    "bitflags 2.13.0",
+    "block2 0.5.1",
+    "objc2 0.5.2",
+    "objc2-core-location",
+    "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3097,9 +3035,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
+    "block2 0.5.1",
+    "objc2 0.5.2",
+    "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3108,10 +3046,10 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.13.0",
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
+    "bitflags 2.13.0",
+    "block2 0.5.1",
+    "objc2 0.5.2",
+    "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3120,9 +3058,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.13.0",
- "dispatch2",
- "objc2 0.6.4",
+    "bitflags 2.13.0",
+    "dispatch2",
+    "objc2 0.6.4",
 ]
 
 [[package]]
@@ -3131,11 +3069,11 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.13.0",
- "dispatch2",
- "objc2 0.6.4",
- "objc2-core-foundation",
- "objc2-io-surface",
+    "bitflags 2.13.0",
+    "dispatch2",
+    "objc2 0.6.4",
+    "objc2-core-foundation",
+    "objc2-io-surface",
 ]
 
 [[package]]
@@ -3144,10 +3082,10 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
- "objc2-metal",
+    "block2 0.5.1",
+    "objc2 0.5.2",
+    "objc2-foundation 0.2.2",
+    "objc2-metal",
 ]
 
 [[package]]
@@ -3156,10 +3094,10 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-contacts",
- "objc2-foundation 0.2.2",
+    "block2 0.5.1",
+    "objc2 0.5.2",
+    "objc2-contacts",
+    "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3174,11 +3112,11 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.13.0",
- "block2 0.5.1",
- "dispatch",
- "libc",
- "objc2 0.5.2",
+    "bitflags 2.13.0",
+    "block2 0.5.1",
+    "dispatch",
+    "libc",
+    "objc2 0.5.2",
 ]
 
 [[package]]
@@ -3187,10 +3125,10 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.13.0",
- "block2 0.6.2",
- "objc2 0.6.4",
- "objc2-core-foundation",
+    "bitflags 2.13.0",
+    "block2 0.6.2",
+    "objc2 0.6.4",
+    "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3199,9 +3137,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.13.0",
- "objc2 0.6.4",
- "objc2-core-foundation",
+    "bitflags 2.13.0",
+    "objc2 0.6.4",
+    "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3210,10 +3148,10 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-app-kit 0.2.2",
- "objc2-foundation 0.2.2",
+    "block2 0.5.1",
+    "objc2 0.5.2",
+    "objc2-app-kit 0.2.2",
+    "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3222,10 +3160,10 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.13.0",
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
+    "bitflags 2.13.0",
+    "block2 0.5.1",
+    "objc2 0.5.2",
+    "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3234,11 +3172,11 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.13.0",
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
- "objc2-metal",
+    "bitflags 2.13.0",
+    "block2 0.5.1",
+    "objc2 0.5.2",
+    "objc2-foundation 0.2.2",
+    "objc2-metal",
 ]
 
 [[package]]
@@ -3247,8 +3185,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
 dependencies = [
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
+    "objc2 0.5.2",
+    "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3257,19 +3195,19 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.13.0",
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-cloud-kit",
- "objc2-core-data",
- "objc2-core-image",
- "objc2-core-location",
- "objc2-foundation 0.2.2",
- "objc2-link-presentation",
- "objc2-quartz-core",
- "objc2-symbols",
- "objc2-uniform-type-identifiers",
- "objc2-user-notifications",
+    "bitflags 2.13.0",
+    "block2 0.5.1",
+    "objc2 0.5.2",
+    "objc2-cloud-kit",
+    "objc2-core-data",
+    "objc2-core-image",
+    "objc2-core-location",
+    "objc2-foundation 0.2.2",
+    "objc2-link-presentation",
+    "objc2-quartz-core",
+    "objc2-symbols",
+    "objc2-uniform-type-identifiers",
+    "objc2-user-notifications",
 ]
 
 [[package]]
@@ -3278,10 +3216,10 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.13.0",
- "objc2 0.6.4",
- "objc2-core-foundation",
- "objc2-foundation 0.3.2",
+    "bitflags 2.13.0",
+    "objc2 0.6.4",
+    "objc2-core-foundation",
+    "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3290,9 +3228,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
+    "block2 0.5.1",
+    "objc2 0.5.2",
+    "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3301,11 +3239,11 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.13.0",
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-core-location",
- "objc2-foundation 0.2.2",
+    "bitflags 2.13.0",
+    "block2 0.5.1",
+    "objc2 0.5.2",
+    "objc2-core-location",
+    "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3332,8 +3270,8 @@ version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747"
 dependencies = [
- "libc",
- "libredox",
+    "libc",
+    "libredox",
 ]
 
 [[package]]
@@ -3342,7 +3280,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
- "ttf-parser",
+    "ttf-parser",
 ]
 
 [[package]]
@@ -3351,8 +3289,8 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
- "libc",
- "winapi",
+    "libc",
+    "winapi",
 ]
 
 [[package]]
@@ -3361,9 +3299,9 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
 dependencies = [
- "approx",
- "fast-srgb8",
- "palette_derive",
+    "approx",
+    "fast-srgb8",
+    "palette_derive",
 ]
 
 [[package]]
@@ -3372,10 +3310,10 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
 dependencies = [
- "by_address",
- "proc-macro2",
- "quote",
- "syn",
+    "by_address",
+    "proc-macro2",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -3384,8 +3322,8 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
- "lock_api",
- "parking_lot_core",
+    "lock_api",
+    "parking_lot_core",
 ]
 
 [[package]]
@@ -3394,11 +3332,11 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall 0.5.18",
- "smallvec",
- "windows-link",
+    "cfg-if",
+    "libc",
+    "redox_syscall 0.5.18",
+    "smallvec",
+    "windows-link",
 ]
 
 [[package]]
@@ -3409,14 +3347,14 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pdf-writer"
-version = "0.12.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5df03c7d216de06f93f398ef06f1385a60f2c597bb96f8195c8d98e08a26b1d5"
+checksum = "f5e456864a7a304047bff84977dc6fb162bd956475d40ba50b2dcecaada7f753"
 dependencies = [
- "bitflags 2.13.0",
- "itoa",
- "memchr",
- "ryu",
+    "bitflags 2.13.0",
+    "itoa",
+    "memchr",
+    "ryu",
 ]
 
 [[package]]
@@ -3425,11 +3363,11 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "839c8299360d2e998bdb106dc0a6cd71dcc5f4df51df1b620361bf50e283cca6"
 dependencies = [
- "bytemuck",
- "color",
- "kurbo 0.13.1",
- "linebender_resource_handle",
- "smallvec",
+    "bytemuck",
+    "color",
+    "kurbo",
+    "linebender_resource_handle",
+    "smallvec",
 ]
 
 [[package]]
@@ -3444,8 +3382,8 @@ version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
- "memchr",
- "ucd-trie",
+    "memchr",
+    "ucd-trie",
 ]
 
 [[package]]
@@ -3454,8 +3392,8 @@ version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
 dependencies = [
- "pest",
- "pest_generator",
+    "pest",
+    "pest_generator",
 ]
 
 [[package]]
@@ -3464,11 +3402,11 @@ version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
 dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn",
+    "pest",
+    "pest_meta",
+    "proc-macro2",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -3477,18 +3415,19 @@ version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
- "pest",
- "sha2",
+    "pest",
+    "sha2",
 ]
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
- "fixedbitset",
- "indexmap",
+    "fixedbitset",
+    "hashbrown 0.15.5",
+    "indexmap",
 ]
 
 [[package]]
@@ -3497,8 +3436,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
+    "phf_macros 0.11.3",
+    "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -3507,9 +3446,9 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros 0.13.1",
- "phf_shared 0.13.1",
- "serde",
+    "phf_macros 0.13.1",
+    "phf_shared 0.13.1",
+    "serde",
 ]
 
 [[package]]
@@ -3518,8 +3457,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+    "phf_generator 0.13.1",
+    "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -3528,8 +3467,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.6",
+    "phf_shared 0.11.3",
+    "rand 0.8.6",
 ]
 
 [[package]]
@@ -3538,8 +3477,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
- "fastrand",
- "phf_shared 0.13.1",
+    "fastrand",
+    "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -3548,11 +3487,11 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn",
+    "phf_generator 0.11.3",
+    "phf_shared 0.11.3",
+    "proc-macro2",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -3561,11 +3500,11 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
- "proc-macro2",
- "quote",
- "syn",
+    "phf_generator 0.13.1",
+    "phf_shared 0.13.1",
+    "proc-macro2",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -3574,7 +3513,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher",
+    "siphasher",
 ]
 
 [[package]]
@@ -3583,7 +3522,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
- "siphasher",
+    "siphasher",
 ]
 
 [[package]]
@@ -3598,7 +3537,7 @@ version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
- "pin-project-internal",
+    "pin-project-internal",
 ]
 
 [[package]]
@@ -3607,9 +3546,9 @@ version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+    "proc-macro2",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -3636,11 +3575,11 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
+    "num-traits",
+    "plotters-backend",
+    "plotters-svg",
+    "wasm-bindgen",
+    "web-sys",
 ]
 
 [[package]]
@@ -3655,20 +3594,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
- "plotters-backend",
-]
-
-[[package]]
-name = "png"
-version = "0.17.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
+    "plotters-backend",
 ]
 
 [[package]]
@@ -3677,11 +3603,11 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.13.0",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
+    "bitflags 2.13.0",
+    "crc32fast",
+    "fdeflate",
+    "flate2",
+    "miniz_oxide",
 ]
 
 [[package]]
@@ -3690,12 +3616,12 @@ version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
+    "cfg-if",
+    "concurrent-queue",
+    "hermit-abi",
+    "pin-project-lite",
+    "rustix 1.1.4",
+    "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3704,7 +3630,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
 dependencies = [
- "arrayvec",
+    "arrayvec",
 ]
 
 [[package]]
@@ -3719,7 +3645,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
- "portable-atomic",
+    "portable-atomic",
 ]
 
 [[package]]
@@ -3728,7 +3654,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
- "zerovec",
+    "zerovec",
 ]
 
 [[package]]
@@ -3737,7 +3663,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+    "zerocopy",
 ]
 
 [[package]]
@@ -3752,9 +3678,9 @@ version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
 dependencies = [
- "anstyle",
- "difflib",
- "predicates-core",
+    "anstyle",
+    "difflib",
+    "predicates-core",
 ]
 
 [[package]]
@@ -3769,8 +3695,8 @@ version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
- "predicates-core",
- "termtree",
+    "predicates-core",
+    "termtree",
 ]
 
 [[package]]
@@ -3779,7 +3705,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+    "toml_edit",
 ]
 
 [[package]]
@@ -3788,7 +3714,7 @@ version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
- "unicode-ident",
+    "unicode-ident",
 ]
 
 [[package]]
@@ -3799,15 +3725,15 @@ checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.12.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.13.0",
- "getopts",
- "memchr",
- "pulldown-cmark-escape",
- "unicase",
+    "bitflags 2.13.0",
+    "getopts",
+    "memchr",
+    "pulldown-cmark-escape",
+    "unicase",
 ]
 
 [[package]]
@@ -3834,27 +3760,27 @@ version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
- "memchr",
+    "memchr",
 ]
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash 2.1.2",
- "rustls",
- "socket2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
+    "bytes",
+    "cfg_aliases",
+    "pin-project-lite",
+    "quinn-proto",
+    "quinn-udp",
+    "rustc-hash 2.1.2",
+    "rustls",
+    "socket2",
+    "thiserror 2.0.18",
+    "tokio",
+    "tracing",
+    "web-time",
 ]
 
 [[package]]
@@ -3863,19 +3789,19 @@ version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand 0.9.4",
- "ring",
- "rustc-hash 2.1.2",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
+    "bytes",
+    "getrandom 0.3.4",
+    "lru-slab",
+    "rand 0.9.4",
+    "ring",
+    "rustc-hash 2.1.2",
+    "rustls",
+    "rustls-pki-types",
+    "slab",
+    "thiserror 2.0.18",
+    "tinyvec",
+    "tracing",
+    "web-time",
 ]
 
 [[package]]
@@ -3884,21 +3810,21 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.60.2",
+    "cfg_aliases",
+    "libc",
+    "once_cell",
+    "socket2",
+    "tracing",
+    "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
- "proc-macro2",
+    "proc-macro2",
 ]
 
 [[package]]
@@ -3919,7 +3845,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "rand_core 0.6.4",
+    "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3928,8 +3854,8 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core 0.9.5",
+    "rand_chacha",
+    "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3938,9 +3864,9 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20",
- "getrandom 0.4.3",
- "rand_core 0.10.1",
+    "chacha20",
+    "getrandom 0.4.3",
+    "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3949,8 +3875,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
+    "ppv-lite86",
+    "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3965,7 +3891,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.3.4",
+    "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3980,8 +3906,8 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "076f9ca8409eed1b0d9de1c666cf231665e0b6d1691b8c28e27c2bdd55f4c8b1"
 dependencies = [
- "phf 0.11.3",
- "ratex-types",
+    "phf 0.11.3",
+    "ratex-types",
 ]
 
 [[package]]
@@ -3990,11 +3916,11 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "333f58d51a30e9a5dedc503bffb1e1592e80a7e754dd6b7024ad7b26766f73b8"
 dependencies = [
- "ab_glyph",
- "ratex-font",
- "ratex-katex-fonts",
- "ratex-types",
- "ratex-unicode-font",
+    "ab_glyph",
+    "ratex-font",
+    "ratex-katex-fonts",
+    "ratex-types",
+    "ratex-unicode-font",
 ]
 
 [[package]]
@@ -4003,7 +3929,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b451364ad69b55587baa549522244aaeabb0dc26d84f12a37987e9f1c59342b"
 dependencies = [
- "rust-embed",
+    "rust-embed",
 ]
 
 [[package]]
@@ -4012,10 +3938,10 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4253612c4cd7f28e40fcd4a3b8f35570b77c74717946796550dc873e086a6cd"
 dependencies = [
- "ratex-font",
- "ratex-parser",
- "ratex-types",
- "serde_json",
+    "ratex-font",
+    "ratex-parser",
+    "ratex-types",
+    "serde_json",
 ]
 
 [[package]]
@@ -4024,9 +3950,9 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b0cc7746f4a617f857390f5361cb413d79d9cc0f607b05d398ddef0b8b21522"
 dependencies = [
- "ratex-types",
- "serde",
- "thiserror 1.0.69",
+    "ratex-types",
+    "serde",
+    "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4035,16 +3961,16 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d1c51aaae3f99f6f61e3d76d820b01afb3a0c19cf092ed11fedef7604930cd"
 dependencies = [
- "fancy-regex",
- "ratex-font",
- "ratex-lexer",
- "ratex-types",
- "regex",
- "regex-lite",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "unicode-normalization",
+    "fancy-regex",
+    "ratex-font",
+    "ratex-lexer",
+    "ratex-types",
+    "regex",
+    "regex-lite",
+    "serde",
+    "serde_json",
+    "thiserror 1.0.69",
+    "unicode-normalization",
 ]
 
 [[package]]
@@ -4053,13 +3979,13 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d8de42ad88f7d5f50dbe4f0d0d431051398fb09725920568ef75553a4a80ae6"
 dependencies = [
- "ab_glyph",
- "base64",
- "ratex-font",
- "ratex-font-loader",
- "ratex-katex-fonts",
- "ratex-types",
- "ratex-unicode-font",
+    "ab_glyph",
+    "base64",
+    "ratex-font",
+    "ratex-font-loader",
+    "ratex-katex-fonts",
+    "ratex-types",
+    "ratex-unicode-font",
 ]
 
 [[package]]
@@ -4068,7 +3994,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "694d45327eb6f5bf76d5d06f5dc1123a1d1202e3d392f2b260bd12bcca0dc19d"
 dependencies = [
- "serde",
+    "serde",
 ]
 
 [[package]]
@@ -4077,9 +4003,9 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692e6fb9ce62d33edc6f6beb6fe4ebaf1f61f8fc4297552573e74750c4472f86"
 dependencies = [
- "fontdb",
- "system-fonts",
- "ttf-parser",
+    "fontdb",
+    "system-fonts",
+    "ttf-parser",
 ]
 
 [[package]]
@@ -4100,8 +4026,8 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
- "either",
- "rayon-core",
+    "either",
+    "rayon-core",
 ]
 
 [[package]]
@@ -4110,8 +4036,8 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
+    "crossbeam-deque",
+    "crossbeam-utils",
 ]
 
 [[package]]
@@ -4120,8 +4046,8 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
 dependencies = [
- "bytemuck",
- "font-types",
+    "bytemuck",
+    "font-types",
 ]
 
 [[package]]
@@ -4130,8 +4056,8 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
 dependencies = [
- "bytemuck",
- "font-types",
+    "bytemuck",
+    "font-types",
 ]
 
 [[package]]
@@ -4140,7 +4066,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
- "bitflags 1.3.2",
+    "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -4149,7 +4075,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+    "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4158,18 +4084,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
- "bitflags 2.13.0",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 1.0.69",
+    "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4178,10 +4093,10 @@ version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
+    "aho-corasick",
+    "memchr",
+    "regex-automata",
+    "regex-syntax",
 ]
 
 [[package]]
@@ -4190,9 +4105,9 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
+    "aho-corasick",
+    "memchr",
+    "regex-syntax",
 ]
 
 [[package]]
@@ -4219,72 +4134,55 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
+    "base64",
+    "bytes",
+    "futures-channel",
+    "futures-core",
+    "futures-util",
+    "http",
+    "http-body",
+    "http-body-util",
+    "hyper",
+    "hyper-rustls",
+    "hyper-util",
+    "js-sys",
+    "log",
+    "percent-encoding",
+    "pin-project-lite",
+    "quinn",
+    "rustls",
+    "rustls-pki-types",
+    "serde",
+    "serde_json",
+    "serde_urlencoded",
+    "sync_wrapper",
+    "tokio",
+    "tokio-rustls",
+    "tower",
+    "tower-http",
+    "tower-service",
+    "url",
+    "wasm-bindgen",
+    "wasm-bindgen-futures",
+    "web-sys",
+    "webpki-roots",
 ]
 
 [[package]]
 name = "resvg"
-version = "0.45.1"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
+checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
 dependencies = [
- "gif 0.13.3",
- "image-webp",
- "log",
- "pico-args",
- "rgb",
- "svgtypes 0.15.3",
- "tiny-skia",
- "usvg 0.45.1",
- "zune-jpeg 0.4.21",
-]
-
-[[package]]
-name = "resvg"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b563218631706d614e23059436526d005b50ab5f2d506b55a17eb65c5eb83419"
-dependencies = [
- "gif 0.14.2",
- "image-webp",
- "log",
- "pico-args",
- "rgb",
- "svgtypes 0.16.1",
- "tiny-skia",
- "usvg 0.46.0",
- "zune-jpeg 0.5.15",
+    "gif",
+    "image-webp",
+    "log",
+    "pico-args",
+    "rgb",
+    "svgtypes",
+    "tiny-skia",
+    "usvg",
+    "zune-jpeg",
 ]
 
 [[package]]
@@ -4293,7 +4191,7 @@ version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 dependencies = [
- "bytemuck",
+    "bytemuck",
 ]
 
 [[package]]
@@ -4302,25 +4200,25 @@ version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
+    "cc",
+    "cfg-if",
+    "getrandom 0.2.17",
+    "libc",
+    "untrusted",
+    "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "roughr-merman"
 version = "0.12.1"
 dependencies = [
- "derive_builder",
- "euclid",
- "getrandom 0.4.3",
- "num-traits",
- "palette",
- "rand 0.10.1",
- "svgtypes 0.16.1",
+    "derive_builder",
+    "euclid",
+    "getrandom 0.4.3",
+    "num-traits",
+    "palette",
+    "rand 0.10.1",
+    "svgtypes",
 ]
 
 [[package]]
@@ -4335,7 +4233,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
 dependencies = [
- "memchr",
+    "memchr",
 ]
 
 [[package]]
@@ -4344,9 +4242,9 @@ version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
 dependencies = [
- "rust-embed-impl",
- "rust-embed-utils",
- "walkdir",
+    "rust-embed-impl",
+    "rust-embed-utils",
+    "walkdir",
 ]
 
 [[package]]
@@ -4355,11 +4253,11 @@ version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
 dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils",
- "syn",
- "walkdir",
+    "proc-macro2",
+    "quote",
+    "rust-embed-utils",
+    "syn",
+    "walkdir",
 ]
 
 [[package]]
@@ -4368,8 +4266,8 @@ version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
- "sha2",
- "walkdir",
+    "sha2",
+    "walkdir",
 ]
 
 [[package]]
@@ -4390,7 +4288,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+    "semver",
 ]
 
 [[package]]
@@ -4399,11 +4297,11 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.13.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+    "bitflags 2.13.0",
+    "errno",
+    "libc",
+    "linux-raw-sys 0.4.15",
+    "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4412,25 +4310,25 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
- "errno",
- "libc",
- "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+    "bitflags 2.13.0",
+    "errno",
+    "libc",
+    "linux-raw-sys 0.12.1",
+    "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
+    "once_cell",
+    "ring",
+    "rustls-pki-types",
+    "rustls-webpki",
+    "subtle",
+    "zeroize",
 ]
 
 [[package]]
@@ -4439,8 +4337,8 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
- "web-time",
- "zeroize",
+    "web-time",
+    "zeroize",
 ]
 
 [[package]]
@@ -4449,9 +4347,9 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
+    "ring",
+    "rustls-pki-types",
+    "untrusted",
 ]
 
 [[package]]
@@ -4466,16 +4364,16 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
 dependencies = [
- "bitflags 2.13.0",
- "bytemuck",
- "core_maths",
- "log",
- "smallvec",
- "ttf-parser",
- "unicode-bidi-mirroring",
- "unicode-ccc",
- "unicode-properties",
- "unicode-script",
+    "bitflags 2.13.0",
+    "bytemuck",
+    "core_maths",
+    "log",
+    "smallvec",
+    "ttf-parser",
+    "unicode-bidi-mirroring",
+    "unicode-ccc",
+    "unicode-properties",
+    "unicode-script",
 ]
 
 [[package]]
@@ -4496,7 +4394,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
 dependencies = [
- "bytemuck",
+    "bytemuck",
 ]
 
 [[package]]
@@ -4505,7 +4403,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
- "winapi-util",
+    "winapi-util",
 ]
 
 [[package]]
@@ -4526,7 +4424,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
 dependencies = [
- "scroll_derive",
+    "scroll_derive",
 ]
 
 [[package]]
@@ -4535,9 +4433,9 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+    "proc-macro2",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -4546,17 +4444,17 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cfaaa6035167f0e604e42723c7650d59ee269ef220d7bbe0565602c8a0173b9"
 dependencies = [
- "bitflags 2.13.0",
- "cssparser",
- "derive_more",
- "log",
- "new_debug_unreachable",
- "phf 0.13.1",
- "phf_codegen",
- "precomputed-hash",
- "rustc-hash 2.1.2",
- "servo_arc",
- "smallvec",
+    "bitflags 2.13.0",
+    "cssparser",
+    "derive_more",
+    "log",
+    "new_debug_unreachable",
+    "phf 0.13.1",
+    "phf_codegen",
+    "precomputed-hash",
+    "rustc-hash 2.1.2",
+    "servo_arc",
+    "smallvec",
 ]
 
 [[package]]
@@ -4571,8 +4469,8 @@ version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
- "serde",
- "serde_core",
+    "serde",
+    "serde_core",
 ]
 
 [[package]]
@@ -4581,8 +4479,8 @@ version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
- "serde_core",
- "serde_derive",
+    "serde_core",
+    "serde_derive",
 ]
 
 [[package]]
@@ -4591,9 +4489,9 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
 dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
+    "js-sys",
+    "serde",
+    "wasm-bindgen",
 ]
 
 [[package]]
@@ -4602,7 +4500,7 @@ version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
- "serde_derive",
+    "serde_derive",
 ]
 
 [[package]]
@@ -4611,9 +4509,9 @@ version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+    "proc-macro2",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -4622,12 +4520,12 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "indexmap",
- "itoa",
- "memchr",
- "serde",
- "serde_core",
- "zmij",
+    "indexmap",
+    "itoa",
+    "memchr",
+    "serde",
+    "serde_core",
+    "zmij",
 ]
 
 [[package]]
@@ -4636,7 +4534,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde_core",
+    "serde_core",
 ]
 
 [[package]]
@@ -4645,10 +4543,10 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
+    "form_urlencoded",
+    "itoa",
+    "ryu",
+    "serde",
 ]
 
 [[package]]
@@ -4657,11 +4555,11 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
+    "indexmap",
+    "itoa",
+    "ryu",
+    "serde",
+    "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4670,7 +4568,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
- "stable_deref_trait",
+    "stable_deref_trait",
 ]
 
 [[package]]
@@ -4679,9 +4577,19 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
+    "cfg-if",
+    "cpufeatures 0.2.17",
+    "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+    "digest",
+    "keccak",
 ]
 
 [[package]]
@@ -4696,10 +4604,10 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f45c644a9f3a386f9288625d9f0c1e999e1acf07a37df35d0516c7f199d9cb2"
 dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "wide",
+    "approx",
+    "num-complex",
+    "num-traits",
+    "wide",
 ]
 
 [[package]]
@@ -4714,8 +4622,8 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
 dependencies = [
- "rustc_version",
- "simdutf8",
+    "rustc_version",
+    "simdutf8",
 ]
 
 [[package]]
@@ -4730,7 +4638,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
 dependencies = [
- "log",
+    "log",
 ]
 
 [[package]]
@@ -4745,8 +4653,8 @@ version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
 dependencies = [
- "bytemuck",
- "read-fonts 0.37.0",
+    "bytemuck",
+    "read-fonts 0.37.0",
 ]
 
 [[package]]
@@ -4755,8 +4663,8 @@ version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
 dependencies = [
- "bytemuck",
- "read-fonts 0.39.2",
+    "bytemuck",
+    "read-fonts 0.39.2",
 ]
 
 [[package]]
@@ -4771,7 +4679,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
 dependencies = [
- "version_check",
+    "version_check",
 ]
 
 [[package]]
@@ -4792,23 +4700,23 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.13.0",
- "calloop 0.13.0",
- "calloop-wayland-source 0.3.0",
- "cursor-icon",
- "libc",
- "log",
- "memmap2",
- "rustix 0.38.44",
- "thiserror 1.0.69",
- "wayland-backend",
- "wayland-client",
- "wayland-csd-frame",
- "wayland-cursor",
- "wayland-protocols",
- "wayland-protocols-wlr",
- "wayland-scanner",
- "xkeysym",
+    "bitflags 2.13.0",
+    "calloop 0.13.0",
+    "calloop-wayland-source 0.3.0",
+    "cursor-icon",
+    "libc",
+    "log",
+    "memmap2",
+    "rustix 0.38.44",
+    "thiserror 1.0.69",
+    "wayland-backend",
+    "wayland-client",
+    "wayland-csd-frame",
+    "wayland-cursor",
+    "wayland-protocols",
+    "wayland-protocols-wlr",
+    "wayland-scanner",
+    "xkeysym",
 ]
 
 [[package]]
@@ -4817,25 +4725,25 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
 dependencies = [
- "bitflags 2.13.0",
- "calloop 0.14.4",
- "calloop-wayland-source 0.4.1",
- "cursor-icon",
- "libc",
- "log",
- "memmap2",
- "rustix 1.1.4",
- "thiserror 2.0.18",
- "wayland-backend",
- "wayland-client",
- "wayland-csd-frame",
- "wayland-cursor",
- "wayland-protocols",
- "wayland-protocols-experimental",
- "wayland-protocols-misc",
- "wayland-protocols-wlr",
- "wayland-scanner",
- "xkeysym",
+    "bitflags 2.13.0",
+    "calloop 0.14.4",
+    "calloop-wayland-source 0.4.1",
+    "cursor-icon",
+    "libc",
+    "log",
+    "memmap2",
+    "rustix 1.1.4",
+    "thiserror 2.0.18",
+    "wayland-backend",
+    "wayland-client",
+    "wayland-csd-frame",
+    "wayland-cursor",
+    "wayland-protocols",
+    "wayland-protocols-experimental",
+    "wayland-protocols-misc",
+    "wayland-protocols-wlr",
+    "wayland-scanner",
+    "xkeysym",
 ]
 
 [[package]]
@@ -4844,9 +4752,9 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71704c03f739f7745053bde45fa203a46c58d25bc5c4efba1d9a60e9dba81226"
 dependencies = [
- "libc",
- "smithay-client-toolkit 0.20.0",
- "wayland-backend",
+    "libc",
+    "smithay-client-toolkit 0.20.0",
+    "wayland-backend",
 ]
 
 [[package]]
@@ -4855,7 +4763,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
- "serde",
+    "serde",
 ]
 
 [[package]]
@@ -4864,8 +4772,8 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
- "libc",
- "windows-sys 0.61.2",
+    "libc",
+    "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4892,19 +4800,19 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 dependencies = [
- "float-cmp",
+    "float-cmp",
 ]
 
 [[package]]
 name = "string_cache"
-version = "0.8.9"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared 0.11.3",
- "precomputed-hash",
+    "new_debug_unreachable",
+    "parking_lot",
+    "phf_shared 0.13.1",
+    "precomputed-hash",
 ]
 
 [[package]]
@@ -4919,10 +4827,10 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38803281d1c23166c5ebcb455439a5d2afe711cc909cf88af72448c297756ad6"
 dependencies = [
- "kurbo 0.13.1",
- "rustc-hash 2.1.2",
- "skrifa 0.42.1",
- "write-fonts",
+    "kurbo",
+    "rustc-hash 2.1.2",
+    "skrifa 0.42.1",
+    "write-fonts",
 ]
 
 [[package]]
@@ -4932,43 +4840,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
-name = "svg2pdf"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50dc062439cc1a396181059c80932a6e6bd731b130e674c597c0c8874b6df22"
-dependencies = [
- "fontdb",
- "image",
- "log",
- "miniz_oxide",
- "once_cell",
- "pdf-writer",
- "resvg 0.45.1",
- "siphasher",
- "subsetter",
- "tiny-skia",
- "ttf-parser",
- "usvg 0.45.1",
-]
-
-[[package]]
-name = "svgtypes"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
-dependencies = [
- "kurbo 0.11.3",
- "siphasher",
-]
-
-[[package]]
 name = "svgtypes"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
 dependencies = [
- "kurbo 0.13.1",
- "siphasher",
+    "kurbo",
+    "siphasher",
 ]
 
 [[package]]
@@ -4977,9 +4855,9 @@ version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+    "proc-macro2",
+    "quote",
+    "unicode-ident",
 ]
 
 [[package]]
@@ -4988,7 +4866,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
- "futures-core",
+    "futures-core",
 ]
 
 [[package]]
@@ -4997,9 +4875,9 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+    "proc-macro2",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -5008,7 +4886,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
 dependencies = [
- "libc",
+    "libc",
 ]
 
 [[package]]
@@ -5017,9 +4895,9 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46ba78ea149d4bb0626dacad10aa789eedc83395889890a0e6e7ec69a4577442"
 dependencies = [
- "fontdb",
- "sys-locale",
- "web-sys",
+    "fontdb",
+    "sys-locale",
+    "web-sys",
 ]
 
 [[package]]
@@ -5028,22 +4906,20 @@ version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "fastrand",
- "getrandom 0.4.3",
- "once_cell",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
+    "fastrand",
+    "getrandom 0.4.3",
+    "once_cell",
+    "rustix 1.1.4",
+    "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "term"
-version = "0.7.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
+    "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5058,7 +4934,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
- "smawk",
+    "smawk",
 ]
 
 [[package]]
@@ -5067,7 +4943,7 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.69",
+    "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -5076,7 +4952,7 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
+    "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -5085,9 +4961,9 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+    "proc-macro2",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -5096,9 +4972,9 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+    "proc-macro2",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -5107,47 +4983,38 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
 dependencies = [
- "fax",
- "flate2",
- "half",
- "quick-error",
- "weezl",
- "zune-jpeg 0.5.15",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
+    "fax",
+    "flate2",
+    "half",
+    "quick-error",
+    "weezl",
+    "zune-jpeg",
 ]
 
 [[package]]
 name = "tiny-skia"
-version = "0.11.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+checksum = "47ffee5eaaf5527f630fb0e356b90ebdec84d5d18d937c5e440350f88c5a91ea"
 dependencies = [
- "arrayref",
- "arrayvec",
- "bytemuck",
- "cfg-if",
- "log",
- "png 0.17.16",
- "tiny-skia-path",
+    "arrayref",
+    "arrayvec",
+    "bytemuck",
+    "cfg-if",
+    "log",
+    "png",
+    "tiny-skia-path",
 ]
 
 [[package]]
 name = "tiny-skia-path"
-version = "0.11.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
 dependencies = [
- "arrayref",
- "bytemuck",
- "strict-num",
+    "arrayref",
+    "bytemuck",
+    "strict-num",
 ]
 
 [[package]]
@@ -5156,8 +5023,8 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
- "displaydoc",
- "zerovec",
+    "displaydoc",
+    "zerovec",
 ]
 
 [[package]]
@@ -5166,8 +5033,8 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
- "serde",
- "serde_json",
+    "serde",
+    "serde_json",
 ]
 
 [[package]]
@@ -5176,7 +5043,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
- "tinyvec_macros",
+    "tinyvec_macros",
 ]
 
 [[package]]
@@ -5191,12 +5058,12 @@ version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
- "bytes",
- "libc",
- "mio",
- "pin-project-lite",
- "socket2",
- "windows-sys 0.61.2",
+    "bytes",
+    "libc",
+    "mio",
+    "pin-project-lite",
+    "socket2",
+    "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5205,8 +5072,8 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
- "tokio",
+    "rustls",
+    "tokio",
 ]
 
 [[package]]
@@ -5215,13 +5082,13 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
+    "indexmap",
+    "serde_core",
+    "serde_spanned",
+    "toml_datetime 0.7.5+spec-1.1.0",
+    "toml_parser",
+    "toml_writer",
+    "winnow 0.7.15",
 ]
 
 [[package]]
@@ -5230,7 +5097,7 @@ version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
- "serde_core",
+    "serde_core",
 ]
 
 [[package]]
@@ -5239,7 +5106,7 @@ version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
- "serde_core",
+    "serde_core",
 ]
 
 [[package]]
@@ -5248,10 +5115,10 @@ version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
- "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
- "toml_parser",
- "winnow 1.0.3",
+    "indexmap",
+    "toml_datetime 1.1.1+spec-1.1.0",
+    "toml_parser",
+    "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5260,7 +5127,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+    "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5275,13 +5142,13 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
- "futures-core",
- "futures-util",
- "pin-project-lite",
- "sync_wrapper",
- "tokio",
- "tower-layer",
- "tower-service",
+    "futures-core",
+    "futures-util",
+    "pin-project-lite",
+    "sync_wrapper",
+    "tokio",
+    "tower-layer",
+    "tower-service",
 ]
 
 [[package]]
@@ -5290,16 +5157,16 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
- "url",
+    "bitflags 2.13.0",
+    "bytes",
+    "futures-util",
+    "http",
+    "http-body",
+    "pin-project-lite",
+    "tower",
+    "tower-layer",
+    "tower-service",
+    "url",
 ]
 
 [[package]]
@@ -5320,21 +5187,9 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+    "log",
+    "pin-project-lite",
+    "tracing-core",
 ]
 
 [[package]]
@@ -5343,7 +5198,7 @@ version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
- "once_cell",
+    "once_cell",
 ]
 
 [[package]]
@@ -5358,7 +5213,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 dependencies = [
- "core_maths",
+    "core_maths",
 ]
 
 [[package]]
@@ -5367,7 +5222,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
- "rustc-hash 2.1.2",
+    "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -5418,7 +5273,7 @@ version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
- "tinyvec",
+    "tinyvec",
 ]
 
 [[package]]
@@ -5463,12 +5318,12 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46eefd5468602930da46b1f49d3448c6dfc2e81295f93120f23f8174fd70267f"
 dependencies = [
- "anyhow",
- "cargo_metadata",
- "uniffi_bindgen",
- "uniffi_core",
- "uniffi_macros",
- "uniffi_pipeline",
+    "anyhow",
+    "cargo_metadata",
+    "uniffi_bindgen",
+    "uniffi_core",
+    "uniffi_macros",
+    "uniffi_pipeline",
 ]
 
 [[package]]
@@ -5477,24 +5332,24 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a0c9b375d32e1365cdb2bdd7cb495eecf6fac851ddbad077412b4ee1888514"
 dependencies = [
- "anyhow",
- "askama",
- "camino",
- "cargo_metadata",
- "fs-err",
- "glob",
- "goblin",
- "heck",
- "indexmap",
- "once_cell",
- "serde",
- "tempfile",
- "textwrap",
- "toml",
- "uniffi_internal_macros",
- "uniffi_meta",
- "uniffi_pipeline",
- "uniffi_udl",
+    "anyhow",
+    "askama",
+    "camino",
+    "cargo_metadata",
+    "fs-err",
+    "glob",
+    "goblin",
+    "heck",
+    "indexmap",
+    "once_cell",
+    "serde",
+    "tempfile",
+    "textwrap",
+    "toml",
+    "uniffi_internal_macros",
+    "uniffi_meta",
+    "uniffi_pipeline",
+    "uniffi_udl",
 ]
 
 [[package]]
@@ -5503,10 +5358,10 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eec017b112701681f6fbbe5d92014b5c468eb0b177a94389de03ceec40665095"
 dependencies = [
- "anyhow",
- "bytes",
- "once_cell",
- "static_assertions",
+    "anyhow",
+    "bytes",
+    "once_cell",
+    "static_assertions",
 ]
 
 [[package]]
@@ -5515,11 +5370,11 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4641669b48fefbc5e80ff08c5004d9c7617fb91232131a6734ab6712779cb04c"
 dependencies = [
- "anyhow",
- "indexmap",
- "proc-macro2",
- "quote",
- "syn",
+    "anyhow",
+    "indexmap",
+    "proc-macro2",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -5528,15 +5383,15 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeb8617ee814de22caf7417bf514715ba0b3f46bd9d5a5d794413fd8282cb737"
 dependencies = [
- "camino",
- "fs-err",
- "once_cell",
- "proc-macro2",
- "quote",
- "serde",
- "syn",
- "toml",
- "uniffi_meta",
+    "camino",
+    "fs-err",
+    "once_cell",
+    "proc-macro2",
+    "quote",
+    "serde",
+    "syn",
+    "toml",
+    "uniffi_meta",
 ]
 
 [[package]]
@@ -5545,10 +5400,10 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58d5b94fc92803d21b2928bd15c6f06e57609b95caf98ea561c99cda1b6d2a25"
 dependencies = [
- "anyhow",
- "siphasher",
- "uniffi_internal_macros",
- "uniffi_pipeline",
+    "anyhow",
+    "siphasher",
+    "uniffi_internal_macros",
+    "uniffi_pipeline",
 ]
 
 [[package]]
@@ -5557,11 +5412,11 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "032739b3ec725576914c15899dedaf080163ced86b6934566c20ec2b20ce90ca"
 dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "tempfile",
- "uniffi_internal_macros",
+    "anyhow",
+    "heck",
+    "indexmap",
+    "tempfile",
+    "uniffi_internal_macros",
 ]
 
 [[package]]
@@ -5570,10 +5425,10 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0a1d0a0252ce1af9e8ce78ba67ac0d8937fb2bedaf10cbddd43d3614d06ec6"
 dependencies = [
- "anyhow",
- "textwrap",
- "uniffi_meta",
- "weedle2",
+    "anyhow",
+    "textwrap",
+    "uniffi_meta",
+    "weedle2",
 ]
 
 [[package]]
@@ -5594,64 +5449,38 @@ version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
+    "form_urlencoded",
+    "idna",
+    "percent-encoding",
+    "serde",
 ]
 
 [[package]]
 name = "usvg"
-version = "0.45.1"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
+checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
 dependencies = [
- "base64",
- "data-url",
- "flate2",
- "fontdb",
- "imagesize 0.13.0",
- "kurbo 0.11.3",
- "log",
- "pico-args",
- "roxmltree 0.20.0",
- "rustybuzz",
- "simplecss",
- "siphasher",
- "strict-num",
- "svgtypes 0.15.3",
- "tiny-skia-path",
- "unicode-bidi",
- "unicode-script",
- "unicode-vo",
- "xmlwriter",
-]
-
-[[package]]
-name = "usvg"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e419dff010bb12512b0ae9e3d2f318dfbdf0167fde7eb05465134d4e8756076f"
-dependencies = [
- "base64",
- "data-url",
- "flate2",
- "fontdb",
- "imagesize 0.14.0",
- "kurbo 0.13.1",
- "log",
- "pico-args",
- "roxmltree 0.21.1",
- "rustybuzz",
- "simplecss",
- "siphasher",
- "strict-num",
- "svgtypes 0.16.1",
- "tiny-skia-path",
- "unicode-bidi",
- "unicode-script",
- "unicode-vo",
- "xmlwriter",
+    "base64",
+    "data-url",
+    "flate2",
+    "fontdb",
+    "imagesize",
+    "kurbo",
+    "log",
+    "pico-args",
+    "roxmltree 0.21.1",
+    "rustybuzz",
+    "simplecss",
+    "siphasher",
+    "strict-num",
+    "svgtypes",
+    "tiny-skia-path",
+    "ttf-parser",
+    "unicode-bidi",
+    "unicode-script",
+    "unicode-vo",
+    "xmlwriter",
 ]
 
 [[package]]
@@ -5672,9 +5501,9 @@ version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
- "getrandom 0.4.3",
- "js-sys",
- "wasm-bindgen",
+    "getrandom 0.4.3",
+    "js-sys",
+    "wasm-bindgen",
 ]
 
 [[package]]
@@ -5683,13 +5512,13 @@ version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd1a4c633ce09e7d713df1a6e036644a125e15e0c169cfb5180ddf5836ca04b"
 dependencies = [
- "bytemuck",
- "fearless_simd",
- "hashbrown 0.16.1",
- "log",
- "peniko",
- "skrifa 0.40.0",
- "smallvec",
+    "bytemuck",
+    "fearless_simd",
+    "hashbrown 0.16.1",
+    "log",
+    "peniko",
+    "skrifa 0.40.0",
+    "smallvec",
 ]
 
 [[package]]
@@ -5698,9 +5527,9 @@ version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0162bfe48aabf6a9fdcd401b628c7d9f260c2cbabb343c70a65feba6f7849edc"
 dependencies = [
- "bytemuck",
- "hashbrown 0.16.1",
- "vello_common",
+    "bytemuck",
+    "hashbrown 0.16.1",
+    "vello_common",
 ]
 
 [[package]]
@@ -5709,8 +5538,8 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61584a325b16f97b5b25fcc852eb9550843a251057a5e3e5992d2376f3df4bb2"
 dependencies = [
- "proc-macro2",
- "quote",
+    "proc-macro2",
+    "quote",
 ]
 
 [[package]]
@@ -5725,7 +5554,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
- "libc",
+    "libc",
 ]
 
 [[package]]
@@ -5734,8 +5563,8 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
- "same-file",
- "winapi-util",
+    "same-file",
+    "winapi-util",
 ]
 
 [[package]]
@@ -5744,7 +5573,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "try-lock",
+    "try-lock",
 ]
 
 [[package]]
@@ -5759,7 +5588,7 @@ version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen",
+    "wit-bindgen",
 ]
 
 [[package]]
@@ -5768,11 +5597,11 @@ version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
- "wasm-bindgen-shared",
+    "cfg-if",
+    "once_cell",
+    "rustversion",
+    "wasm-bindgen-macro",
+    "wasm-bindgen-shared",
 ]
 
 [[package]]
@@ -5781,8 +5610,8 @@ version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
- "js-sys",
- "wasm-bindgen",
+    "js-sys",
+    "wasm-bindgen",
 ]
 
 [[package]]
@@ -5791,8 +5620,8 @@ version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
+    "quote",
+    "wasm-bindgen-macro-support",
 ]
 
 [[package]]
@@ -5801,11 +5630,11 @@ version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
- "bumpalo",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
+    "bumpalo",
+    "proc-macro2",
+    "quote",
+    "syn",
+    "wasm-bindgen-shared",
 ]
 
 [[package]]
@@ -5814,7 +5643,7 @@ version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
- "unicode-ident",
+    "unicode-ident",
 ]
 
 [[package]]
@@ -5823,9 +5652,9 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae17f1dd65ee737caf73ea45f517c09578ab60970c28e5e96b7900fe2e245633"
 dependencies = [
- "proc-macro2",
- "quote",
- "venial",
+    "proc-macro2",
+    "quote",
+    "venial",
 ]
 
 [[package]]
@@ -5834,11 +5663,11 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2300d0f78cba12f14e29e8dd157ea64050c0a688179aefdb2050105805594a0c"
 dependencies = [
- "spin",
- "wasmi_collections",
- "wasmi_core",
- "wasmi_ir",
- "wasmparser",
+    "spin",
+    "wasmi_collections",
+    "wasmi_core",
+    "wasmi_ir",
+    "wasmparser",
 ]
 
 [[package]]
@@ -5853,7 +5682,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9013136083d988725953390bf668b64b7a218fabf26f8b913bbc59546b97ee27"
 dependencies = [
- "libm",
+    "libm",
 ]
 
 [[package]]
@@ -5862,7 +5691,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba1fa003f79156f406d62ef0e1464dc03e11ace37170e9fa7524299a75ad8f68"
 dependencies = [
- "wasmi_core",
+    "wasmi_core",
 ]
 
 [[package]]
@@ -5871,7 +5700,7 @@ version = "0.239.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
 dependencies = [
- "bitflags 2.13.0",
+    "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -5880,12 +5709,12 @@ version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
- "cc",
- "downcast-rs",
- "rustix 1.1.4",
- "scoped-tls",
- "smallvec",
- "wayland-sys",
+    "cc",
+    "downcast-rs",
+    "rustix 1.1.4",
+    "scoped-tls",
+    "smallvec",
+    "wayland-sys",
 ]
 
 [[package]]
@@ -5894,10 +5723,10 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.13.0",
- "rustix 1.1.4",
- "wayland-backend",
- "wayland-scanner",
+    "bitflags 2.13.0",
+    "rustix 1.1.4",
+    "wayland-backend",
+    "wayland-scanner",
 ]
 
 [[package]]
@@ -5906,9 +5735,9 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.13.0",
- "cursor-icon",
- "wayland-backend",
+    "bitflags 2.13.0",
+    "cursor-icon",
+    "wayland-backend",
 ]
 
 [[package]]
@@ -5917,21 +5746,21 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
 dependencies = [
- "rustix 1.1.4",
- "wayland-client",
- "xcursor",
+    "rustix 1.1.4",
+    "wayland-client",
+    "xcursor",
 ]
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.12"
+version = "0.32.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
 dependencies = [
- "bitflags 2.13.0",
- "wayland-backend",
- "wayland-client",
- "wayland-scanner",
+    "bitflags 2.13.0",
+    "wayland-backend",
+    "wayland-client",
+    "wayland-scanner",
 ]
 
 [[package]]
@@ -5940,11 +5769,11 @@ version = "20250721.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
 dependencies = [
- "bitflags 2.13.0",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-scanner",
+    "bitflags 2.13.0",
+    "wayland-backend",
+    "wayland-client",
+    "wayland-protocols",
+    "wayland-scanner",
 ]
 
 [[package]]
@@ -5953,11 +5782,11 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
 dependencies = [
- "bitflags 2.13.0",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-scanner",
+    "bitflags 2.13.0",
+    "wayland-backend",
+    "wayland-client",
+    "wayland-protocols",
+    "wayland-scanner",
 ]
 
 [[package]]
@@ -5966,11 +5795,11 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
 dependencies = [
- "bitflags 2.13.0",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-scanner",
+    "bitflags 2.13.0",
+    "wayland-backend",
+    "wayland-client",
+    "wayland-protocols",
+    "wayland-scanner",
 ]
 
 [[package]]
@@ -5979,11 +5808,11 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.13.0",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-scanner",
+    "bitflags 2.13.0",
+    "wayland-backend",
+    "wayland-client",
+    "wayland-protocols",
+    "wayland-scanner",
 ]
 
 [[package]]
@@ -5992,9 +5821,9 @@ version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
- "proc-macro2",
- "quick-xml",
- "quote",
+    "proc-macro2",
+    "quick-xml",
+    "quote",
 ]
 
 [[package]]
@@ -6003,10 +5832,10 @@ version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
- "dlib",
- "log",
- "once_cell",
- "pkg-config",
+    "dlib",
+    "log",
+    "once_cell",
+    "pkg-config",
 ]
 
 [[package]]
@@ -6015,8 +5844,8 @@ version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
- "js-sys",
- "wasm-bindgen",
+    "js-sys",
+    "wasm-bindgen",
 ]
 
 [[package]]
@@ -6025,8 +5854,8 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
- "js-sys",
- "wasm-bindgen",
+    "js-sys",
+    "wasm-bindgen",
 ]
 
 [[package]]
@@ -6035,14 +5864,14 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
 dependencies = [
- "core-foundation 0.10.1",
- "jni",
- "log",
- "ndk-context",
- "objc2 0.6.4",
- "objc2-foundation 0.3.2",
- "url",
- "web-sys",
+    "core-foundation 0.10.1",
+    "jni",
+    "log",
+    "ndk-context",
+    "objc2 0.6.4",
+    "objc2-foundation 0.3.2",
+    "url",
+    "web-sys",
 ]
 
 [[package]]
@@ -6051,7 +5880,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
- "rustls-pki-types",
+    "rustls-pki-types",
 ]
 
 [[package]]
@@ -6060,7 +5889,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
 dependencies = [
- "nom",
+    "nom",
 ]
 
 [[package]]
@@ -6075,26 +5904,26 @@ version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
 dependencies = [
- "arrayvec",
- "bitflags 2.13.0",
- "bytemuck",
- "cfg-if",
- "cfg_aliases",
- "document-features",
- "hashbrown 0.16.1",
- "js-sys",
- "log",
- "portable-atomic",
- "profiling",
- "raw-window-handle",
- "smallvec",
- "static_assertions",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "wgpu-core",
- "wgpu-hal",
- "wgpu-types",
+    "arrayvec",
+    "bitflags 2.13.0",
+    "bytemuck",
+    "cfg-if",
+    "cfg_aliases",
+    "document-features",
+    "hashbrown 0.16.1",
+    "js-sys",
+    "log",
+    "portable-atomic",
+    "profiling",
+    "raw-window-handle",
+    "smallvec",
+    "static_assertions",
+    "wasm-bindgen",
+    "wasm-bindgen-futures",
+    "web-sys",
+    "wgpu-core",
+    "wgpu-hal",
+    "wgpu-types",
 ]
 
 [[package]]
@@ -6103,29 +5932,29 @@ version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
 dependencies = [
- "arrayvec",
- "bit-set 0.9.1",
- "bit-vec 0.9.1",
- "bitflags 2.13.0",
- "bytemuck",
- "cfg_aliases",
- "document-features",
- "hashbrown 0.16.1",
- "indexmap",
- "log",
- "naga",
- "once_cell",
- "parking_lot",
- "portable-atomic",
- "profiling",
- "raw-window-handle",
- "rustc-hash 1.1.0",
- "smallvec",
- "thiserror 2.0.18",
- "wgpu-core-deps-windows-linux-android",
- "wgpu-hal",
- "wgpu-naga-bridge",
- "wgpu-types",
+    "arrayvec",
+    "bit-set 0.9.1",
+    "bit-vec 0.9.1",
+    "bitflags 2.13.0",
+    "bytemuck",
+    "cfg_aliases",
+    "document-features",
+    "hashbrown 0.16.1",
+    "indexmap",
+    "log",
+    "naga",
+    "once_cell",
+    "parking_lot",
+    "portable-atomic",
+    "profiling",
+    "raw-window-handle",
+    "rustc-hash 1.1.0",
+    "smallvec",
+    "thiserror 2.0.18",
+    "wgpu-core-deps-windows-linux-android",
+    "wgpu-hal",
+    "wgpu-naga-bridge",
+    "wgpu-types",
 ]
 
 [[package]]
@@ -6134,7 +5963,7 @@ version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb01076d0aa08b0ba9bd741e178b5cc440f5abe99d9581323a4c8b5d1a1916"
 dependencies = [
- "wgpu-hal",
+    "wgpu-hal",
 ]
 
 [[package]]
@@ -6143,19 +5972,19 @@ version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
 dependencies = [
- "bitflags 2.13.0",
- "cfg-if",
- "cfg_aliases",
- "libloading 0.8.9",
- "log",
- "naga",
- "portable-atomic",
- "portable-atomic-util",
- "raw-window-handle",
- "renderdoc-sys",
- "thiserror 2.0.18",
- "wgpu-naga-bridge",
- "wgpu-types",
+    "bitflags 2.13.0",
+    "cfg-if",
+    "cfg_aliases",
+    "libloading 0.8.9",
+    "log",
+    "naga",
+    "portable-atomic",
+    "portable-atomic-util",
+    "raw-window-handle",
+    "renderdoc-sys",
+    "thiserror 2.0.18",
+    "wgpu-naga-bridge",
+    "wgpu-types",
 ]
 
 [[package]]
@@ -6164,8 +5993,8 @@ version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
 dependencies = [
- "naga",
- "wgpu-types",
+    "naga",
+    "wgpu-types",
 ]
 
 [[package]]
@@ -6174,12 +6003,12 @@ version = "29.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
 dependencies = [
- "bitflags 2.13.0",
- "bytemuck",
- "js-sys",
- "log",
- "raw-window-handle",
- "web-sys",
+    "bitflags 2.13.0",
+    "bytemuck",
+    "js-sys",
+    "log",
+    "raw-window-handle",
+    "web-sys",
 ]
 
 [[package]]
@@ -6188,8 +6017,8 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfdfe6a32973f2d1b268b8895845a8a96cac2f0191e72c27cc929036060dbf89"
 dependencies = [
- "bytemuck",
- "safe_arch",
+    "bytemuck",
+    "safe_arch",
 ]
 
 [[package]]
@@ -6198,8 +6027,8 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
+    "winapi-i686-pc-windows-gnu",
+    "winapi-x86_64-pc-windows-gnu",
 ]
 
 [[package]]
@@ -6214,7 +6043,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+    "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6229,11 +6058,11 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+    "windows-implement",
+    "windows-interface",
+    "windows-link",
+    "windows-result",
+    "windows-strings",
 ]
 
 [[package]]
@@ -6242,9 +6071,9 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+    "proc-macro2",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -6253,9 +6082,9 @@ version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+    "proc-macro2",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -6270,7 +6099,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+    "windows-link",
 ]
 
 [[package]]
@@ -6279,7 +6108,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+    "windows-link",
 ]
 
 [[package]]
@@ -6288,7 +6117,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+    "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6297,7 +6126,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+    "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6306,7 +6135,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.5",
+    "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -6315,7 +6144,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+    "windows-link",
 ]
 
 [[package]]
@@ -6324,14 +6153,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+    "windows_aarch64_gnullvm 0.52.6",
+    "windows_aarch64_msvc 0.52.6",
+    "windows_i686_gnu 0.52.6",
+    "windows_i686_gnullvm 0.52.6",
+    "windows_i686_msvc 0.52.6",
+    "windows_x86_64_gnu 0.52.6",
+    "windows_x86_64_gnullvm 0.52.6",
+    "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -6340,15 +6169,15 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+    "windows-link",
+    "windows_aarch64_gnullvm 0.53.1",
+    "windows_aarch64_msvc 0.53.1",
+    "windows_i686_gnu 0.53.1",
+    "windows_i686_gnullvm 0.53.1",
+    "windows_i686_msvc 0.53.1",
+    "windows_x86_64_gnu 0.53.1",
+    "windows_x86_64_gnullvm 0.53.1",
+    "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6453,49 +6282,49 @@ version = "0.30.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
 dependencies = [
- "ahash",
- "android-activity",
- "atomic-waker",
- "bitflags 2.13.0",
- "block2 0.5.1",
- "bytemuck",
- "calloop 0.13.0",
- "cfg_aliases",
- "concurrent-queue",
- "core-foundation 0.9.4",
- "core-graphics",
- "cursor-icon",
- "dpi",
- "js-sys",
- "libc",
- "memmap2",
- "ndk",
- "objc2 0.5.2",
- "objc2-app-kit 0.2.2",
- "objc2-foundation 0.2.2",
- "objc2-ui-kit 0.2.2",
- "orbclient",
- "percent-encoding",
- "pin-project",
- "raw-window-handle",
- "redox_syscall 0.4.1",
- "rustix 0.38.44",
- "smithay-client-toolkit 0.19.2",
- "smol_str",
- "tracing",
- "unicode-segmentation",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "wayland-protocols-plasma",
- "web-sys",
- "web-time",
- "windows-sys 0.52.0",
- "x11-dl",
- "x11rb",
- "xkbcommon-dl",
+    "ahash",
+    "android-activity",
+    "atomic-waker",
+    "bitflags 2.13.0",
+    "block2 0.5.1",
+    "bytemuck",
+    "calloop 0.13.0",
+    "cfg_aliases",
+    "concurrent-queue",
+    "core-foundation 0.9.4",
+    "core-graphics",
+    "cursor-icon",
+    "dpi",
+    "js-sys",
+    "libc",
+    "memmap2",
+    "ndk",
+    "objc2 0.5.2",
+    "objc2-app-kit 0.2.2",
+    "objc2-foundation 0.2.2",
+    "objc2-ui-kit 0.2.2",
+    "orbclient",
+    "percent-encoding",
+    "pin-project",
+    "raw-window-handle",
+    "redox_syscall 0.4.1",
+    "rustix 0.38.44",
+    "smithay-client-toolkit 0.19.2",
+    "smol_str",
+    "tracing",
+    "unicode-segmentation",
+    "wasm-bindgen",
+    "wasm-bindgen-futures",
+    "wayland-backend",
+    "wayland-client",
+    "wayland-protocols",
+    "wayland-protocols-plasma",
+    "web-sys",
+    "web-time",
+    "windows-sys 0.52.0",
+    "x11-dl",
+    "x11rb",
+    "xkbcommon-dl",
 ]
 
 [[package]]
@@ -6504,7 +6333,7 @@ version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
- "memchr",
+    "memchr",
 ]
 
 [[package]]
@@ -6513,7 +6342,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
- "memchr",
+    "memchr",
 ]
 
 [[package]]
@@ -6528,11 +6357,11 @@ version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb731d4c4d93eacc69a1ad2f270f905788a98e4a3438267bcafbe08d3431c8d8"
 dependencies = [
- "font-types",
- "indexmap",
- "kurbo 0.13.1",
- "log",
- "read-fonts 0.39.2",
+    "font-types",
+    "indexmap",
+    "kurbo",
+    "log",
+    "read-fonts 0.39.2",
 ]
 
 [[package]]
@@ -6547,9 +6376,9 @@ version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
 dependencies = [
- "libc",
- "once_cell",
- "pkg-config",
+    "libc",
+    "once_cell",
+    "pkg-config",
 ]
 
 [[package]]
@@ -6558,13 +6387,13 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
- "as-raw-xcb-connection",
- "gethostname",
- "libc",
- "libloading 0.8.9",
- "once_cell",
- "rustix 1.1.4",
- "x11rb-protocol",
+    "as-raw-xcb-connection",
+    "gethostname",
+    "libc",
+    "libloading 0.8.9",
+    "once_cell",
+    "rustix 1.1.4",
+    "x11rb-protocol",
 ]
 
 [[package]]
@@ -6585,11 +6414,11 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.13.0",
- "dlib",
- "log",
- "once_cell",
- "xkeysym",
+    "bitflags 2.13.0",
+    "dlib",
+    "log",
+    "once_cell",
+    "xkeysym",
 ]
 
 [[package]]
@@ -6611,27 +6440,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
+name = "xmp-writer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9440ea3e5aeabb0ac63af70daf835274065238cdd0cec83418f417eae38bacee"
+
+[[package]]
 name = "xtask"
 version = "0.8.0-alpha.2"
 dependencies = [
- "base64",
- "brotli",
- "chrono",
- "dugong",
- "flate2",
- "futures",
- "merman",
- "merman-core",
- "merman-layout-elk",
- "merman-render",
- "regex",
- "roxmltree 0.20.0",
- "serde",
- "serde_json",
- "serde_yaml",
- "thiserror 2.0.18",
- "toml",
- "wasmi",
+    "base64",
+    "brotli",
+    "chrono",
+    "dugong",
+    "flate2",
+    "futures",
+    "merman",
+    "merman-core",
+    "merman-layout-elk",
+    "merman-render",
+    "regex",
+    "roxmltree 0.20.0",
+    "serde",
+    "serde_json",
+    "serde_yaml",
+    "thiserror 2.0.18",
+    "toml",
+    "wasmi",
 ]
 
 [[package]]
@@ -6640,9 +6475,9 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
+    "stable_deref_trait",
+    "yoke-derive",
+    "zerofrom",
 ]
 
 [[package]]
@@ -6651,10 +6486,10 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
+    "proc-macro2",
+    "quote",
+    "syn",
+    "synstructure",
 ]
 
 [[package]]
@@ -6663,7 +6498,7 @@ version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
- "zerocopy-derive",
+    "zerocopy-derive",
 ]
 
 [[package]]
@@ -6672,9 +6507,9 @@ version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+    "proc-macro2",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -6683,7 +6518,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
- "zerofrom-derive",
+    "zerofrom-derive",
 ]
 
 [[package]]
@@ -6692,10 +6527,10 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
+    "proc-macro2",
+    "quote",
+    "syn",
+    "synstructure",
 ]
 
 [[package]]
@@ -6710,9 +6545,9 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
+    "displaydoc",
+    "yoke",
+    "zerofrom",
 ]
 
 [[package]]
@@ -6721,9 +6556,9 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
+    "yoke",
+    "zerofrom",
+    "zerovec-derive",
 ]
 
 [[package]]
@@ -6732,9 +6567,9 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+    "proc-macro2",
+    "quote",
+    "syn",
 ]
 
 [[package]]
@@ -6745,24 +6580,9 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zune-core"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
-
-[[package]]
-name = "zune-core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
-
-[[package]]
-name = "zune-jpeg"
-version = "0.4.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
-dependencies = [
- "zune-core 0.4.12",
-]
 
 [[package]]
 name = "zune-jpeg"
@@ -6770,5 +6590,5 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
- "zune-core 0.5.1",
+    "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,28 +1,28 @@
 [workspace]
 resolver = "2"
 members = [
-  "crates/merman",
-  "crates/merman-core",
-  "crates/merman-ascii",
-  "crates/merman-bindings-core",
-  "crates/merman-cli",
-  "crates/merman-ffi",
-  "crates/merman-elk-layered",
-  "crates/merman-layout-elk",
-  "crates/merman-rustdoc",
-  "crates/merman-render",
-  "crates/merman-typst-plugin",
-  "crates/merman-uniffi",
-  "crates/merman-wasm",
-  "crates/dugong",
-  "crates/dugong-graphlib",
-  "crates/manatee",
-  "crates/roughr",
-  "crates/xtask",
+    "crates/merman",
+    "crates/merman-core",
+    "crates/merman-ascii",
+    "crates/merman-bindings-core",
+    "crates/merman-cli",
+    "crates/merman-ffi",
+    "crates/merman-elk-layered",
+    "crates/merman-layout-elk",
+    "crates/merman-rustdoc",
+    "crates/merman-render",
+    "crates/merman-typst-plugin",
+    "crates/merman-uniffi",
+    "crates/merman-wasm",
+    "crates/dugong",
+    "crates/dugong-graphlib",
+    "crates/manatee",
+    "crates/roughr",
+    "crates/xtask",
 ]
 exclude = [
-  "repo-ref/dear-imgui-rs",
-  "repo-ref/mermaid-rs-renderer",
+    "repo-ref/dear-imgui-rs",
+    "repo-ref/mermaid-rs-renderer",
 ]
 
 [workspace.package]
@@ -41,11 +41,10 @@ euclid = "0.22.14"
 flate2 = "1.1.9"
 htmlize = { version = "1.1.0", features = ["unescape"] }
 indexmap = { version = "2.2.6", features = ["serde"] }
-lalrpop = "0.20.2"
-lalrpop-util = "0.20.2"
-logos = "0.14.4"
+lalrpop = "0.23.1"
+lalrpop-util = "0.23.1"
 nalgebra = { version = "0.35.0", default-features = false, features = ["std"] }
-pulldown-cmark = "0.12.2"
+pulldown-cmark = " 0.13.4"
 ratex-layout = "0.1.11"
 ratex-parser = "0.1.11"
 ratex-svg = { version = "0.1.11", default-features = false }
@@ -68,23 +67,24 @@ tracing = "0.1.41"
 uniffi = "0.31.1"
 futures = "0.3.31"
 hashbrown = "0.16.1"
-lol_html = "2.7.1"
+lol_html = "2.8"
 url = "2.5.4"
-uuid = { version = "1.12.1", default-features = false, features = ["std"] }
-chrono = { version = "0.4.40", default-features = false, features = ["std"] }
-clap = { version = "4.5", features = ["derive"] }
-clap_complete = "4.5"
+uuid = { version = "1.23", default-features = false, features = ["std"] }
+chrono = { version = "0.4.45", default-features = false, features = ["std"] }
+clap = { version = "4.6", features = ["derive"] }
+clap_complete = "4.6"
 console_error_panic_hook = "0.1"
 image = { version = "0.25", default-features = false, features = ["jpeg"] }
-png = "0.17.16"
+png = "0.18"
 proc-macro2 = "1"
 quote = "1"
-resvg = "0.46.0"
+resvg = "0.47"
 serde-wasm-bindgen = "0.6"
 syn = { version = "2", features = ["full", "parsing"] }
-usvg = "0.46.0"
-tiny-skia = "0.11.4"
-svg2pdf = "0.13.0"
+usvg = "0.47"
+tiny-skia = "0.12"
+krilla = "0.8"
+krilla-svg = " 0.8"
 unicode-width = "0.2.2"
 wasm-bindgen = "0.2"
 web-time = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ indexmap = { version = "2.2.6", features = ["serde"] }
 lalrpop = "0.23.1"
 lalrpop-util = "0.23.1"
 nalgebra = { version = "0.35.0", default-features = false, features = ["std"] }
-pulldown-cmark = " 0.13.4"
+pulldown-cmark = "0.13.4"
 ratex-layout = "0.1.11"
 ratex-parser = "0.1.11"
 ratex-svg = { version = "0.1.11", default-features = false }
@@ -84,7 +84,7 @@ syn = { version = "2", features = ["full", "parsing"] }
 usvg = "0.47"
 tiny-skia = "0.12"
 krilla = "0.8"
-krilla-svg = " 0.8"
+krilla-svg = "0.8"
 unicode-width = "0.2.2"
 wasm-bindgen = "0.2"
 web-time = "1.1.0"

--- a/crates/dugong/Cargo.toml
+++ b/crates/dugong/Cargo.toml
@@ -26,7 +26,6 @@ serde_json.workspace = true
 
 [dev-dependencies]
 criterion = "0.8.2"
-gag = "1.0.0"
 
 [[bench]]
 name = "network_simplex"

--- a/crates/merman-cli/tests/png_smoke.rs
+++ b/crates/merman-cli/tests/png_smoke.rs
@@ -1,7 +1,7 @@
 use assert_cmd::prelude::*;
 use png::ColorType;
 use std::fs;
-use std::io::Read;
+use std::io::{Cursor, Read};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -248,10 +248,13 @@ fn cli_renders_png_for_negative_viewbox_diagrams() {
         .expect("open png")
         .read_to_end(&mut bytes)
         .expect("read png");
-
-    let decoder = png::Decoder::new(bytes.as_slice());
+    let cursor = Cursor::new(bytes.as_slice());
+    let decoder = png::Decoder::new(cursor);
     let mut reader = decoder.read_info().expect("png read_info");
-    let mut buf = vec![0u8; reader.output_buffer_size()];
+    let size = reader
+        .output_buffer_size()
+        .expect("invalid png output buffer size");
+    let mut buf = vec![0u8; size];
     let info = reader.next_frame(&mut buf).expect("png next_frame");
     assert_eq!(info.color_type, ColorType::Rgba, "expected RGBA output");
     assert_eq!(
@@ -267,7 +270,8 @@ fn cli_renders_png_for_negative_viewbox_diagrams() {
 }
 
 fn png_dimensions(bytes: &[u8]) -> (u32, u32) {
-    let decoder = png::Decoder::new(bytes);
+    let cursor = Cursor::new(bytes);
+    let decoder = png::Decoder::new(cursor);
     let reader = decoder.read_info().expect("png read_info");
     let info = reader.info();
     (info.width, info.height)

--- a/crates/merman-core/Cargo.toml
+++ b/crates/merman-core/Cargo.toml
@@ -32,14 +32,12 @@ euclid.workspace = true
 htmlize.workspace = true
 indexmap.workspace = true
 lalrpop-util.workspace = true
-logos.workspace = true
 regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml = { workspace = true, optional = true }
 json5 = { workspace = true, optional = true }
 thiserror.workspace = true
-tracing.workspace = true
 lol_html = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }

--- a/crates/merman/Cargo.toml
+++ b/crates/merman/Cargo.toml
@@ -13,10 +13,10 @@ readme = "../../README.md"
 keywords = ["mermaid", "diagrams", "svg", "parser", "headless"]
 categories = ["parser-implementations", "visualization"]
 exclude = [
-  "tests/mindmap_br_variants_031.rs",
-  "tests/resvg_safe_fixture_smoke.rs",
-  "tests/zed_mermaid_issue_fixtures.rs",
-  "tests/zed_pr_57644_corpus.rs",
+    "tests/mindmap_br_variants_031.rs",
+    "tests/resvg_safe_fixture_smoke.rs",
+    "tests/zed_mermaid_issue_fixtures.rs",
+    "tests/zed_pr_57644_corpus.rs",
 ]
 
 [package.metadata.docs.rs]
@@ -38,7 +38,8 @@ raster = [
     "dep:resvg",
     "dep:usvg",
     "dep:tiny-skia",
-    "dep:svg2pdf",
+    "dep:krilla",
+    "dep:krilla-svg",
 ]
 
 [dependencies]
@@ -52,7 +53,8 @@ image = { workspace = true, optional = true }
 resvg = { workspace = true, optional = true }
 usvg = { workspace = true, optional = true }
 tiny-skia = { workspace = true, optional = true }
-svg2pdf = { workspace = true, optional = true }
+krilla = { workspace = true, optional = true }
+krilla-svg = { workspace = true, optional = true }
 
 [dev-dependencies]
 base64.workspace = true

--- a/crates/merman/examples/example_10_integration_egui.rs
+++ b/crates/merman/examples/example_10_integration_egui.rs
@@ -1,8 +1,10 @@
-use eframe::egui::{self, ColorImage, TextureHandle};
+use eframe::Frame;
+use eframe::egui::{self, ColorImage, TextureHandle, Ui};
 use merman::render::{
     HeadlessRenderer,
     raster::{RasterFitBox, RasterOptions, svg_to_png},
 };
+use std::io::Cursor;
 use std::path::Path;
 
 const DEFAULT_SOURCE: &str = r#"flowchart TD
@@ -111,11 +113,11 @@ impl MermanEguiApp {
 }
 
 impl eframe::App for MermanEguiApp {
-    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        egui::TopBottomPanel::top("toolbar").show(ctx, |ui| {
+    fn ui(&mut self, ui: &mut Ui, _frame: &mut Frame) {
+        egui::Panel::top("toolbar").show_inside(ui, |ui| {
             ui.horizontal(|ui| {
                 if ui.button("Render").clicked() {
-                    self.render(ctx);
+                    self.render(ui);
                 }
                 if ui.button("Save SVG").clicked() {
                     self.save_svg();
@@ -127,10 +129,10 @@ impl eframe::App for MermanEguiApp {
             });
         });
 
-        egui::SidePanel::left("source")
+        egui::Panel::left("source")
             .resizable(true)
-            .default_width(380.0)
-            .show(ctx, |ui| {
+            .default_size(380.0)
+            .show_inside(ui, |ui| {
                 ui.heading("Mermaid source");
                 let response = ui.add(
                     egui::TextEdit::multiline(&mut self.source)
@@ -146,7 +148,7 @@ impl eframe::App for MermanEguiApp {
                 }
             });
 
-        egui::CentralPanel::default().show(ctx, |ui| {
+        egui::CentralPanel::default().show_inside(ui, |ui| {
             ui.heading("PNG preview");
             if let Some(texture) = &self.texture {
                 let available = ui.available_size();
@@ -169,11 +171,15 @@ fn fit_size(source: egui::Vec2, bounds: egui::Vec2) -> egui::Vec2 {
 }
 
 fn png_to_color_image(bytes: &[u8]) -> Result<ColorImage, String> {
-    let decoder = png::Decoder::new(bytes);
+    let cursor = Cursor::new(bytes);
+    let decoder = png::Decoder::new(cursor);
     let mut reader = decoder
         .read_info()
         .map_err(|err| format!("invalid PNG preview: {err}"))?;
-    let mut buf = vec![0; reader.output_buffer_size()];
+    let size = reader
+        .output_buffer_size()
+        .expect("invalid PNG output buffer size");
+    let mut buf = vec![0; size];
     let info = reader
         .next_frame(&mut buf)
         .map_err(|err| format!("invalid PNG frame: {err}"))?;

--- a/crates/merman/src/render/raster.rs
+++ b/crates/merman/src/render/raster.rs
@@ -9,6 +9,8 @@ pub enum RasterError {
     Headless(#[from] HeadlessError),
     #[error("failed to parse SVG")]
     SvgParse,
+    #[error("failed to set SVG Document size from tree")]
+    SvgDocSize,
     #[error("failed to allocate pixmap for raster rendering")]
     PixmapAlloc,
     #[error("invalid raster scale; expected a finite positive number")]
@@ -287,17 +289,32 @@ pub fn validate_svg_pdf_size(svg: &str, options: &RasterOptions) -> Result<Raste
 }
 
 fn svg_to_pdf_unchecked(svg: &str) -> Result<Vec<u8>> {
-    let mut opt = svg2pdf::usvg::Options::default();
-    configure_usvg_options_for_pdf(&mut opt);
+    use krilla_svg::SurfaceExt;
+    use std::sync::Arc;
 
-    let tree = svg2pdf::usvg::Tree::from_str(svg, &opt).map_err(|_| RasterError::SvgParse)?;
+    let mut fontdb = usvg::fontdb::Database::new();
+    fontdb.load_system_fonts();
+    let opts = usvg::Options {
+        fontdb: Arc::new(fontdb),
+        font_family: "Arial".to_string(),
+        ..Default::default()
+    };
+    let svg_tree = usvg::Tree::from_str(svg, &opts).map_err(|_| RasterError::SvgParse)?;
+    let mut document = krilla::Document::new();
+    let Some(svg_size) =
+        krilla::geom::Size::from_wh(svg_tree.size().width(), svg_tree.size().height())
+    else {
+        return Err(RasterError::SvgDocSize);
+    };
+    let mut page = document.start_page_with(krilla::page::PageSettings::new(svg_size));
+    let mut surface = page.surface();
+    surface.draw_svg(&svg_tree, svg_size, krilla_svg::SvgSettings::default());
+    surface.finish();
+    page.finish();
 
-    svg2pdf::to_pdf(
-        &tree,
-        svg2pdf::ConversionOptions::default(),
-        svg2pdf::PageOptions::default(),
-    )
-    .map_err(|_| RasterError::PdfConvert)
+    let pdf = document.finish().map_err(|_| RasterError::PdfConvert)?;
+
+    Ok(pdf)
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -594,7 +611,7 @@ fn configure_usvg_options_for_raster(opt: &mut usvg::Options<'_>, svg: &str) {
     opt.font_resolver = browser_like_font_resolver();
 }
 
-fn configure_usvg_options_for_pdf(opt: &mut svg2pdf::usvg::Options<'_>) {
+fn configure_usvg_options_for_pdf(opt: &mut usvg::Options<'_>) {
     opt.fontdb_mut().load_system_fonts();
     configure_fontdb_generic_families(opt.fontdb_mut());
     opt.font_family =
@@ -615,16 +632,16 @@ fn browser_like_font_resolver() -> usvg::FontResolver<'static> {
     }
 }
 
-fn browser_like_pdf_font_resolver() -> svg2pdf::usvg::FontResolver<'static> {
-    let default_select = svg2pdf::usvg::FontResolver::default_font_selector();
+fn browser_like_pdf_font_resolver() -> usvg::FontResolver<'static> {
+    let default_select = usvg::FontResolver::default_font_selector();
 
-    svg2pdf::usvg::FontResolver {
+    usvg::FontResolver {
         select_font: Box::new(move |font, fontdb| {
             default_select(font, fontdb)
                 .or_else(|| query_browser_like_pdf_fallback_font(font, fontdb.as_ref()))
                 .or_else(|| fontdb.faces().next().map(|face| face.id))
         }),
-        select_fallback: svg2pdf::usvg::FontResolver::default_fallback_selector(),
+        select_fallback: usvg::FontResolver::default_fallback_selector(),
     }
 }
 
@@ -681,23 +698,23 @@ fn query_browser_like_fallback_font(
 }
 
 fn query_browser_like_pdf_fallback_font(
-    font: &svg2pdf::usvg::Font,
-    fontdb: &svg2pdf::usvg::fontdb::Database,
-) -> Option<svg2pdf::usvg::fontdb::ID> {
+    font: &usvg::Font,
+    fontdb: &usvg::fontdb::Database,
+) -> Option<usvg::fontdb::ID> {
     let mut families = Vec::with_capacity(3);
     if pdf_font_requests_monospace(font) {
-        families.push(svg2pdf::usvg::fontdb::Family::Monospace);
-        families.push(svg2pdf::usvg::fontdb::Family::SansSerif);
-        families.push(svg2pdf::usvg::fontdb::Family::Serif);
+        families.push(usvg::fontdb::Family::Monospace);
+        families.push(usvg::fontdb::Family::SansSerif);
+        families.push(usvg::fontdb::Family::Serif);
     } else {
-        families.push(svg2pdf::usvg::fontdb::Family::SansSerif);
-        families.push(svg2pdf::usvg::fontdb::Family::Serif);
-        families.push(svg2pdf::usvg::fontdb::Family::Monospace);
+        families.push(usvg::fontdb::Family::SansSerif);
+        families.push(usvg::fontdb::Family::Serif);
+        families.push(usvg::fontdb::Family::Monospace);
     }
 
-    let query = svg2pdf::usvg::fontdb::Query {
+    let query = usvg::fontdb::Query {
         families: &families,
-        weight: svg2pdf::usvg::fontdb::Weight(font.weight()),
+        weight: usvg::fontdb::Weight(font.weight()),
         stretch: font.stretch().into(),
         style: font.style().into(),
     };
@@ -753,10 +770,10 @@ fn font_requests_monospace(font: &usvg::Font) -> bool {
     })
 }
 
-fn pdf_font_requests_monospace(font: &svg2pdf::usvg::Font) -> bool {
+fn pdf_font_requests_monospace(font: &usvg::Font) -> bool {
     font.families().iter().any(|family| match family {
-        svg2pdf::usvg::FontFamily::Monospace => true,
-        svg2pdf::usvg::FontFamily::Named(name) => {
+        usvg::FontFamily::Monospace => true,
+        usvg::FontFamily::Named(name) => {
             let name = name.to_ascii_lowercase();
             name.contains("mono")
                 || name.contains("courier")

--- a/crates/merman/src/render/raster.rs
+++ b/crates/merman/src/render/raster.rs
@@ -969,18 +969,36 @@ mod tests {
     }
 
     fn png_size(bytes: &[u8]) -> (u32, u32) {
-        let img = image::load_from_memory_with_format(bytes, image::ImageFormat::Png)
-            .unwrap()
-            .to_rgba8();
-        img.dimensions()
+        let decoder = png::Decoder::new(std::io::Cursor::new(bytes));
+        let reader = decoder.read_info().expect("png read_info");
+        let info = reader.info();
+        (info.width, info.height)
     }
 
     fn assert_png_has_visible_non_background_ink(bytes: &[u8]) {
-        let img = image::load_from_memory_with_format(bytes, image::ImageFormat::Png)
-            .unwrap()
-            .to_rgba8();
-        let pixels = img.as_raw();
-        let background = &pixels[..4];
+        let decoder = png::Decoder::new(std::io::Cursor::new(bytes));
+        let mut reader = decoder.read_info().expect("png read_info");
+        let size = reader
+            .output_buffer_size()
+            .expect("invalid png output buffer size");
+        let mut buf = vec![0u8; size];
+        let info = reader.next_frame(&mut buf).expect("png next_frame");
+
+        assert_eq!(
+            info.color_type,
+            png::ColorType::Rgba,
+            "expected RGBA PNG output"
+        );
+        assert_eq!(
+            info.bit_depth,
+            png::BitDepth::Eight,
+            "expected 8-bit PNG output"
+        );
+
+        let pixels = &buf[..info.buffer_size()];
+        let Some(background) = pixels.chunks_exact(4).next() else {
+            panic!("expected at least one PNG pixel");
+        };
         let differing_pixels = pixels
             .chunks_exact(4)
             .filter(|px| {

--- a/crates/merman/tests/resvg_safe_fixture_smoke.rs
+++ b/crates/merman/tests/resvg_safe_fixture_smoke.rs
@@ -4,6 +4,7 @@ use merman::MermaidConfig;
 use merman::render::HeadlessRenderer;
 use serde_json::{Map, Value};
 use std::collections::BTreeSet;
+use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
@@ -388,11 +389,15 @@ fn assert_rasterizes_when_enabled(name: &str, source: &str, svg: &str) {
 
 #[cfg(feature = "raster")]
 fn assert_png_has_visible_non_background_ink(name: &str, png_bytes: &[u8]) {
-    let decoder = png::Decoder::new(png_bytes);
+    let cursor = Cursor::new(png_bytes);
+    let decoder = png::Decoder::new(cursor);
     let mut reader = decoder
         .read_info()
         .unwrap_or_else(|err| panic!("{name}: expected decodable PNG output: {err}"));
-    let mut buf = vec![0u8; reader.output_buffer_size()];
+    let size = reader
+        .output_buffer_size()
+        .expect("invalid PNG output buffer size");
+    let mut buf = vec![0u8; size];
     let info = reader
         .next_frame(&mut buf)
         .unwrap_or_else(|err| panic!("{name}: expected readable PNG frame: {err}"));

--- a/crates/merman/tests/security_regression.rs
+++ b/crates/merman/tests/security_regression.rs
@@ -2,6 +2,7 @@
 
 use merman::MermaidConfig;
 use merman::render::{HeadlessRenderer, RenderResourceLimits};
+use std::io::Cursor;
 use std::sync::Arc;
 
 fn render_svg(renderer: &HeadlessRenderer, name: &str, source: &str) -> String {
@@ -265,7 +266,8 @@ fn default_pdf_conversion_rejects_oversized_intrinsic_svg() {
 
 #[cfg(feature = "raster")]
 fn png_dimensions(bytes: &[u8]) -> (u32, u32) {
-    let decoder = png::Decoder::new(bytes);
+    let cursor = Cursor::new(bytes);
+    let decoder = png::Decoder::new(cursor);
     let reader = decoder.read_info().expect("valid PNG header");
     let info = reader.info();
     (info.width, info.height)


### PR DESCRIPTION
## Summary

Upgrade some dependencies to new versions and reduce multiple versions of the same-named boxes of dependencies

## What changed
1. remove `gag` in `dugong` and  `logos` in `merman-core`
2. replace `svg2pdf` with `krilla-svg`, reason see: [this](https://github.com/typst/svg2pdf/pull/97#issuecomment-3794473091)
3. update `eframe` example, using `ui` function, no `update` function

## Verification
- [ ] `cargo fmt --all --check`
- [x] Relevant tests ran
- [ ] Benchmark or report updated if this affects performance

## Performance / parity notes
- Benchmark or report:
- Parity impact:
- Rollback risk:

## Follow-ups

