### PR TITLE
fix(playground): reflect current ascii capabilities

### DIFF
--- a/crates/merman-bindings-core/src/metadata.rs
+++ b/crates/merman-bindings-core/src/metadata.rs
@@ -1,4 +1,4 @@
-use crate::common::{BindingError, internal_json_error};
+use crate::common::{internal_json_error, BindingError};
 use serde::Serialize;
 use std::sync::OnceLock;
 
@@ -25,6 +25,7 @@ pub const ASCII_SUPPORTED_DIAGRAMS: &[&str] = &[
     "timeline",
     "treeView",
     "xychart",
+    "zenuml",
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -325,7 +326,8 @@ mod tests {
                     "state",
                     "timeline",
                     "treeView",
-                    "xychart"
+                    "xychart",
+                    "zenuml",
                 ]
             );
         } else {
@@ -344,34 +346,26 @@ mod tests {
         let family_capabilities: Value =
             serde_json::from_slice(&diagram_family_capabilities_json().unwrap()).unwrap();
 
-        assert!(
-            diagrams
-                .as_array()
-                .unwrap()
-                .contains(&Value::String("flowchart".to_string()))
-        );
+        assert!(diagrams
+            .as_array()
+            .unwrap()
+            .contains(&Value::String("flowchart".to_string())));
         assert!(ascii_diagrams.is_array());
-        assert!(
-            themes
-                .as_array()
-                .unwrap()
-                .contains(&Value::String("default".to_string()))
-        );
+        assert!(themes
+            .as_array()
+            .unwrap()
+            .contains(&Value::String("default".to_string())));
         assert!(host_presets.is_array());
         if cfg!(feature = "render") {
-            assert!(
-                host_presets
-                    .as_array()
-                    .unwrap()
-                    .contains(&Value::String("one-dark".to_string()))
-            );
-        }
-        assert!(
-            family_capabilities
+            assert!(host_presets
                 .as_array()
                 .unwrap()
-                .iter()
-                .any(|capability| capability["diagram_type"] == "flowchart")
-        );
+                .contains(&Value::String("one-dark".to_string())));
+        }
+        assert!(family_capabilities
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|capability| capability["diagram_type"] == "flowchart"));
     }
 }

--- a/crates/merman-bindings-core/src/metadata.rs
+++ b/crates/merman-bindings-core/src/metadata.rs
@@ -10,7 +10,22 @@ static DIAGRAM_FAMILY_CAPABILITIES_JSON: OnceLock<Vec<u8>> = OnceLock::new();
 static BINDING_CAPABILITIES_JSON: OnceLock<Vec<u8>> = OnceLock::new();
 
 #[cfg(feature = "ascii")]
-pub const ASCII_SUPPORTED_DIAGRAMS: &[&str] = &["class", "er", "flowchart", "sequence", "xychart"];
+pub const ASCII_SUPPORTED_DIAGRAMS: &[&str] = &[
+    "class",
+    "er",
+    "flowchart",
+    "gantt",
+    "gitgraph",
+    "journey",
+    "kanban",
+    "mindmap",
+    "packet",
+    "sequence",
+    "state",
+    "timeline",
+    "treeView",
+    "xychart",
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct BindingCapabilities {
@@ -296,7 +311,22 @@ mod tests {
         if cfg!(feature = "ascii") {
             assert_eq!(
                 ascii_supported_diagrams(),
-                &["class", "er", "flowchart", "sequence", "xychart"]
+                &[
+                    "class",
+                    "er",
+                    "flowchart",
+                    "gantt",
+                    "gitgraph",
+                    "journey",
+                    "kanban",
+                    "mindmap",
+                    "packet",
+                    "sequence",
+                    "state",
+                    "timeline",
+                    "treeView",
+                    "xychart"
+                ]
             );
         } else {
             assert!(ascii_supported_diagrams().is_empty());

--- a/crates/merman-ffi/src/android_jni.rs
+++ b/crates/merman-ffi/src/android_jni.rs
@@ -1,9 +1,9 @@
 use jni::{
-    Env, EnvUnowned, JavaVM,
     errors::{Result as JniResult, ThrowRuntimeExAndDefault},
     objects::{Global, JClass, JObject, JString, JValue},
     strings::JNIString,
     sys::{jint, jlong, jstring},
+    Env, EnvUnowned, JavaVM,
 };
 #[cfg(feature = "render")]
 use merman_bindings_core::TextMeasurer;

--- a/crates/merman-ffi/src/lib.rs
+++ b/crates/merman-ffi/src/lib.rs
@@ -1121,7 +1121,17 @@ mod tests {
                 .unwrap()
                 .contains(&Value::String("flowchart".to_string()))
         );
-        assert!(ascii_diagrams.is_array());
+        let ascii_diagrams = ascii_diagrams.as_array().unwrap();
+        if cfg!(feature = "ascii") {
+            for diagram in ["sequence", "gantt", "treeView"] {
+                assert!(
+                    ascii_diagrams.contains(&Value::String(diagram.to_string())),
+                    "expected ASCII metadata to include {diagram}"
+                );
+            }
+        } else {
+            assert!(ascii_diagrams.is_empty());
+        }
         assert!(family_capabilities.as_array().unwrap().iter().any(
             |capability| capability["diagram_type"] == "flowchart"
                 && capability["metadata_id"] == "flowchart"

--- a/crates/merman-ffi/src/lib.rs
+++ b/crates/merman-ffi/src/lib.rs
@@ -7,9 +7,9 @@
 
 #[cfg(feature = "render")]
 use merman_bindings_core::TextMeasurer;
-use merman_bindings_core::{BindingEngine, BindingError, BindingStatus, error_payload_json_bytes};
+use merman_bindings_core::{error_payload_json_bytes, BindingEngine, BindingError, BindingStatus};
 use std::ffi::c_char;
-use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::ptr;
 #[cfg(feature = "render")]
 use std::sync::Arc;
@@ -946,12 +946,10 @@ mod tests {
             error["code_name"],
             BindingStatus::UnsupportedFormat.code_name()
         );
-        assert!(
-            error["message"]
-                .as_str()
-                .unwrap()
-                .contains("render feature")
-        );
+        assert!(error["message"]
+            .as_str()
+            .unwrap()
+            .contains("render feature"));
     }
 
     #[test]
@@ -1115,15 +1113,13 @@ mod tests {
         let host_theme_presets: Value =
             serde_json::from_str(&take_text(host_theme_presets.data)).unwrap();
 
-        assert!(
-            diagrams
-                .as_array()
-                .unwrap()
-                .contains(&Value::String("flowchart".to_string()))
-        );
+        assert!(diagrams
+            .as_array()
+            .unwrap()
+            .contains(&Value::String("flowchart".to_string())));
         let ascii_diagrams = ascii_diagrams.as_array().unwrap();
         if cfg!(feature = "ascii") {
-            for diagram in ["sequence", "gantt", "treeView"] {
+            for diagram in ["sequence", "gantt", "treeView", "zenuml"] {
                 assert!(
                     ascii_diagrams.contains(&Value::String(diagram.to_string())),
                     "expected ASCII metadata to include {diagram}"
@@ -1132,26 +1128,24 @@ mod tests {
         } else {
             assert!(ascii_diagrams.is_empty());
         }
-        assert!(family_capabilities.as_array().unwrap().iter().any(
-            |capability| capability["diagram_type"] == "flowchart"
+        assert!(family_capabilities
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|capability| capability["diagram_type"] == "flowchart"
                 && capability["metadata_id"] == "flowchart"
                 && capability["has_semantic_parser"] == true
-                && capability["has_render_parser"] == true
-        ));
-        assert!(
-            themes
-                .as_array()
-                .unwrap()
-                .contains(&Value::String("default".to_string()))
-        );
+                && capability["has_render_parser"] == true));
+        assert!(themes
+            .as_array()
+            .unwrap()
+            .contains(&Value::String("default".to_string())));
         assert!(host_theme_presets.is_array());
         if cfg!(feature = "render") {
-            assert!(
-                host_theme_presets
-                    .as_array()
-                    .unwrap()
-                    .contains(&Value::String("one-dark".to_string()))
-            );
+            assert!(host_theme_presets
+                .as_array()
+                .unwrap()
+                .contains(&Value::String("one-dark".to_string())));
         }
     }
 
@@ -1236,12 +1230,10 @@ mod tests {
                 error["code_name"],
                 BindingStatus::ResourceLimitExceeded.code_name()
             );
-            assert!(
-                error["message"]
-                    .as_str()
-                    .unwrap()
-                    .contains("max_source_bytes")
-            );
+            assert!(error["message"]
+                .as_str()
+                .unwrap()
+                .contains("max_source_bytes"));
         } else {
             expect_render_feature_error(result);
         }

--- a/crates/merman-ffi/tests/c_consumer_smoke.c
+++ b/crates/merman-ffi/tests/c_consumer_smoke.c
@@ -237,7 +237,7 @@ int merman_c_consumer_smoke(MermanApi api) {
     rc = expect_ok_with(
         api.ascii_supported_diagrams_json(),
         api.buffer_free,
-        api.ascii_enabled ? "sequence" : "[]"
+        api.ascii_enabled ? "treeView" : "[]"
     );
     if (rc != 0) {
         return rc;

--- a/crates/merman-ffi/tests/c_consumer_smoke.c
+++ b/crates/merman-ffi/tests/c_consumer_smoke.c
@@ -237,7 +237,7 @@ int merman_c_consumer_smoke(MermanApi api) {
     rc = expect_ok_with(
         api.ascii_supported_diagrams_json(),
         api.buffer_free,
-        api.ascii_enabled ? "treeView" : "[]"
+        api.ascii_enabled ? "zenuml" : "[]"
     );
     if (rc != 0) {
         return rc;

--- a/crates/merman-uniffi/src/lib.rs
+++ b/crates/merman-uniffi/src/lib.rs
@@ -714,32 +714,26 @@ mod tests {
     fn engine_exposes_metadata() {
         let engine = engine();
 
-        assert!(
-            engine
-                .supported_diagrams()
-                .contains(&"flowchart".to_string())
-        );
+        assert!(engine
+            .supported_diagrams()
+            .contains(&"flowchart".to_string()));
         let ascii_supported_diagrams = engine.ascii_supported_diagrams();
-        for diagram in ["sequence", "gantt", "treeView"] {
+        for diagram in ["sequence", "gantt", "treeView", "zenuml"] {
             assert!(
                 ascii_supported_diagrams.contains(&diagram.to_string()),
                 "expected UniFFI ASCII metadata to include {diagram}"
             );
         }
         assert!(engine.supported_themes().contains(&"default".to_string()));
-        assert!(
-            engine
-                .supported_host_theme_presets()
-                .contains(&"one-dark".to_string())
-        );
+        assert!(engine
+            .supported_host_theme_presets()
+            .contains(&"one-dark".to_string()));
         let capabilities = engine.diagram_family_capabilities();
-        assert!(
-            capabilities
-                .iter()
-                .any(|capability| capability.diagram_type == "flowchart"
-                    && capability.has_semantic_parser
-                    && capability.has_render_parser)
-        );
+        assert!(capabilities
+            .iter()
+            .any(|capability| capability.diagram_type == "flowchart"
+                && capability.has_semantic_parser
+                && capability.has_render_parser));
     }
 
     #[test]

--- a/crates/merman-uniffi/src/lib.rs
+++ b/crates/merman-uniffi/src/lib.rs
@@ -719,11 +719,13 @@ mod tests {
                 .supported_diagrams()
                 .contains(&"flowchart".to_string())
         );
-        assert!(
-            engine
-                .ascii_supported_diagrams()
-                .contains(&"sequence".to_string())
-        );
+        let ascii_supported_diagrams = engine.ascii_supported_diagrams();
+        for diagram in ["sequence", "gantt", "treeView"] {
+            assert!(
+                ascii_supported_diagrams.contains(&diagram.to_string()),
+                "expected UniFFI ASCII metadata to include {diagram}"
+            );
+        }
         assert!(engine.supported_themes().contains(&"default".to_string()));
         assert!(
             engine

--- a/crates/merman-uniffi/tests/bindgen_smoke.rs
+++ b/crates/merman-uniffi/tests/bindgen_smoke.rs
@@ -240,7 +240,9 @@ assert invalid.code_name == "MERMAN_NO_DIAGRAM"
 assert "no Mermaid diagram" in invalid.error
 
 assert "flowchart" in engine.supported_diagrams()
-assert "sequence" in engine.ascii_supported_diagrams()
+ascii_supported_diagrams = engine.ascii_supported_diagrams()
+for diagram in ("sequence", "gantt", "treeView"):
+    assert diagram in ascii_supported_diagrams
 assert "default" in engine.supported_themes()
 assert "one-dark" in engine.supported_host_theme_presets()
 assert any(

--- a/crates/merman-uniffi/tests/bindgen_smoke.rs
+++ b/crates/merman-uniffi/tests/bindgen_smoke.rs
@@ -241,7 +241,7 @@ assert "no Mermaid diagram" in invalid.error
 
 assert "flowchart" in engine.supported_diagrams()
 ascii_supported_diagrams = engine.ascii_supported_diagrams()
-for diagram in ("sequence", "gantt", "treeView"):
+for diagram in ("sequence", "gantt", "treeView", "zenuml"):
     assert diagram in ascii_supported_diagrams
 assert "default" in engine.supported_themes()
 assert "one-dark" in engine.supported_host_theme_presets()

--- a/platforms/web/README.md
+++ b/platforms/web/README.md
@@ -223,13 +223,16 @@ initialization is usually simpler.
 - `layoutJson()`, `layoutJsonWithTextMeasurer()`, `layoutObject()`
 - `validate()`
 - `supportedDiagrams()`, `asciiSupportedDiagrams()`, `supportedThemes()`, `supportedHostThemePresets()`
+- `SUPPORTED_DIAGRAMS`, `SUPPORTED_ASCII_DIAGRAMS`, `isDiagramType()`, `isAsciiDiagramType()`
 - `createBrowserTextMeasurer()`, `bindingCapabilities()`, `selectedRegistryProfile()`, `diagramFamilyCapabilities()`
 - `abiVersion()`, `packageVersion()`, `encodeOptions()`
 
 All render, parse, layout, validation, and metadata functions require `initMerman()` first.
 `supportedDiagrams()`, `asciiSupportedDiagrams()`, `supportedThemes()`, and
 `supportedHostThemePresets()` return typed metadata and fail fast if the generated WebAssembly
-metadata drifts from the TypeScript surface.
+metadata drifts from the TypeScript surface. ASCII support is typed separately from SVG diagram
+metadata because some terminal-friendly renderers, such as `treeView`, can be exposed through
+`asciiSupportedDiagrams()` even when they are not part of the public SVG `supportedDiagrams()` list.
 
 ## Benchmarking against Mermaid JS
 

--- a/platforms/web/scripts/build-wasm.mjs
+++ b/platforms/web/scripts/build-wasm.mjs
@@ -111,13 +111,13 @@ console.log(
 
 const wasmPackArgs = [
   "build",
-  "../../crates/merman-wasm",
   "--target",
   "web",
   "--profile",
   "wasm-size",
   "--out-dir",
   "../../platforms/web/pkg",
+  "../../crates/merman-wasm",
 ];
 const cargoArgs = cargoFeatureArgs(preset);
 

--- a/platforms/web/scripts/smoke.mjs
+++ b/platforms/web/scripts/smoke.mjs
@@ -207,7 +207,7 @@ if (capabilities.core_full) {
 
 const asciiDiagrams = api.asciiSupportedDiagrams();
 for (const diagram of asciiDiagrams) {
-  assert.equal(api.isDiagramType(diagram), true);
+  assert.equal(api.isAsciiDiagramType(diagram), true);
 }
 
 function textMeasureRequest(text, maxWidth) {

--- a/platforms/web/src/index.ts
+++ b/platforms/web/src/index.ts
@@ -204,6 +204,25 @@ export const SUPPORTED_DIAGRAMS = [
 
 export type DiagramType = (typeof SUPPORTED_DIAGRAMS)[number];
 
+export const SUPPORTED_ASCII_DIAGRAMS = [
+  "class",
+  "er",
+  "flowchart",
+  "gantt",
+  "gitgraph",
+  "journey",
+  "kanban",
+  "mindmap",
+  "packet",
+  "sequence",
+  "state",
+  "timeline",
+  "treeView",
+  "xychart",
+] as const;
+
+export type AsciiDiagramType = (typeof SUPPORTED_ASCII_DIAGRAMS)[number];
+
 export const BINDING_STATUS_CODE_NAMES = [
   "MERMAN_OK",
   "MERMAN_INVALID_ARGUMENT",
@@ -267,6 +286,12 @@ export function isHostThemePresetName(
 
 export function isDiagramType(diagram: string): diagram is DiagramType {
   return (SUPPORTED_DIAGRAMS as readonly string[]).includes(diagram);
+}
+
+export function isAsciiDiagramType(
+  diagram: string
+): diagram is AsciiDiagramType {
+  return (SUPPORTED_ASCII_DIAGRAMS as readonly string[]).includes(diagram);
 }
 
 export function isBindingStatusCodeName(
@@ -346,7 +371,7 @@ export type MermanInitInput = MermanWasmLoader | MermanInitOptions;
 let wasmModule: MermanWasmModule | null = null;
 let initPromise: Promise<MermanWasmModule> | null = null;
 let supportedDiagramsCache: DiagramType[] | null = null;
-let asciiSupportedDiagramsCache: DiagramType[] | null = null;
+let asciiSupportedDiagramsCache: AsciiDiagramType[] | null = null;
 let diagramFamilyCapabilitiesCache: DiagramFamilyCapability[] | null = null;
 let supportedHostThemePresetsCache: HostThemePresetName[] | null = null;
 let supportedThemesCache: ThemeName[] | null = null;
@@ -626,10 +651,10 @@ export function diagramFamilyCapabilities(): DiagramFamilyCapability[] {
   return diagramFamilyCapabilitiesCache.map((capability) => ({ ...capability }));
 }
 
-export function asciiSupportedDiagrams(): DiagramType[] {
+export function asciiSupportedDiagrams(): AsciiDiagramType[] {
   asciiSupportedDiagramsCache ??= getMerman()
     .asciiSupportedDiagrams()
-    .map(assertDiagramType);
+    .map(assertAsciiDiagramType);
   return [...asciiSupportedDiagramsCache];
 }
 
@@ -667,6 +692,13 @@ function assertDiagramType(diagram: string): DiagramType {
     return diagram;
   }
   throw new Error(`Merman WASM returned unknown diagram type: ${diagram}`);
+}
+
+function assertAsciiDiagramType(diagram: string): AsciiDiagramType {
+  if (isAsciiDiagramType(diagram)) {
+    return diagram;
+  }
+  throw new Error(`Merman WASM returned unknown ASCII diagram type: ${diagram}`);
 }
 
 function normalizeDiagramFamilyCapability(

--- a/platforms/web/src/index.ts
+++ b/platforms/web/src/index.ts
@@ -219,6 +219,7 @@ export const SUPPORTED_ASCII_DIAGRAMS = [
   "timeline",
   "treeView",
   "xychart",
+  "zenuml",
 ] as const;
 
 export type AsciiDiagramType = (typeof SUPPORTED_ASCII_DIAGRAMS)[number];

--- a/playground/src/components/ExampleGallery.tsx
+++ b/playground/src/components/ExampleGallery.tsx
@@ -1,11 +1,13 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { categories, getExamplesByCategory } from "@/src/lib/examples";
+import { useAsciiSupport } from "@/src/lib/ascii-capabilities";
+import { detectDiagramType } from "@/src/lib/diagram-detection";
 import { useAppStore } from "@/src/store";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { X, Code, ChevronRight } from "lucide-react";
+import { X, Code, ChevronRight, Terminal } from "lucide-react";
 
 // 分类翻译映射
 const categoryKeys: Record<string, string> = {
@@ -33,17 +35,27 @@ const categoryKeys: Record<string, string> = {
   Sankey: "examples.categories.sankey",
   Radar: "examples.categories.radar",
   Treemap: "examples.categories.treemap",
+  TreeView: "examples.categories.treeview",
   Requirement: "examples.categories.requirement",
 };
 
 export function ExampleGallery() {
   const { t } = useTranslation();
   const { showExamples, toggleExamples, setCode } = useAppStore();
+  const asciiSupport = useAsciiSupport();
   const [selectedCategory, setSelectedCategory] = useState("All");
+  const [asciiOnly, setAsciiOnly] = useState(false);
+
+  const filteredExamples = useMemo(
+    () =>
+      getExamplesByCategory(selectedCategory).filter(
+        (example) =>
+          !asciiOnly || asciiSupport.isSupported(detectDiagramType(example.code))
+      ),
+    [asciiOnly, asciiSupport, selectedCategory]
+  );
 
   if (!showExamples) return null;
-
-  const filteredExamples = getExamplesByCategory(selectedCategory);
 
   const handleSelectExample = (code: string) => {
     setCode(code);
@@ -73,7 +85,28 @@ export function ExampleGallery() {
       <div className="flex-1 flex flex-col overflow-hidden md:flex-row">
         {/* 左侧分类 */}
         <div className="scrollbar-thin shrink-0 overflow-x-auto border-b p-2 md:w-48 md:overflow-y-auto md:border-b-0 md:border-r">
+          <Button
+            variant={asciiOnly ? "secondary" : "ghost"}
+            size="sm"
+            onClick={() => setAsciiOnly((value) => !value)}
+            className="mb-2 hidden w-full justify-start gap-2 md:flex"
+          >
+            <Terminal className="size-4" />
+            <span>{t("examples.asciiOnly")}</span>
+          </Button>
           <nav className="flex gap-1 md:block md:space-y-1">
+            <button
+              onClick={() => setAsciiOnly((value) => !value)}
+              className={cn(
+                "flex shrink-0 items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors md:hidden",
+                asciiOnly
+                  ? "bg-secondary text-secondary-foreground"
+                  : "text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+              )}
+            >
+              <Terminal className="size-4 flex-shrink-0" />
+              <span>{t("examples.asciiOnly")}</span>
+            </button>
             {categories.map((category) => (
               <button
                 key={category}

--- a/playground/src/components/Preview.tsx
+++ b/playground/src/components/Preview.tsx
@@ -11,6 +11,8 @@ import {
   mermanRuntimeErrorI18nKey,
   useMerman,
 } from "@/src/hooks/useMerman";
+import { useAsciiSupport } from "@/src/lib/ascii-capabilities";
+import { detectDiagramType } from "@/src/lib/diagram-detection";
 import { prewarmWasmRenderer } from "@/src/lib/wasm-loader";
 import { useAppStore } from "@/src/store";
 import {
@@ -77,8 +79,6 @@ interface DiagnosticArtifact {
   elapsedMs: number | null;
 }
 
-const ASCII_SUPPORTED_TYPES = ["flowchart", "sequence", "class", "er", "xychart"];
-
 const EMPTY_DIAGNOSTICS: Record<DiagnosticKey, DiagnosticArtifact> = {
   parse: { json: null, error: null, elapsedMs: null },
   layout: { json: null, error: null, elapsedMs: null },
@@ -98,6 +98,7 @@ export function Preview({ className }: PreviewProps) {
     isDarkMode,
   } = useAppStore();
   const { ready, loading, render, renderAscii, parseJson, layoutJson } = useMerman();
+  const asciiSupport = useAsciiSupport();
   const [svg, setSvg] = useState<string | null>(null);
   const [ascii, setAscii] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -147,37 +148,7 @@ export function Preview({ className }: PreviewProps) {
     [activeHostThemePreset, diagramFont, textMeasurementMode]
   );
 
-  const detectDiagramType = useCallback((source: string): string => {
-    const firstLine = source.trim().split("\n")[0]?.toLowerCase() || "";
-    if (firstLine.startsWith("flowchart") || firstLine.startsWith("graph")) return "flowchart";
-    if (firstLine.startsWith("sequencediagram")) return "sequence";
-    if (firstLine.startsWith("classdiagram")) return "class";
-    if (firstLine.startsWith("statediagram")) return "state";
-    if (firstLine.startsWith("erdiagram")) return "er";
-    if (firstLine.startsWith("gantt")) return "gantt";
-    if (firstLine.startsWith("pie")) return "pie";
-    if (firstLine.startsWith("mindmap")) return "mindmap";
-    if (firstLine.startsWith("gitgraph")) return "gitgraph";
-    if (firstLine.startsWith("timeline")) return "timeline";
-    if (firstLine.startsWith("journey")) return "journey";
-    if (firstLine.startsWith("info")) return "info";
-    if (firstLine.startsWith("zenuml")) return "zenuml";
-    if (firstLine.startsWith("eventmodeling")) return "eventmodeling";
-    if (firstLine.startsWith("c4")) return "c4";
-    if (firstLine.startsWith("xychart")) return "xychart";
-    if (firstLine.startsWith("architecture")) return "architecture";
-    if (firstLine.startsWith("block")) return "block";
-    if (firstLine.startsWith("packet")) return "packet";
-    if (firstLine.startsWith("kanban")) return "kanban";
-    if (firstLine.startsWith("quadrantchart")) return "quadrantchart";
-    if (firstLine.startsWith("sankey")) return "sankey";
-    if (firstLine.startsWith("radar")) return "radar";
-    if (firstLine.startsWith("treemap")) return "treemap";
-    if (firstLine.startsWith("requirementdiagram")) return "requirement";
-    return "unknown";
-  }, []);
-
-  const isAsciiSupported = ASCII_SUPPORTED_TYPES.includes(currentDiagramType);
+  const isAsciiSupported = asciiSupport.isSupported(currentDiagramType);
   const localizeMermanError = useCallback(
     (message: string | null): string | null => {
       if (!message) return null;
@@ -235,7 +206,7 @@ export function Preview({ className }: PreviewProps) {
           setMermanRenderTime(result.error ? null : result.renderTime);
           setLastRenderTime(result.renderTime);
 
-          if (ASCII_SUPPORTED_TYPES.includes(diagramType)) {
+          if (asciiSupport.isSupported(diagramType)) {
             setAscii(renderAscii(code, diagramTheme, mermaidConfig));
           } else {
             setAscii(null);
@@ -258,7 +229,7 @@ export function Preview({ className }: PreviewProps) {
   }, [
     code,
     activeHostThemePreset,
-    detectDiagramType,
+    asciiSupport,
     diagramTheme,
     localizeMermanError,
     mermaidConfig,

--- a/playground/src/components/Toolbar.tsx
+++ b/playground/src/components/Toolbar.tsx
@@ -19,8 +19,8 @@ import {
   exportASCII,
   copySVGToClipboard,
   copyCodeToClipboard,
-  isAsciiSupported,
 } from "@/src/lib/export";
+import { useAsciiSupport } from "@/src/lib/ascii-capabilities";
 import { useMerman } from "@/src/hooks/useMerman";
 import { BenchDialog } from "@/src/components/BenchDialog";
 import { languages, changeLanguage, getCurrentLanguage } from "@/src/i18n";
@@ -104,6 +104,7 @@ export function Toolbar() {
   } = useAppStore();
   const { copyShareUrl } = useShare();
   const { render, renderAscii, getThemes } = useMerman();
+  const asciiSupport = useAsciiSupport();
   const [isExporting, setIsExporting] = useState(false);
   const currentLang = getCurrentLanguage();
 
@@ -191,7 +192,7 @@ export function Toolbar() {
 
   // 导出 ASCII
   const handleExportASCII = useCallback(() => {
-    if (!isAsciiSupported(diagramType)) {
+    if (!asciiSupport.isSupported(diagramType)) {
       toast.error(t("export.asciiNotSupported"));
       return;
     }
@@ -202,7 +203,7 @@ export function Toolbar() {
     }
     exportASCII(ascii, "merman-diagram");
     toast.success(t("export.asciiSuccess"));
-  }, [code, diagramType, diagramTheme, mermaidConfig, renderAscii, t]);
+  }, [asciiSupport, code, diagramType, diagramTheme, mermaidConfig, renderAscii, t]);
 
   // 复制代码
   const handleCopyCode = useCallback(async () => {
@@ -388,7 +389,7 @@ export function Toolbar() {
     </DropdownMenuContent>
   );
 
-  const asciiSupported = isAsciiSupported(diagramType);
+  const asciiSupported = asciiSupport.isSupported(diagramType);
 
   return (
     <>

--- a/playground/src/hooks/useMerman.ts
+++ b/playground/src/hooks/useMerman.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { DEFAULT_MERMAID_CONFIG } from "@/src/lib/mermaid-config";
+import { FALLBACK_ASCII_SUPPORTED_TYPES } from "@/src/lib/ascii-support";
 import {
   getWasm,
   isWasmLoaded,
@@ -178,7 +179,7 @@ export function useMerman() {
 
   const getAsciiSupportedDiagrams = useCallback((): string[] => {
     if (!ready || !wasmRef.current) {
-      return ['flowchart', 'sequence', 'class', 'er', 'xychart'];
+      return [...FALLBACK_ASCII_SUPPORTED_TYPES];
     }
     return wasmRef.current.get_ascii_supported_diagrams();
   }, [ready]);

--- a/playground/src/i18n/locales/en.json
+++ b/playground/src/i18n/locales/en.json
@@ -91,6 +91,7 @@
     "title": "Example Gallery",
     "description": "Select an example to load into the editor",
     "all": "All",
+    "asciiOnly": "ASCII supported",
     "lines": "lines",
     "categories": {
       "flowchart": "Flowchart",
@@ -116,6 +117,7 @@
       "sankey": "Sankey",
       "radar": "Radar",
       "treemap": "Treemap",
+      "treeview": "TreeView",
       "requirement": "Requirement"
     },
     "items": {
@@ -170,6 +172,7 @@
       "radar-named-values": "Named Values",
       "treemap-package-surface": "Package Surface",
       "treemap-styled-sections": "Styled Sections",
+      "treeview-package-tree": "Package Tree",
       "requirement-ffi-api": "FFI API Requirement",
       "requirement-styled-elements": "Styled Elements"
     }
@@ -320,6 +323,7 @@
     "sankey": "Sankey",
     "radar": "Radar",
     "treemap": "Treemap",
+    "treeView": "TreeView",
     "requirement": "Requirement",
     "unknown": "Unknown"
   }

--- a/playground/src/i18n/locales/zh.json
+++ b/playground/src/i18n/locales/zh.json
@@ -91,6 +91,7 @@
     "title": "示例库",
     "description": "选择一个示例加载到编辑器",
     "all": "全部",
+    "asciiOnly": "支持 ASCII",
     "lines": "行",
     "categories": {
       "flowchart": "流程图",
@@ -116,6 +117,7 @@
       "sankey": "桑基图",
       "radar": "雷达图",
       "treemap": "矩形树图",
+      "treeview": "树视图",
       "requirement": "需求图"
     },
     "items": {
@@ -170,6 +172,7 @@
       "radar-named-values": "命名值",
       "treemap-package-surface": "包结构",
       "treemap-styled-sections": "样式分区",
+      "treeview-package-tree": "包树",
       "requirement-ffi-api": "FFI API 需求",
       "requirement-styled-elements": "样式元素"
     }
@@ -320,6 +323,7 @@
     "sankey": "桑基图",
     "radar": "雷达图",
     "treemap": "矩形树图",
+    "treeView": "树视图",
     "requirement": "需求图",
     "unknown": "未知"
   }

--- a/playground/src/lib/ascii-capabilities.ts
+++ b/playground/src/lib/ascii-capabilities.ts
@@ -1,0 +1,28 @@
+import { useMemo } from "react";
+import { useMerman } from "@/src/hooks/useMerman";
+import {
+  FALLBACK_ASCII_SUPPORTED_TYPES,
+  normalizeAsciiDiagramType,
+} from "@/src/lib/ascii-support";
+
+export function useAsciiSupport() {
+  const { ready, getAsciiSupportedDiagrams } = useMerman();
+  const supportedTypes = useMemo(
+    () =>
+      ready
+        ? getAsciiSupportedDiagrams().map(normalizeAsciiDiagramType)
+        : [...FALLBACK_ASCII_SUPPORTED_TYPES],
+    [getAsciiSupportedDiagrams, ready]
+  );
+
+  const supportedTypeSet = useMemo(() => new Set(supportedTypes), [supportedTypes]);
+
+  return useMemo(
+    () => ({
+      supportedTypes,
+      isSupported: (diagramType: string) =>
+        supportedTypeSet.has(normalizeAsciiDiagramType(diagramType)),
+    }),
+    [supportedTypeSet, supportedTypes]
+  );
+}

--- a/playground/src/lib/ascii-support.ts
+++ b/playground/src/lib/ascii-support.ts
@@ -1,0 +1,17 @@
+import { SUPPORTED_ASCII_DIAGRAMS } from "@mermanjs/web";
+
+export const FALLBACK_ASCII_SUPPORTED_TYPES = SUPPORTED_ASCII_DIAGRAMS;
+
+export type AsciiSupportedType =
+  (typeof FALLBACK_ASCII_SUPPORTED_TYPES)[number];
+
+export function normalizeAsciiDiagramType(diagramType: string): string {
+  return diagramType === "gitGraph" ? "gitgraph" : diagramType;
+}
+
+export function isAsciiSupported(
+  diagramType: string,
+  supportedTypes: readonly string[] = FALLBACK_ASCII_SUPPORTED_TYPES
+): boolean {
+  return supportedTypes.includes(normalizeAsciiDiagramType(diagramType));
+}

--- a/playground/src/lib/diagram-detection.ts
+++ b/playground/src/lib/diagram-detection.ts
@@ -1,0 +1,32 @@
+export function detectDiagramType(source: string): string {
+  const firstLine = source.trim().split("\n")[0]?.toLowerCase() || "";
+  if (firstLine.startsWith("flowchart") || firstLine.startsWith("graph")) {
+    return "flowchart";
+  }
+  if (firstLine.startsWith("sequencediagram")) return "sequence";
+  if (firstLine.startsWith("classdiagram")) return "class";
+  if (firstLine.startsWith("statediagram")) return "state";
+  if (firstLine.startsWith("erdiagram")) return "er";
+  if (firstLine.startsWith("gantt")) return "gantt";
+  if (firstLine.startsWith("pie")) return "pie";
+  if (firstLine.startsWith("mindmap")) return "mindmap";
+  if (firstLine.startsWith("gitgraph")) return "gitgraph";
+  if (firstLine.startsWith("timeline")) return "timeline";
+  if (firstLine.startsWith("journey")) return "journey";
+  if (firstLine.startsWith("info")) return "info";
+  if (firstLine.startsWith("zenuml")) return "zenuml";
+  if (firstLine.startsWith("eventmodeling")) return "eventmodeling";
+  if (firstLine.startsWith("c4")) return "c4";
+  if (firstLine.startsWith("xychart")) return "xychart";
+  if (firstLine.startsWith("architecture")) return "architecture";
+  if (firstLine.startsWith("block")) return "block";
+  if (firstLine.startsWith("packet")) return "packet";
+  if (firstLine.startsWith("kanban")) return "kanban";
+  if (firstLine.startsWith("quadrantchart")) return "quadrantchart";
+  if (firstLine.startsWith("sankey")) return "sankey";
+  if (firstLine.startsWith("radar")) return "radar";
+  if (firstLine.startsWith("treemap")) return "treemap";
+  if (firstLine.startsWith("treeview-beta")) return "treeView";
+  if (firstLine.startsWith("requirementdiagram")) return "requirement";
+  return "unknown";
+}

--- a/playground/src/lib/examples.ts
+++ b/playground/src/lib/examples.ts
@@ -760,6 +760,21 @@ export const examples: Example[] = [
 classDef hot fill:#fecaca,color:#7f1d1d,stroke:#f87171;`,
   },
   {
+    id: "treeview-package-tree",
+    name: "Package Tree",
+    category: "TreeView",
+    code: `treeView-beta
+    "packages"
+        "merman"
+            "src"
+        "merman-core"
+            "src"
+        "merman-ascii"
+            "src"
+        "web"
+            "src"`,
+  },
+  {
     id: "requirement-ffi-api",
     name: "FFI API Requirement",
     category: "Requirement",

--- a/playground/src/lib/export.ts
+++ b/playground/src/lib/export.ts
@@ -1,26 +1,6 @@
 import { normalizeSvgDimensions } from "@/src/lib/svg-geometry";
 
 /**
- * 支持 ASCII 导出的图表类型
- */
-export const ASCII_SUPPORTED_TYPES = [
-  'flowchart',
-  'sequence',
-  'class',
-  'er',
-  'xychart',
-] as const;
-
-export type AsciiSupportedType = (typeof ASCII_SUPPORTED_TYPES)[number];
-
-/**
- * 检查图表类型是否支持 ASCII 导出
- */
-export function isAsciiSupported(diagramType: string): boolean {
-  return ASCII_SUPPORTED_TYPES.includes(diagramType as AsciiSupportedType);
-}
-
-/**
  * 导出 SVG 文件
  */
 export function exportSVG(svg: string, filename: string = 'diagram'): void {


### PR DESCRIPTION
## Summary
Playground and binding surfaces now share the current ASCII capability list instead of relying on stale hard-coded checks. That keeps the editor, ASCII export gate, and example filtering aligned with what the runtime actually supports.

## Validation
- `cargo fmt --all`
- `cargo nextest run -p merman-bindings-core --features ascii ascii_supported_diagrams_reflects_feature_surface`
- `cargo nextest run -p merman-ffi metadata_entry_points_return_json_arrays c_consumer_smoke`
- `cargo nextest run -p merman-uniffi engine_exposes_metadata`
- `npm run build:ts` in `platforms/web`
- `npm run smoke` in `platforms/web`
- `npm run build` in `playground`
- `npm run lint` in `playground` (one existing warning remains in `BenchDialog.tsx`)