### PR TITLE
fix(render): remove stale root pins and stabilize railroad lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on *Keep a Changelog*, and this project adheres to *Semantic
 
 ### Fixes and polish
 
+- Removed 37 obsolete fixture-scoped root viewport pins and tightened the no-growth guard to the 183-entry Mermaid 11.16 inventory.
 - Fixed Mermaid 11.16 edge cases in TreeView annotation boundaries, 14px built-in icons, and highlight bounds; Cynefin inline syntax, frontmatter titles, and global fonts; Architecture reserved IDs; exact Railroad ABNF overflow diagnostics; and generated XYChart axis defaults. #21
 - Hardened upstream SVG maintenance so full-family generation removes obsolete fixture baselines transactionally, compare/audit readers cannot race shared Mermaid CLI installs, and root-override audits consume root attributes captured from the locked compare generation. #21
 - Unified fixture importer reject/defer rollback handling so all import sources restore the same transaction state after a failed baseline or deferred-fixture operation. #21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ The format is based on *Keep a Changelog*, and this project adheres to *Semantic
 
 ### Fixes and polish
 
-- Removed 37 obsolete fixture-scoped root viewport pins and tightened the no-growth guard to the 183-entry Mermaid 11.16 inventory.
-- Kept centered Railroad choice branches straight when equivalent lane coordinates differ only because of floating-point addition order.
+- Removed 37 obsolete fixture-scoped root viewport pins and tightened the no-growth guard to the 183-entry Mermaid 11.16 inventory. #22
+- Kept centered Railroad choice branches straight when equivalent lane coordinates differ only because of floating-point addition order. #22
 - Fixed Mermaid 11.16 edge cases in TreeView annotation boundaries, 14px built-in icons, and highlight bounds; Cynefin inline syntax, frontmatter titles, and global fonts; Architecture reserved IDs; exact Railroad ABNF overflow diagnostics; and generated XYChart axis defaults. #21
 - Hardened upstream SVG maintenance so full-family generation removes obsolete fixture baselines transactionally, compare/audit readers cannot race shared Mermaid CLI installs, and root-override audits consume root attributes captured from the locked compare generation. #21
 - Unified fixture importer reject/defer rollback handling so all import sources restore the same transaction state after a failed baseline or deferred-fixture operation. #21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on *Keep a Changelog*, and this project adheres to *Semantic
 ### Fixes and polish
 
 - Removed 37 obsolete fixture-scoped root viewport pins and tightened the no-growth guard to the 183-entry Mermaid 11.16 inventory.
+- Kept centered Railroad choice branches straight when equivalent lane coordinates differ only because of floating-point addition order.
 - Fixed Mermaid 11.16 edge cases in TreeView annotation boundaries, 14px built-in icons, and highlight bounds; Cynefin inline syntax, frontmatter titles, and global fonts; Architecture reserved IDs; exact Railroad ABNF overflow diagnostics; and generated XYChart axis defaults. #21
 - Hardened upstream SVG maintenance so full-family generation removes obsolete fixture baselines transactionally, compare/audit readers cannot race shared Mermaid CLI installs, and root-override audits consume root attributes captured from the locked compare generation. #21
 - Unified fixture importer reject/defer rollback handling so all import sources restore the same transaction state after a failed baseline or deferred-fixture operation. #21

--- a/crates/merman-render/src/generated/c4_root_overrides_11_12_2.rs
+++ b/crates/merman-render/src/generated/c4_root_overrides_11_12_2.rs
@@ -8,66 +8,7 @@
 
 pub fn lookup_c4_root_viewport_override(diagram_id: &str) -> Option<(&'static str, &'static str)> {
     match diagram_id {
-        "link_tags_context" => Some(("0 -70 715 998", "715")),
-        "sprite_empty_person" => Some(("0 -70 881 470", "881")),
-        "sprite_positional_boundary" => Some(("0 -70 981 624", "981")),
-        "sprite_positional_componentdb_ext" => Some(("0 -70 832 489", "832")),
-        "sprite_positional_container" => Some(("0 -70 875 694", "875")),
-        "sprite_positional_container_ext" => Some(("0 -70 875 723", "875")),
-        "sprite_positional_containerdb_ext" => Some(("0 -70 875 489", "875")),
-        "sprite_positional_containerqueue_ext" => Some(("0 -70 876 489", "876")),
-        "sprite_positional_person" => Some(("0 -70 881 518", "881")),
-        "sprite_positional_person_ext" => Some(("0 -70 881 518", "881")),
-        "sprite_positional_system" => Some(("0 -70 881 656", "881")),
-        "sprite_positional_system_ext" => Some(("0 -70 881 704", "881")),
-        "sprite_positional_systemdb_ext" => Some(("0 -70 881 470", "881")),
-        "sprite_positional_systemqueue_ext" => Some(("0 -70 881 470", "881")),
-        "tags_positional_fields" => Some(("0 -70 615 608", "615")),
-        "upstream_cypress_c4_spec_c4_1_should_render_a_simple_c4context_diagram_001" => {
-            Some(("0 -70 952 1104", "952"))
-        }
-        "upstream_cypress_c4_spec_c4_2_should_render_a_simple_c4container_diagram_002" => {
-            Some(("0 -70 919 1017", "919"))
-        }
-        "upstream_cypress_c4_spec_c4_3_should_render_a_simple_c4component_diagram_003" => {
-            Some(("0 -70 820 802", "820"))
-        }
-        "upstream_cypress_c4_spec_c4_4_should_render_a_simple_c4dynamic_diagram_004" => {
-            Some(("0 -70 866 1212", "866"))
-        }
-        "upstream_cypress_c4_spec_c4_5_should_render_a_simple_c4deployment_diagram_005" => {
-            Some(("0 -70 1791 759", "1791"))
-        }
-        "upstream_docs_c4_c4_component_diagram_c4component_008" => Some(("0 -70 926 2013", "926")),
-        "upstream_docs_c4_c4_container_diagram_c4container_006" => {
-            Some(("0 -70 1023 2023", "1023"))
-        }
-        "upstream_docs_c4_c4_deployment_diagram_c4deployment_012" => {
-            Some(("0 -70 1982 1709", "1982"))
-        }
-        "upstream_docs_c4_c4_diagrams_001" => Some(("0 -70 1059 2985", "1059")),
-        "upstream_docs_c4_c4_dynamic_diagram_c4dynamic_010" => Some(("0 -70 866 1212", "866")),
-        "upstream_docs_readme_c4_diagram_a_href_https_mermaid_js_org_syntax_c4_html_docs_a_019" => {
-            Some(("0 -70 1328 2346", "1328"))
-        }
-        "upstream_examples_c4_internet_banking_system_context_001" => {
-            Some(("0 -70 1488 2483", "1488"))
-        }
-        "upstream_html_demos_c4context_c4_context_diagram_demos_001" => {
-            Some(("0 -70 1059 2985", "1059"))
-        }
-        "upstream_html_demos_c4context_c4_context_diagram_demos_002" => {
-            Some(("0 -70 1023 2023", "1023"))
-        }
-        "upstream_html_demos_c4context_c4_context_diagram_demos_003" => {
-            Some(("0 -70 926 2013", "926"))
-        }
-        "upstream_html_demos_c4context_c4_context_diagram_demos_005" => {
-            Some(("0 -70 1982 1709", "1982"))
-        }
-        "upstream_pkgtests_c4person_spec_001" => Some(("0 -70 653 470", "653")),
         "upstream_pkgtests_c4person_spec_004" => Some(("0 -10 653 393", "653")),
-        "upstream_pkgtests_c4personext_spec_001" => Some(("0 -70 653 470", "653")),
         "upstream_pkgtests_c4personext_spec_004" => Some(("0 -10 653 393", "653")),
         _ => None,
     }

--- a/crates/merman-render/src/generated/flowchart_root_overrides_11_12_2.rs
+++ b/crates/merman-render/src/generated/flowchart_root_overrides_11_12_2.rs
@@ -59,12 +59,8 @@ pub fn lookup_flowchart_root_viewport_override(
         | "upstream_html_demos_flowchart_flowchart_049" => {
             Some(("0 0 2007.41015625 1046", "2007.41"))
         }
-        "upstream_cypress_flowchart_icon_spec_example_002" => Some(("0 0 98.046875 70", "98.0469")),
         "upstream_cypress_flowchart_icon_spec_should_render_aws_icons_with_labels_and_rect_elements_005" => {
             Some(("0 0 104.6875 368", "104.688"))
-        }
-        "upstream_cypress_flowchart_shape_alias_spec_shape_alias_aliasset34_034" => {
-            Some(("0 0 609.140625 80", "609.141"))
         }
         "upstream_cypress_flowchart_spec_12_should_render_a_flowchart_with_long_names_and_class_definitio_012" => {
             Some(("0 0 1896.984375 452", "1896.98"))

--- a/crates/merman-render/src/generated/state_root_overrides_11_12_2.rs
+++ b/crates/merman-render/src/generated/state_root_overrides_11_12_2.rs
@@ -13,7 +13,6 @@ pub fn lookup_state_root_viewport_override(
         "stress_state_frontmatter_accessibility_012" => {
             Some(("-86.8125 -50 233.875 324", "233.875"))
         }
-        "stress_state_long_descriptions_and_aliases_006" => Some(("0 0 513.890625 541", "513.891")),
         "stress_state_three_way_concurrency_013" => Some(("0 0 573.27734375 1657", "573.277")),
         "stress_state_quoted_multiline_names_015" => {
             Some(("0 0 430.5703125 644.0999755859375", "430.57"))

--- a/crates/merman-render/src/generated/timeline_root_overrides_11_12_2.rs
+++ b/crates/merman-render/src/generated/timeline_root_overrides_11_12_2.rs
@@ -25,7 +25,6 @@ pub fn lookup_timeline_root_viewport_override(
         "timeline_stress_font_size_precedence" => {
             Some(("-5 -77 1228.375 530.3999938964844", "1228.38"))
         }
-        "timeline_stress_unicode_cjk_and_emoji" => Some(("95 -61 995 629.5999755859375", "995")),
         "timeline_stress_very_long_unbroken_word" => {
             Some(("-107.984375 -61 1516.3203125 594.3999938964844", "1516.32"))
         }

--- a/crates/merman-render/src/railroad.rs
+++ b/crates/merman-render/src/railroad.rs
@@ -693,8 +693,9 @@ fn layout_choice(
         let elem_y = y;
         let elem_center_y = elem_y + child.up;
         let elem_x = arc_radius * 2.0 + (max_width - child.width) / 2.0;
-        let below_center = elem_center_y > center_y;
-        let left_path = if (elem_center_y - center_y).abs() < f64::EPSILON {
+        let is_center = same_layout_coordinate(elem_center_y, center_y);
+        let below_center = !is_center && elem_center_y > center_y;
+        let left_path = if is_center {
             PathBuilder::new()
                 .move_to(0.0, center_y)
                 .line_to(elem_x, elem_center_y)
@@ -742,7 +743,7 @@ fn layout_choice(
 
         let right_start = elem_x + child.width;
         let right_lane_x = total_width - arc_radius * 2.0;
-        let right_path = if (elem_center_y - center_y).abs() < f64::EPSILON {
+        let right_path = if is_center {
             PathBuilder::new()
                 .move_to(right_start, elem_center_y)
                 .line_to(total_width, center_y)
@@ -803,6 +804,11 @@ fn layout_choice(
     }
 
     out
+}
+
+fn same_layout_coordinate(left: f64, right: f64) -> bool {
+    // Distinct addition orders can drift while still producing the same emitted coordinate.
+    left.is_finite() && right.is_finite() && fmt_number(left) == fmt_number(right)
 }
 
 fn layout_optional(
@@ -1172,7 +1178,11 @@ fn fmt_number(value: f64) -> String {
     if !value.is_finite() || value.abs() < 0.0005 {
         return "0".to_string();
     }
-    let mut rounded = (value * 1000.0).round() / 1000.0;
+    let mut rounded = if value.abs() <= f64::MAX / 1000.0 {
+        (value * 1000.0).round() / 1000.0
+    } else {
+        value
+    };
     if rounded.abs() < 0.0005 {
         rounded = 0.0;
     }
@@ -1190,6 +1200,7 @@ fn fmt_number(value: f64) -> String {
 mod tests {
     use super::*;
     use crate::text::{DeterministicTextMeasurer, TextMetrics};
+    use roughr::{PathParser, PathSegment};
 
     struct RailroadBBoxMeasurer;
 
@@ -1213,6 +1224,88 @@ mod tests {
         fn measure_svg_simple_text_bbox_height_px(&self, _text: &str, style: &TextStyle) -> f64 {
             style.font_size * 1.1
         }
+    }
+
+    fn choice_branch_connector_paths(
+        source: &str,
+        effective_config: &serde_json::Value,
+        branch_label: &str,
+    ) -> (String, String) {
+        let parsed = merman_core::Engine::new()
+            .parse_diagram_for_render_model_sync(source, merman_core::ParseOptions::strict())
+            .unwrap()
+            .expect("railroad render model parses");
+        let merman_core::RenderSemanticModel::Railroad(model) = parsed.model else {
+            panic!("expected railroad render model");
+        };
+
+        let style = railroad_style(effective_config);
+        let (render_node, _) = railroad_render_node(
+            &model.rules[0].definition,
+            &style,
+            &DeterministicTextMeasurer::default(),
+        );
+        let RailroadRenderNode::Group {
+            class, children, ..
+        } = render_node
+        else {
+            panic!("expected railroad choice render group");
+        };
+        assert_eq!(class, "railroad-choice");
+        let mut branches = children.chunks_exact(3);
+        assert!(
+            branches.remainder().is_empty(),
+            "choice render children must be branch/left-path/right-path triples"
+        );
+        let mut matching_branches = branches.by_ref().filter_map(|branch| {
+            let [
+                branch,
+                RailroadRenderNode::Path(left_path),
+                RailroadRenderNode::Path(right_path),
+            ] = branch
+            else {
+                panic!("choice render children must be branch/left-path/right-path triples");
+            };
+            matches!(
+                branch,
+                RailroadRenderNode::Element { layout, .. } if layout.label == branch_label
+            )
+            .then_some((left_path, right_path))
+        });
+        let (left_path, right_path) = matching_branches
+            .next()
+            .unwrap_or_else(|| panic!("choice branch render node: {branch_label}"));
+        assert!(
+            matching_branches.next().is_none(),
+            "choice branch label must be unique: {branch_label}"
+        );
+
+        (left_path.d.clone(), right_path.d.clone())
+    }
+
+    fn connector_segments(path: &str) -> Vec<PathSegment> {
+        PathParser::from(path)
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap_or_else(|error| panic!("valid connector path {path:?}: {error}"))
+    }
+
+    fn assert_straight_connector(path: &str) {
+        assert!(
+            matches!(
+                connector_segments(path).as_slice(),
+                [PathSegment::MoveTo { .. }, PathSegment::LineTo { .. }]
+            ),
+            "expected a straight connector: {path}"
+        );
+    }
+
+    fn assert_curved_connector(path: &str) {
+        assert!(
+            connector_segments(path)
+                .iter()
+                .any(|segment| matches!(segment, PathSegment::EllipticalArc { .. })),
+            "expected an arc connector: {path}"
+        );
     }
 
     #[test]
@@ -1258,6 +1351,49 @@ mod tests {
             serde_json::to_value(&ebnf_layout).unwrap()["diagram_type"],
             "railroadEbnf"
         );
+    }
+
+    #[test]
+    fn railroad_choice_keeps_center_branch_connectors_straight() {
+        let effective_config = serde_json::json!({
+            "themeVariables": { "fontSize": 16 }
+        });
+        let source = "railroad-ebnf-beta\nx = a | b | c | number | e | f | g ;\n";
+        let (left_path, right_path) =
+            choice_branch_connector_paths(source, &effective_config, "number");
+
+        assert_straight_connector(&left_path);
+        assert_straight_connector(&right_path);
+
+        let (upper_left_path, upper_right_path) =
+            choice_branch_connector_paths(source, &effective_config, "a");
+        assert_curved_connector(&upper_left_path);
+        assert_curved_connector(&upper_right_path);
+    }
+
+    #[test]
+    fn railroad_lane_coordinate_equality_matches_path_serialization() {
+        assert!(same_layout_coordinate(56.5004, 56.50049));
+        assert!(!same_layout_coordinate(56.5004, 56.5006));
+        assert!(!same_layout_coordinate(f64::INFINITY, f64::INFINITY));
+        assert!(!same_layout_coordinate(f64::NAN, f64::NAN));
+        assert_ne!(fmt_number(f64::MAX), "inf");
+    }
+
+    #[test]
+    fn railroad_choice_keeps_center_branch_connectors_straight_with_fractional_spacing() {
+        let effective_config = serde_json::json!({
+            "themeVariables": { "fontSize": 16 },
+            "railroad": { "verticalSeparation": 0.1 }
+        });
+        let (left_path, right_path) = choice_branch_connector_paths(
+            "railroad-ebnf-beta\nx = a | b | c ;\n",
+            &effective_config,
+            "b",
+        );
+
+        assert_straight_connector(&left_path);
+        assert_straight_connector(&right_path);
     }
 
     #[test]

--- a/crates/xtask/src/cmd/overrides/report.rs
+++ b/crates/xtask/src/cmd/overrides/report.rs
@@ -61,7 +61,7 @@ impl OverrideCategory {
 
     fn no_growth_budget(self) -> usize {
         match self {
-            OverrideCategory::RootViewport => 308,
+            OverrideCategory::RootViewport => 183,
             OverrideCategory::TextLookup => 689,
             OverrideCategory::SvgTextMetrics => 1036,
             OverrideCategory::FontMetrics => 3774,
@@ -1017,7 +1017,7 @@ pub fn lookup_c4_text_width_px(
         let err = check_override_no_growth(&entries).expect_err("growth should fail");
         let msg = err.to_string();
         assert!(msg.contains("Root viewport overrides grew"));
-        assert!(msg.contains("budget 308"));
+        assert!(msg.contains("budget 183"));
     }
 
     #[test]

--- a/docs/alignment/ROOT_VIEWPORT_OVERRIDES.md
+++ b/docs/alignment/ROOT_VIEWPORT_OVERRIDES.md
@@ -105,6 +105,12 @@ cargo run -p xtask -- compare-all-svgs --check-dom --dom-mode parity-root --dom-
 - Do not add broad/global constants that affect unrelated diagrams.
 - Store exact upstream strings for `viewBox`/`max-width` to avoid re-rounding drift.
 - Prefer real layout/render parity fixes first; use overrides for remaining deterministic gaps.
+- Before deleting a pin, capture a disabled-root audit for the affected families without
+  `--fail-on-stale`, using explicit, distinct pre-delete `--out` and `--report-dir` paths. Remove
+  only its stale candidates, then capture a post-delete audit with distinct paths and
+  `--fail-on-stale`; require zero stale entries and runner issues. Compare the exact outside-table
+  mismatch key set between the two reports; `--fail-on-stale` does not admit or hide those
+  independent mismatches.
 
 ## Current Status
 

--- a/docs/alignment/STATUS.md
+++ b/docs/alignment/STATUS.md
@@ -192,6 +192,12 @@ Railroad entries have matching descendants and differ only in browser-derived ro
 height, so they are now admitted by family-, fixture-, marker-, and value-locked policies. The
 policy inventory is therefore 9 exact records; the other 756 observed residuals remain actionable.
 
+Recent progress (2026-07-12): a disabled-root audit proved that 37 fixture-scoped root viewport
+pins were obsolete and removed them: C4 33, Flowchart 2, State 1, and Timeline 1. The generated
+inventory is now 183 entries (C4 2, Flowchart 36, State 32, Timeline 7 for the affected tables).
+The audit preserved the exact 130 outside-table mismatch keys across those four families; this
+cleanup did not add root pins, comparator normalization, or residual-policy records.
+
 Recent progress (2026-02-16): imported an additional batch of Architecture stress fixtures (with upstream SVG
 baselines), expanding coverage for cross-group edges, labeled ports, icon-text fallbacks, and long edge label
 wrapping. Added Architecture root viewport overrides for the new fixture IDs and hardened one edge-label wrap

--- a/docs/workstreams/fearless-refactor/OVERRIDE_FOOTPRINT.md
+++ b/docs/workstreams/fearless-refactor/OVERRIDE_FOOTPRINT.md
@@ -5,6 +5,40 @@ fearless refactor work. Overrides are useful when upstream behavior depends on b
 measurement or a temporary raw SVG/path compatibility bridge, but new model fixes should be
 preferred when the mismatch comes from our own data or geometry.
 
+## Snapshot: 2026-07-12
+
+Commands:
+
+`cargo run -p xtask -- report-overrides --check-no-growth`
+
+`cargo run -p xtask -- audit-root-overrides --diagram c4 --diagram flowchart --diagram state --diagram timeline --fail-on-stale`
+
+Mermaid baseline: `@11.16.0`.
+
+Generated override modules scanned: `21`.
+
+### Root Viewport Overrides
+
+Total entries reported by `xtask`: `183`.
+
+| file | entries |
+| --- | ---: |
+| `c4_root_overrides_11_12_2.rs` | 2 |
+| `er_root_overrides_11_12_2.rs` | 6 |
+| `eventmodeling_root_overrides_11_15_0.rs` | 9 |
+| `flowchart_root_overrides_11_12_2.rs` | 36 |
+| `mindmap_root_overrides_11_12_2.rs` | 30 |
+| `pie_root_overrides_11_12_2.rs` | 58 |
+| `sankey_root_overrides_11_12_2.rs` | 3 |
+| `state_root_overrides_11_12_2.rs` | 32 |
+| `timeline_root_overrides_11_12_2.rs` | 7 |
+
+The targeted disabled-root audit removed 37 stale entries (C4 33, Flowchart 2, State 1, and
+Timeline 1). Its post-delete inventory contained 77 entries spanning 83 fixture keys across the
+affected tables, reported zero stale entries and runner issues, and preserved the exact 130
+outside-table mismatch keys. The audit reports under `target/compare/` are uncommitted execution
+evidence.
+
 ## Snapshot: 2026-06-06
 
 Command:

--- a/docs/workstreams/fearless-refactor/STATUS.md
+++ b/docs/workstreams/fearless-refactor/STATUS.md
@@ -20,12 +20,11 @@ What is done:
 - M4 large renderer decomposition is effectively complete.
 - Render numeric config parsing is centralized in `crates/merman-render/src/config.rs`; diagram
   modules no longer carry local `json_f64` / `config_f64` / CSS `px` parser copies.
-- Root viewport override no-growth is now `308` according to
-  `cargo run -p xtask -- report-overrides --check-no-growth`. The root-viewport derivation
-  workstream removed additional generated pins through the ER cleanup series, while later
-  EventModeling admission added 9 reviewed root guards for browser `getBBox()` max-width tails.
-  A current family-local check passes with those guards enabled and reproduces the 9 root-only
-  mismatches with root overrides disabled.
+- Root viewport override no-growth is now `183` according to
+  `cargo run -p xtask -- report-overrides --check-no-growth`. A 2026-07-12 disabled-root audit
+  removed 37 stale generated pins from C4, Flowchart, State, and Timeline, while retaining the
+  77 entries that still guard root drift. The exact 130 outside-table mismatch keys in those four
+  families stayed unchanged and remain separate parity work rather than override evidence.
 - Sequence layout has been split down to focused actor, activation, block-step, block-bounds,
   note, message, rect, root-bounds, and orchestration owners.
 - `cargo run -p xtask -- verify --strict` passes; the latest closeout run covered workspace
@@ -33,12 +32,8 @@ What is done:
   explicit nine-residual policy.
 - `cargo run -p xtask -- verify --strict` includes full `parity-root` coverage.
 - `cargo run -p xtask -- report-overrides --check-no-growth` passes.
-- A disabled-root cross-check after numeric config parser centralization found no newly stale root
-  viewport pins across generated root tables, so current root debt remains retained evidence rather
-  than cleanup-by-count work.
-- The latest root closeout keeps generated root pins stale-free and locks the nine accepted
-  outside-table root residuals to exact fixture/value pairs, so changed or additional residuals
-  fail the strict gate.
+- The latest targeted disabled-root audit keeps the affected generated root pins stale-free and
+  preserves the outside-table key set without widening comparator or residual policy.
 - `cargo bench -p merman --features render` has a fresh post-cleanup release gate record in
   `docs/performance/spotcheck_2026-05-14_flowchart_override_inventory_full_bench_gate.md`.
 - Root `CHANGELOG.md` now calls out the refactor release-readiness work.
@@ -65,9 +60,9 @@ It is mostly evidence-driven debt reduction:
 
 Largest remaining buckets:
 
-- root viewport: `pie` 58, `sequence` 49, `flowchart` 38, `mindmap` 39, `c4` 35, `state` 33,
-  `gitgraph` 23, `eventmodeling` 9, `timeline` 8, `requirement` 7, `er` 6, `sankey` 3
-- text lookup: `class` 277, `block` 123, `flowchart` 45, `state` 29, `er` 9
+- root viewport: `pie` 58, `flowchart` 36, `state` 32, `mindmap` 30, `eventmodeling` 9,
+  `timeline` 7, `er` 6, `sankey` 3, `c4` 2
+- text lookup: `class` 269, `c4` 201, `block` 120, `flowchart` 50, `state` 27, `er` 9
 
 ## Next Practical Slices
 


### PR DESCRIPTION
## Summary

Mermaid 11.16 parity no longer depends on 37 obsolete fixture-scoped root viewport pins across C4, Flowchart, State, and Timeline. Centered Railroad choice branches also stay straight when floating-point accumulation reaches the same emitted SVG coordinate through different addition orders.

## What changed

- Removed the 37 stale root overrides and lowered the no-growth inventory from 220 to 183 entries.
- Kept the 130 affected-family mismatch keys outside the removed tables unchanged, so this cleanup does not hide newly introduced parity differences.
- Documented the pre-delete and post-delete audit evidence and synchronized the alignment and fearless-refactor status records.
- Classified Railroad lanes using the same three-decimal coordinate representation emitted into path data, while rejecting non-finite coordinates and keeping large finite values out of the rounding overflow path.
- Added regression coverage for default and fractional Railroad spacing, non-center arc connectors, serializer boundaries, and malformed test assumptions.

## Verification

- [x] `cargo fmt --all --check`
- [x] Relevant tests ran: 14 Railroad tests and 19 override-report tests passed
- [x] Override inventory, disabled-root audit, affected-family DOM parity, and focused root parity reports were refreshed and checked

## Performance / parity notes

- Benchmark or report: `report-overrides --check-no-growth` accepts the 183-entry inventory; the disabled-root audit reports zero stale overrides and zero runner issues.
- Parity impact: complete C4, Flowchart, State, Timeline, and Railroad DOM parity checks pass; the 130 outside-table mismatch keys are unchanged.
- Rollback risk: low. Root pins can be restored independently if an environment-specific viewport regression appears; Railroad behavior changes only when two finite layout coordinates serialize identically.

## Follow-ups

- Add source-backed TreeView Iconify pack rendering in a separate PR.
- Replace Railroad repeat-bound sentinel encoding with an explicit bound model in a separate PR.
