### PR TITLE
fix(render): render TreeView Iconify bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on *Keep a Changelog*, and this project adheres to *Semantic
 
 ### Fixes and polish
 
-- TreeView now embeds configured Iconify pack bodies at Mermaid's 14px size and shows the standard unknown icon for missing packs or entries.
+- TreeView now embeds configured Iconify pack bodies at Mermaid's 14px size and shows the standard unknown icon for missing packs or entries. #23
 - Removed 37 obsolete fixture-scoped root viewport pins and tightened the no-growth guard to the 183-entry Mermaid 11.16 inventory. #22
 - Kept centered Railroad choice branches straight when equivalent lane coordinates differ only because of floating-point addition order. #22
 - Fixed Mermaid 11.16 edge cases in TreeView annotation boundaries, 14px built-in icons, and highlight bounds; Cynefin inline syntax, frontmatter titles, and global fonts; Architecture reserved IDs; exact Railroad ABNF overflow diagnostics; and generated XYChart axis defaults. #21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on *Keep a Changelog*, and this project adheres to *Semantic
 
 ### Fixes and polish
 
+- TreeView now embeds configured Iconify pack bodies at Mermaid's 14px size and shows the standard unknown icon for missing packs or entries.
 - Removed 37 obsolete fixture-scoped root viewport pins and tightened the no-growth guard to the 183-entry Mermaid 11.16 inventory. #22
 - Kept centered Railroad choice branches straight when equivalent lane coordinates differ only because of floating-point addition order. #22
 - Fixed Mermaid 11.16 edge cases in TreeView annotation boundaries, 14px built-in icons, and highlight bounds; Cynefin inline syntax, frontmatter titles, and global fonts; Architecture reserved IDs; exact Railroad ABNF overflow diagnostics; and generated XYChart axis defaults. #21

--- a/crates/merman-cli/README.md
+++ b/crates/merman-cli/README.md
@@ -114,8 +114,8 @@ Markdown mode does not support stdout output because it may need to write multip
 
 ## Icon Packs
 
-Iconify packs are loaded into a Rust SVG icon registry, so flowchart and architecture icon nodes can
-embed real icon SVGs without a browser.
+Iconify packs are loaded into a Rust SVG icon registry, so Flowchart, Architecture, and TreeView
+nodes can embed real icon SVGs without a browser.
 
 Load an Iconify package name:
 

--- a/crates/merman-cli/tests/cli_compat.rs
+++ b/crates/merman-cli/tests/cli_compat.rs
@@ -1685,6 +1685,47 @@ fn dynamic_icon_pack_url_file_renders_flowchart_icon() {
 }
 
 #[test]
+fn dynamic_icon_pack_url_file_renders_tree_view_icon() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let icons = tmp.path().join("icons.json");
+    fs::write(
+        &icons,
+        r#"{
+            "prefix": "test",
+            "left": 2,
+            "top": 3,
+            "width": 32,
+            "height": 18,
+            "icons": {
+                "rocket": {
+                    "body": "<path data-icon=\"tree-view-cli\" fill=\"currentColor\" d=\"M2 3H34V21H2z\"/>"
+                }
+            }
+        }"#,
+    )
+    .expect("write icons");
+
+    let icon_arg = format!("test#{}", icons.display());
+    let output = run_with_stdin(
+        &["-i", "-", "-o", "-", "--iconPacksNamesAndUrls", &icon_arg],
+        "treeView-beta\nRoot icon(test:rocket)\n",
+    );
+
+    assert!(output.status.success(), "stderr: {:?}", output.stderr);
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    assert!(
+        stdout.contains(
+            r#"<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="2 3 32 18"><path data-icon="tree-view-cli""#
+        ),
+        "expected a non-empty 14px TreeView icon symbol in SVG:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains(r#"<tspan x="0" y="0">?</tspan>"#),
+        "custom TreeView icon should replace the unknown icon:\n{stdout}"
+    );
+}
+
+#[test]
 fn dynamic_icon_pack_http_url_renders_flowchart_icon() {
     let url = serve_icon_json_once(
         r#"{

--- a/crates/merman-render/Cargo.toml
+++ b/crates/merman-render/Cargo.toml
@@ -47,6 +47,7 @@ ratex-parser = { workspace = true, optional = true }
 ratex-svg = { workspace = true, optional = true }
 ratex-types = { workspace = true, optional = true }
 rustc-hash.workspace = true
+roxmltree.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
@@ -57,4 +58,3 @@ unicode-width.workspace = true
 [dev-dependencies]
 futures.workspace = true
 regex.workspace = true
-roxmltree.workspace = true

--- a/crates/merman-render/src/svg/icon_registry.rs
+++ b/crates/merman-render/src/svg/icon_registry.rs
@@ -2,6 +2,17 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use serde_json::Value;
 use std::fmt::Write as _;
 
+const MERMAID_UNKNOWN_ICON_BODY: &str = r#"<g><rect width="80" height="80" style="fill: #087ebf; stroke-width: 0px;"/><text transform="translate(21.16 64.67)" style="fill: #fff; font-family: ArialMT, Arial; font-size: 67.75px;"><tspan x="0" y="0">?</tspan></text></g>"#;
+
+pub(in crate::svg) fn mermaid_unknown_icon_svg(
+    width: impl std::fmt::Display,
+    height: impl std::fmt::Display,
+) -> String {
+    format!(
+        r#"<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 80 80">{MERMAID_UNKNOWN_ICON_BODY}</svg>"#
+    )
+}
+
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum IconRegistryError {
     #[error("Iconify JSON error: {0}")]

--- a/crates/merman-render/src/svg/icon_registry.rs
+++ b/crates/merman-render/src/svg/icon_registry.rs
@@ -1,8 +1,10 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde_json::Value;
 use std::fmt::Write as _;
+use std::ops::Range;
 
 const MERMAID_UNKNOWN_ICON_BODY: &str = r#"<g><rect width="80" height="80" style="fill: #087ebf; stroke-width: 0px;"/><text transform="translate(21.16 64.67)" style="fill: #fff; font-family: ArialMT, Arial; font-size: 67.75px;"><tspan x="0" y="0">?</tspan></text></g>"#;
+const XLINK_NAMESPACE: &str = "http://www.w3.org/1999/xlink";
 
 pub(in crate::svg) fn mermaid_unknown_icon_svg(
     width: impl std::fmt::Display,
@@ -188,35 +190,323 @@ impl IconRegistry {
 }
 
 pub(in crate::svg) fn scope_svg_internal_ids(body: &str, scope: &str) -> String {
-    let ids = collect_svg_internal_ids(body);
-    if ids.is_empty() {
+    scope_svg_internal_ids_from_xml(body, scope)
+        .unwrap_or_else(|| scope_svg_internal_ids_fallback(body, scope))
+}
+
+fn scope_svg_internal_ids_from_xml(body: &str, scope: &str) -> Option<String> {
+    const WRAPPER_PREFIX: &str =
+        r#"<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">"#;
+    const WRAPPER_SUFFIX: &str = "</svg>";
+
+    let mut wrapped =
+        String::with_capacity(WRAPPER_PREFIX.len() + body.len() + WRAPPER_SUFFIX.len());
+    wrapped.push_str(WRAPPER_PREFIX);
+    wrapped.push_str(body);
+    wrapped.push_str(WRAPPER_SUFFIX);
+    let document = roxmltree::Document::parse(&wrapped).ok()?;
+
+    let prefix = deterministic_iconify_id_prefix(scope);
+    let mut id_replacements = FxHashMap::default();
+    for attribute in document
+        .descendants()
+        .filter(|node| node.is_element())
+        .flat_map(|node| node.attributes())
+        .filter(|attribute| attribute.name() == "id" && attribute.namespace().is_none())
+    {
+        let Some(range) = body_attribute_value_range(attribute, WRAPPER_PREFIX.len(), body.len())
+        else {
+            continue;
+        };
+        let id = &body[range];
+        if id.is_empty() || id_replacements.contains_key(id) {
+            continue;
+        }
+        let replacement = format!("{prefix}{}", id_replacements.len());
+        id_replacements.insert(id.to_string(), replacement);
+    }
+    if id_replacements.is_empty() {
+        return Some(body.to_string());
+    }
+
+    let mut edits = Vec::new();
+    for attribute in document
+        .descendants()
+        .filter(|node| node.is_element())
+        .flat_map(|node| node.attributes())
+    {
+        let Some(range) = body_attribute_value_range(attribute, WRAPPER_PREFIX.len(), body.len())
+        else {
+            continue;
+        };
+        let value = &body[range.clone()];
+        if let Some(rewritten) = rewrite_svg_attribute_value(attribute, value, &id_replacements) {
+            edits.push((range, rewritten));
+        }
+    }
+
+    for node in document.descendants().filter(|node| {
+        node.is_text()
+            && node
+                .parent()
+                .is_some_and(|parent| parent.has_tag_name("style"))
+    }) {
+        let range = node.range();
+        if range.start < WRAPPER_PREFIX.len() || range.end > WRAPPER_PREFIX.len() + body.len() {
+            continue;
+        }
+        let range = range.start - WRAPPER_PREFIX.len()..range.end - WRAPPER_PREFIX.len();
+        let value = &body[range.clone()];
+        if let Some(rewritten) = rewrite_url_references(value, &id_replacements) {
+            edits.push((range, rewritten));
+        }
+    }
+
+    Some(apply_string_edits(body, edits))
+}
+
+fn body_attribute_value_range(
+    attribute: roxmltree::Attribute<'_, '_>,
+    wrapper_prefix_len: usize,
+    body_len: usize,
+) -> Option<Range<usize>> {
+    let range = attribute.range_value();
+    if range.start < wrapper_prefix_len || range.end > wrapper_prefix_len + body_len {
+        return None;
+    }
+    Some(range.start - wrapper_prefix_len..range.end - wrapper_prefix_len)
+}
+
+fn rewrite_svg_attribute_value(
+    attribute: roxmltree::Attribute<'_, '_>,
+    value: &str,
+    id_replacements: &FxHashMap<String, String>,
+) -> Option<String> {
+    if let Some(namespace) = attribute.namespace() {
+        if namespace == XLINK_NAMESPACE && attribute.name() == "href" {
+            return rewrite_fragment_reference(value, id_replacements);
+        }
+        return None;
+    }
+
+    match attribute.name() {
+        "id" => id_replacements.get(value).cloned(),
+        "href" => rewrite_fragment_reference(value, id_replacements),
+        "begin" | "end" => rewrite_smil_timing_references(value, id_replacements),
+        "aria-activedescendant"
+        | "aria-controls"
+        | "aria-describedby"
+        | "aria-details"
+        | "aria-errormessage"
+        | "aria-flowto"
+        | "aria-labelledby"
+        | "aria-owns" => rewrite_idref_list(value, id_replacements),
+        "clip-path" | "color-profile" | "cursor" | "fill" | "filter" | "marker" | "marker-end"
+        | "marker-mid" | "marker-start" | "mask" | "stroke" | "style" => {
+            rewrite_url_references(value, id_replacements)
+        }
+        _ => None,
+    }
+}
+
+fn rewrite_fragment_reference(
+    value: &str,
+    id_replacements: &FxHashMap<String, String>,
+) -> Option<String> {
+    value
+        .strip_prefix('#')
+        .and_then(|id| id_replacements.get(id))
+        .map(|replacement| format!("#{replacement}"))
+}
+
+fn rewrite_idref_list(value: &str, id_replacements: &FxHashMap<String, String>) -> Option<String> {
+    let mut edits = Vec::new();
+    let mut token_start = None;
+    for (index, ch) in value
+        .char_indices()
+        .chain(std::iter::once((value.len(), ' ')))
+    {
+        if ch.is_whitespace() {
+            if let Some(start) = token_start.take()
+                && let Some(replacement) = id_replacements.get(&value[start..index])
+            {
+                edits.push((start..index, replacement.clone()));
+            }
+        } else if token_start.is_none() {
+            token_start = Some(index);
+        }
+    }
+    apply_optional_string_edits(value, edits)
+}
+
+fn rewrite_smil_timing_references(
+    value: &str,
+    id_replacements: &FxHashMap<String, String>,
+) -> Option<String> {
+    let mut edits = Vec::new();
+    let mut segment_start = 0;
+    for segment in value.split_inclusive(';') {
+        let content = segment.strip_suffix(';').unwrap_or(segment);
+        let leading = content.len() - content.trim_start().len();
+        let timing = &content[leading..];
+        let matching_id = id_replacements
+            .keys()
+            .filter(|id| {
+                timing.strip_prefix(id.as_str()).is_some_and(|rest| {
+                    rest.strip_prefix('.')
+                        .and_then(|rest| rest.chars().next())
+                        .is_some_and(|ch| ch.is_ascii_alphabetic())
+                })
+            })
+            .max_by_key(|id| id.len());
+        if let Some(id) = matching_id {
+            let start = segment_start + leading;
+            edits.push((start..start + id.len(), id_replacements[id].clone()));
+        }
+        segment_start += segment.len();
+    }
+    apply_optional_string_edits(value, edits)
+}
+
+fn rewrite_url_references(
+    value: &str,
+    id_replacements: &FxHashMap<String, String>,
+) -> Option<String> {
+    let bytes = value.as_bytes();
+    let mut edits = Vec::new();
+    let mut scan = 0;
+    while scan + 4 <= bytes.len() {
+        let Some(relative) = bytes[scan..]
+            .windows(4)
+            .position(|window| window.eq_ignore_ascii_case(b"url("))
+        else {
+            break;
+        };
+        let function_start = scan + relative;
+        let mut cursor = function_start + 4;
+        while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+            cursor += 1;
+        }
+        let quote = match bytes.get(cursor) {
+            Some(b'\'' | b'"') => {
+                let quote = bytes[cursor];
+                cursor += 1;
+                Some(quote)
+            }
+            _ => None,
+        };
+        if bytes.get(cursor) != Some(&b'#') {
+            scan = function_start + 4;
+            continue;
+        }
+        let id_start = cursor + 1;
+        let Some((id_end, function_end)) = url_reference_end(bytes, id_start, quote) else {
+            scan = function_start + 4;
+            continue;
+        };
+        if let Some(replacement) = id_replacements.get(&value[id_start..id_end]) {
+            edits.push((id_start..id_end, replacement.clone()));
+        }
+        scan = function_end;
+    }
+    apply_optional_string_edits(value, edits)
+}
+
+fn url_reference_end(bytes: &[u8], id_start: usize, quote: Option<u8>) -> Option<(usize, usize)> {
+    if let Some(quote) = quote {
+        let relative_end = bytes[id_start..].iter().position(|byte| *byte == quote)?;
+        let id_end = id_start + relative_end;
+        let mut cursor = id_end + 1;
+        while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+            cursor += 1;
+        }
+        (bytes.get(cursor) == Some(&b')')).then_some((id_end, cursor + 1))
+    } else {
+        let relative_end = bytes[id_start..].iter().position(|byte| *byte == b')')?;
+        let function_end = id_start + relative_end + 1;
+        let mut id_end = function_end - 1;
+        while id_end > id_start && bytes[id_end - 1].is_ascii_whitespace() {
+            id_end -= 1;
+        }
+        Some((id_end, function_end))
+    }
+}
+
+fn apply_string_edits(input: &str, mut edits: Vec<(Range<usize>, String)>) -> String {
+    if edits.is_empty() {
+        return input.to_string();
+    }
+    edits.sort_by_key(|(range, _)| range.start);
+    let added_capacity = edits
+        .iter()
+        .map(|(range, replacement)| replacement.len().saturating_sub(range.len()))
+        .sum::<usize>();
+    let mut out = String::with_capacity(input.len() + added_capacity);
+    let mut previous_end = 0;
+    for (range, replacement) in edits {
+        if range.start < previous_end || range.end > input.len() {
+            continue;
+        }
+        out.push_str(&input[previous_end..range.start]);
+        out.push_str(&replacement);
+        previous_end = range.end;
+    }
+    out.push_str(&input[previous_end..]);
+    out
+}
+
+fn apply_optional_string_edits(input: &str, edits: Vec<(Range<usize>, String)>) -> Option<String> {
+    (!edits.is_empty()).then(|| apply_string_edits(input, edits))
+}
+
+fn scope_svg_internal_ids_fallback(body: &str, scope: &str) -> String {
+    let declarations = collect_svg_internal_id_declarations(body);
+    if declarations.is_empty() {
         return body.to_string();
     }
 
     let prefix = deterministic_iconify_id_prefix(scope);
-    let suffix = format!("IconifyIdsuffix{:016x}", stable_hash64(scope));
-    let mut rewritten = body.to_string();
-    for (index, id) in ids.iter().enumerate() {
-        let new_id = format!("{prefix}{index}{suffix}");
-        rewritten = replace_iconify_id_occurrences(&rewritten, id, &new_id);
+    let mut id_indexes = FxHashMap::default();
+    for (_, id) in &declarations {
+        let next_index = id_indexes.len();
+        id_indexes.entry(id.clone()).or_insert(next_index);
     }
-    rewritten.replace(&suffix, "")
+
+    let mut edits = declarations
+        .into_iter()
+        .map(|(range, id)| {
+            let replacement = format!("{prefix}{}", id_indexes[&id]);
+            (range, replacement)
+        })
+        .collect::<Vec<_>>();
+    for (id, index) in id_indexes {
+        let replacement = format!("{prefix}{index}");
+        edits.extend(
+            collect_svg_reference_ranges(body, &id)
+                .into_iter()
+                .map(|range| (range, replacement.clone())),
+        );
+    }
+    apply_string_edits(body, edits)
 }
 
-fn collect_svg_internal_ids(body: &str) -> Vec<String> {
-    let mut ids = Vec::new();
+fn collect_svg_internal_id_declarations(body: &str) -> Vec<(Range<usize>, String)> {
+    let mut declarations = Vec::new();
     let mut index = 0;
-    while let Some((attr_start, quote, value_start)) = find_next_id_attr(body, index) {
+    while let Some((_, quote, value_start)) = find_next_id_attr(body, index) {
         let Some(relative_end) = body[value_start..].find(quote) else {
             break;
         };
         let value_end = value_start + relative_end;
         if value_start < value_end {
-            ids.push(body[value_start..value_end].to_string());
+            declarations.push((
+                value_start..value_end,
+                body[value_start..value_end].to_string(),
+            ));
         }
-        index = attr_start + 1;
+        index = value_end + quote.len_utf8();
     }
-    ids
+    declarations
 }
 
 fn find_next_id_attr(body: &str, from: usize) -> Option<(usize, char, usize)> {
@@ -250,41 +540,34 @@ fn stable_hash64(value: &str) -> u64 {
     hash
 }
 
-fn replace_iconify_id_occurrences(body: &str, id: &str, replacement: &str) -> String {
-    let mut out = String::with_capacity(body.len());
-    let mut last = 0;
+fn collect_svg_reference_ranges(body: &str, id: &str) -> Vec<Range<usize>> {
+    let mut ranges = Vec::new();
     let mut scan = 0;
     while let Some(relative) = body[scan..].find(id) {
         let start = scan + relative;
         let end = start + id.len();
-        if is_iconify_reference_boundary(body, start, end) {
-            out.push_str(&body[last..start]);
-            out.push_str(replacement);
-            last = end;
+        if is_svg_reference_boundary(body, start, end) {
+            ranges.push(start..end);
         }
         scan = end;
     }
-    out.push_str(&body[last..]);
-    out
+    ranges
 }
 
-fn is_iconify_reference_boundary(body: &str, start: usize, end: usize) -> bool {
+fn is_svg_reference_boundary(body: &str, start: usize, end: usize) -> bool {
     let Some(prev) = body[..start].chars().next_back() else {
         return false;
     };
-    if !matches!(prev, '#' | ';' | '"' | '\'') {
-        return false;
-    }
-
     let Some(next) = body[end..].chars().next() else {
         return false;
     };
-    matches!(next, '"' | '\'' | ')')
-        || (next == '.'
+    (prev == '#' && matches!(next, '"' | '\'' | ')'))
+        || (matches!(prev, ';' | '"' | '\'')
+            && next == '.'
             && body[end + next.len_utf8()..]
                 .chars()
                 .next()
-                .is_some_and(|ch| ch.is_ascii_lowercase()))
+                .is_some_and(|ch| ch.is_ascii_alphabetic()))
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -471,23 +754,56 @@ mod tests {
     #[test]
     fn scoped_svg_rewrites_internal_ids_and_references() {
         let icon = IconSvg::new(
-            r##"<defs><clipPath id="clip"><path id='shape' d="M0 0H1V1H0z"/></clipPath></defs><use href="#shape" xlink:href="#shape" clip-path="url(#clip)"/><animate begin="shape.end;shape.click"/>"##,
+            r##"<g xmlns:meta="urn:test" meta:id="shape" meta:href="#shape" meta:begin="shape.end" meta:aria-controls="shape" meta:fill="url(#none)"><defs><clipPath id="none"><path id='shape' d="M0 0H1V1H0z"/></clipPath></defs><path fill="none"/><use href="#shape" xlink:href="#shape" clip-path="url(#none)"/><animate begin="shape.end;shape.click"/></g>"##,
             16.0,
             16.0,
         );
 
         let svg = icon.to_svg_with_id_scope(16.0, 16.0, None, Some("diagram-node-a"));
 
-        assert!(!svg.contains(r#"id="clip""#), "{svg}");
+        assert!(!svg.contains(r#"id="none""#), "{svg}");
         assert!(!svg.contains(r#"id='shape'"#), "{svg}");
-        assert!(!svg.contains(r##"href="#shape""##), "{svg}");
-        assert!(!svg.contains(r##"xlink:href="#shape""##), "{svg}");
-        assert!(!svg.contains(r#"url(#clip)"#), "{svg}");
-        assert!(!svg.contains("shape.end"), "{svg}");
-        assert!(!svg.contains("shape.click"), "{svg}");
+        assert!(svg.contains(r#"fill="none""#), "{svg}");
+        assert!(svg.contains(r#"meta:id="shape""#), "{svg}");
+        assert!(svg.contains(r##"meta:href="#shape""##), "{svg}");
+        assert!(svg.contains(r#"meta:begin="shape.end""#), "{svg}");
+        assert!(svg.contains(r#"meta:aria-controls="shape""#), "{svg}");
+        assert!(svg.contains(r#"meta:fill="url(#none)""#), "{svg}");
         let scoped_ids = svg.match_indices(r#"id="IconifyId"#).count()
             + svg.match_indices(r#"id='IconifyId"#).count();
         assert_eq!(scoped_ids, 2, "{svg}");
+
+        let document = roxmltree::Document::parse(&svg).expect("valid SVG");
+        let shape_id = document
+            .descendants()
+            .find(|node| node.has_tag_name("path") && node.attribute("id").is_some())
+            .and_then(|node| node.attribute("id"))
+            .expect("scoped shape id");
+        let clip_id = document
+            .descendants()
+            .find(|node| node.has_tag_name("clipPath"))
+            .and_then(|node| node.attribute("id"))
+            .expect("scoped clip id");
+        let use_node = document
+            .descendants()
+            .find(|node| node.has_tag_name("use"))
+            .expect("use node");
+        let expected_href = format!("#{shape_id}");
+        assert_eq!(use_node.attribute("href"), Some(expected_href.as_str()));
+        assert_eq!(
+            use_node.attribute((XLINK_NAMESPACE, "href")),
+            Some(expected_href.as_str())
+        );
+        assert_eq!(
+            use_node.attribute("clip-path"),
+            Some(format!("url(#{clip_id})").as_str())
+        );
+        let begin = document
+            .descendants()
+            .find(|node| node.has_tag_name("animate"))
+            .and_then(|node| node.attribute("begin"))
+            .expect("animate begin");
+        assert_eq!(begin, format!("{shape_id}.end;{shape_id}.click"));
     }
 
     #[test]
@@ -504,6 +820,37 @@ mod tests {
 
         assert_eq!(a1, a2);
         assert_ne!(a1, b);
+    }
+
+    #[test]
+    fn scoped_svg_fallback_preserves_unrelated_sentinel_like_text() {
+        let scope = "diagram-node-a";
+        let sentinel = format!("IconifyIdsuffix{:016x}", stable_hash64(scope));
+        let body = format!(
+            r##"<g id="none" data-note="{sentinel}&broken"><path fill="none" clip-path="url(#none)"/></g>"##
+        );
+        let icon = IconSvg::new(body, 16.0, 16.0);
+
+        let svg = icon.to_svg_with_id_scope(16.0, 16.0, None, Some(scope));
+
+        assert!(
+            svg.contains(&format!(r#"data-note="{sentinel}&broken""#)),
+            "{svg}"
+        );
+        assert!(svg.contains(r#"fill="none""#), "{svg}");
+        assert!(!svg.contains(r#"id="none""#), "{svg}");
+        assert!(!svg.contains(r#"url(#none)"#), "{svg}");
+        let scoped_id = svg
+            .split_once(r#"<g id=""#)
+            .and_then(|(_, rest)| rest.split_once('"'))
+            .map(|(id, _)| id)
+            .expect("fallback scoped id");
+        let url_target = svg
+            .split_once("url(#")
+            .and_then(|(_, rest)| rest.split_once(')'))
+            .map(|(id, _)| id)
+            .expect("fallback URL target");
+        assert_eq!(url_target, scoped_id);
     }
 
     #[test]

--- a/crates/merman-render/src/svg/parity/flowchart/render/node/helpers.rs
+++ b/crates/merman-render/src/svg/parity/flowchart/render/node/helpers.rs
@@ -1,5 +1,6 @@
 //! Node-level helpers (link sanitization, class building, placeholders).
 
+use crate::svg::icon_registry::mermaid_unknown_icon_svg;
 use crate::svg::parity::flowchart::types::{FlowchartRenderCtx, FlowchartRenderDetails};
 use crate::svg::parity::util::escape_attr_display;
 use crate::svg::parity::{escape_xml_display, escape_xml_into, fmt_display};
@@ -16,14 +17,7 @@ pub(in crate::svg::parity::flowchart::render::node) fn icon_svg_or_placeholder(
         .and_then(|registry| {
             registry.svg_for_scoped(icon_name, icon_size, icon_size, None, None, &id_scope)
         })
-        .unwrap_or_else(|| placeholder_icon_svg(icon_size))
-}
-
-fn placeholder_icon_svg(icon_size: f64) -> String {
-    format!(
-        r#"<svg xmlns="http://www.w3.org/2000/svg" width="{s}" height="{s}" viewBox="0 0 80 80"><g><rect width="80" height="80" style="fill: #087ebf; stroke-width: 0px;"/><text transform="translate(21.16 64.67)" style="fill: #fff; font-family: ArialMT, Arial; font-size: 67.75px;"><tspan x="0" y="0">?</tspan></text></g></svg>"#,
-        s = fmt_display(icon_size)
-    )
+        .unwrap_or_else(|| mermaid_unknown_icon_svg(fmt_display(icon_size), fmt_display(icon_size)))
 }
 
 fn is_self_loop_label_node_id(id: &str) -> bool {

--- a/crates/merman-render/src/svg/parity/tree_view/render.rs
+++ b/crates/merman-render/src/svg/parity/tree_view/render.rs
@@ -1,5 +1,6 @@
 use super::super::*;
 use crate::model::TreeViewNodeLayout;
+use crate::svg::icon_registry::mermaid_unknown_icon_svg;
 use crate::tree_view::{
     TREE_VIEW_HIGHLIGHT_RECT_EXTENSION, TREE_VIEW_HIGHLIGHT_WIDTH_GROWTH, TREE_VIEW_ICON_SIZE,
     is_tree_view_highlight_class,
@@ -87,7 +88,12 @@ pub(crate) fn render_tree_view_diagram_svg_model(
         );
     }
     let _ = write!(&mut out, "<style>{css}</style>");
-    push_tree_view_icon_defs(&mut out, layout, diagram_id);
+    push_tree_view_icon_defs(
+        &mut out,
+        layout,
+        diagram_id,
+        options.icon_registry.as_deref(),
+    );
     out.push_str("<g/>");
     out.push_str(r#"<g class="tree-view">"#);
     let mut next_node = 0usize;
@@ -219,7 +225,12 @@ fn tree_view_label_classes(node: &TreeViewNodeLayout) -> String {
     classes.join(" ")
 }
 
-fn push_tree_view_icon_defs(out: &mut String, layout: &TreeViewDiagramLayout, diagram_id: &str) {
+fn push_tree_view_icon_defs(
+    out: &mut String,
+    layout: &TreeViewDiagramLayout,
+    diagram_id: &str,
+    icon_registry: Option<&crate::svg::IconRegistry>,
+) {
     let used_icons = layout
         .nodes
         .iter()
@@ -230,11 +241,8 @@ fn push_tree_view_icon_defs(out: &mut String, layout: &TreeViewDiagramLayout, di
     }
     out.push_str("<defs>");
     for icon in used_icons {
-        let _ = write!(
-            out,
-            r#"<g id="{}">"#,
-            tree_view_icon_symbol_id(diagram_id, icon)
-        );
+        let symbol_id = tree_view_icon_symbol_id(diagram_id, icon);
+        let _ = write!(out, r#"<g id="{symbol_id}">"#);
         if let Some(body) = tree_view_icon_body(icon) {
             let _ = write!(
                 out,
@@ -242,6 +250,22 @@ fn push_tree_view_icon_defs(out: &mut String, layout: &TreeViewDiagramLayout, di
                 fmt(TREE_VIEW_ICON_SIZE),
                 fmt(TREE_VIEW_ICON_SIZE)
             );
+        } else {
+            let icon_svg = icon_registry
+                .and_then(|registry| {
+                    registry.svg_for_scoped(
+                        icon,
+                        TREE_VIEW_ICON_SIZE,
+                        TREE_VIEW_ICON_SIZE,
+                        None,
+                        None,
+                        &symbol_id,
+                    )
+                })
+                .unwrap_or_else(|| {
+                    mermaid_unknown_icon_svg(fmt(TREE_VIEW_ICON_SIZE), fmt(TREE_VIEW_ICON_SIZE))
+                });
+            out.push_str(&icon_svg);
         }
         out.push_str("</g>");
     }

--- a/crates/merman-render/src/svg/parity/tree_view/render.rs
+++ b/crates/merman-render/src/svg/parity/tree_view/render.rs
@@ -6,7 +6,7 @@ use crate::tree_view::{
     is_tree_view_highlight_class,
 };
 use merman_core::diagrams::tree_view::TreeViewDiagramRenderModel;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 const TREE_VIEW_ICON_PREFIX: &str = "mermaid-treeview";
 const TREE_VIEW_DIRECTORY_NODE_TYPE: &str = "directory";
@@ -88,12 +88,8 @@ pub(crate) fn render_tree_view_diagram_svg_model(
         );
     }
     let _ = write!(&mut out, "<style>{css}</style>");
-    push_tree_view_icon_defs(
-        &mut out,
-        layout,
-        diagram_id,
-        options.icon_registry.as_deref(),
-    );
+    let icon_symbol_ids = tree_view_icon_symbol_ids(layout, diagram_id);
+    push_tree_view_icon_defs(&mut out, &icon_symbol_ids, options.icon_registry.as_deref());
     out.push_str("<g/>");
     out.push_str(r#"<g class="tree-view">"#);
     let mut next_node = 0usize;
@@ -112,7 +108,7 @@ pub(crate) fn render_tree_view_diagram_svg_model(
                 &mut out,
                 node,
                 layout,
-                diagram_id,
+                &icon_symbol_ids,
                 &mut width_before_highlight,
             );
             next_node += 1;
@@ -132,7 +128,7 @@ pub(crate) fn render_tree_view_diagram_svg_model(
             &mut out,
             node,
             layout,
-            diagram_id,
+            &icon_symbol_ids,
             &mut width_before_highlight,
         );
     }
@@ -144,7 +140,7 @@ fn push_tree_view_node(
     out: &mut String,
     node: &TreeViewNodeLayout,
     layout: &TreeViewDiagramLayout,
-    diagram_id: &str,
+    icon_symbol_ids: &BTreeMap<&str, String>,
     width_before_highlight: &mut f64,
 ) {
     out.push_str("<g>");
@@ -162,11 +158,15 @@ fn push_tree_view_node(
         );
         *width_before_highlight += TREE_VIEW_HIGHLIGHT_WIDTH_GROWTH;
     }
-    if let Some(icon) = &node.resolved_icon {
+    if let Some(symbol_id) = node
+        .resolved_icon
+        .as_deref()
+        .and_then(|icon| icon_symbol_ids.get(icon))
+    {
         let _ = write!(
             out,
             r##"<use xlink:href="#{}" x="{}" y="{}" class="treeView-node-icon"></use>"##,
-            tree_view_icon_symbol_id(diagram_id, icon),
+            symbol_id,
             fmt(node.x + layout.padding_x),
             fmt(node.y + layout.padding_y)
         );
@@ -227,21 +227,14 @@ fn tree_view_label_classes(node: &TreeViewNodeLayout) -> String {
 
 fn push_tree_view_icon_defs(
     out: &mut String,
-    layout: &TreeViewDiagramLayout,
-    diagram_id: &str,
+    icon_symbol_ids: &BTreeMap<&str, String>,
     icon_registry: Option<&crate::svg::IconRegistry>,
 ) {
-    let used_icons = layout
-        .nodes
-        .iter()
-        .filter_map(|node| node.resolved_icon.as_deref())
-        .collect::<BTreeSet<_>>();
-    if used_icons.is_empty() {
+    if icon_symbol_ids.is_empty() {
         return;
     }
     out.push_str("<defs>");
-    for icon in used_icons {
-        let symbol_id = tree_view_icon_symbol_id(diagram_id, icon);
+    for (icon, symbol_id) in icon_symbol_ids {
         let _ = write!(out, r#"<g id="{symbol_id}">"#);
         if let Some(body) = tree_view_icon_body(icon) {
             let _ = write!(
@@ -259,7 +252,7 @@ fn push_tree_view_icon_defs(
                         TREE_VIEW_ICON_SIZE,
                         None,
                         None,
-                        &symbol_id,
+                        symbol_id,
                     )
                 })
                 .unwrap_or_else(|| {
@@ -272,7 +265,46 @@ fn push_tree_view_icon_defs(
     out.push_str("</defs>");
 }
 
-fn tree_view_icon_symbol_id(diagram_id: &str, icon: &str) -> String {
+fn tree_view_icon_symbol_ids<'a>(
+    layout: &'a TreeViewDiagramLayout,
+    diagram_id: &str,
+) -> BTreeMap<&'a str, String> {
+    let base_ids = layout
+        .nodes
+        .iter()
+        .filter_map(|node| node.resolved_icon.as_deref())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .map(|icon| (icon, tree_view_icon_symbol_id_base(diagram_id, icon)))
+        .collect::<Vec<_>>();
+    let reserved_ids = base_ids
+        .iter()
+        .map(|(_, symbol_id)| symbol_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut next_suffixes = BTreeMap::new();
+    let mut symbol_ids = BTreeMap::new();
+
+    for (icon, base_id) in &base_ids {
+        let next_suffix = next_suffixes.entry(base_id.as_str()).or_insert(1usize);
+        let symbol_id = if *next_suffix == 1 {
+            *next_suffix = 2;
+            base_id.clone()
+        } else {
+            loop {
+                let candidate = format!("{base_id}-{next_suffix}");
+                *next_suffix += 1;
+                if !reserved_ids.contains(candidate.as_str()) {
+                    break candidate;
+                }
+            }
+        };
+        symbol_ids.insert(*icon, symbol_id);
+    }
+
+    symbol_ids
+}
+
+fn tree_view_icon_symbol_id_base(diagram_id: &str, icon: &str) -> String {
     let mut id = format!("tv-icon-{diagram_id}-");
     for ch in icon.chars() {
         if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {

--- a/crates/merman-render/tests/flowchart_svg_test.rs
+++ b/crates/merman-render/tests/flowchart_svg_test.rs
@@ -65,6 +65,16 @@ fn render_flowchart_svg_from_text_with_engine(engine: Engine, text: &str) -> Str
 }
 
 #[test]
+fn flowchart_missing_icon_uses_mermaid_unknown_icon_at_requested_size() {
+    let svg = render_flowchart_svg_from_text(
+        "flowchart TD\nA@{ icon: \"missing:icon\", label: \"Missing\" }\n",
+    );
+    let unknown_icon = r#"<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 80 80"><g><rect width="80" height="80" style="fill: #087ebf; stroke-width: 0px;"/><text transform="translate(21.16 64.67)" style="fill: #fff; font-family: ArialMT, Arial; font-size: 67.75px;"><tspan x="0" y="0">?</tspan></text></g></svg>"#;
+
+    assert!(svg.contains(unknown_icon), "{svg}");
+}
+
+#[test]
 fn flowchart_svg_renders_one_logical_self_loop_edge() {
     let svg = render_flowchart_svg_from_text("flowchart TB\nA -->|again| A\n");
 

--- a/crates/merman-render/tests/svg_internal_id_test.rs
+++ b/crates/merman-render/tests/svg_internal_id_test.rs
@@ -219,32 +219,103 @@ A --> B"#,
 
 #[test]
 fn tree_view_iconify_internal_ids_are_scoped_per_symbol_and_deterministic() {
-    let icon_body = r##"<defs><clipPath id="clip"><path d="M0 0H16V16H0z"/></clipPath></defs><path data-icon="tree-view-id-fixture" clip-path="url(#clip)" d="M0 0H16V16H0z"/>"##;
+    let icon_body = r##"<defs><clipPath id="none"><path id="shape" d="M0 0H16V16H0z"/></clipPath></defs><path data-icon="tree-view-id-fixture" fill="none" clip-path="url(#none)" d="M0 0H16V16H0z"/><use href="#shape" xlink:href="#shape"/><animate begin="shape.end;shape.click"/>"##;
     let mut registry = IconRegistry::new();
-    registry.insert("test:one", IconSvg::new(icon_body, 16.0, 16.0));
-    registry.insert("test:two", IconSvg::new(icon_body, 16.0, 16.0));
+    registry.insert("foo:bar-baz", IconSvg::new(icon_body, 16.0, 16.0));
+    registry.insert("foo-bar:baz", IconSvg::new(icon_body, 16.0, 16.0));
+    registry.insert("foo:bar-baz-2", IconSvg::new(icon_body, 16.0, 16.0));
     let options = SvgRenderOptions {
         diagram_id: Some("m15-tree-view-icons".to_string()),
         icon_registry: Some(Arc::new(registry)),
         ..SvgRenderOptions::default()
     };
-    let input = "treeView-beta\nRoot\n    One icon(test:one)\n    Two icon(test:two)\n";
+    let input = "treeView-beta\nRoot\n    One icon(foo:bar-baz)\n    Two icon(foo-bar:baz)\n    Three icon(foo:bar-baz-2)\n";
 
     let svg = render_svg_from_text_with_options(input, &options);
     let repeated_svg = render_svg_from_text_with_options(input, &options);
 
     assert_eq!(svg, repeated_svg);
-    assert!(!svg.contains(r#"id="clip""#), "{svg}");
-    assert!(!svg.contains(r#"url(#clip)"#), "{svg}");
+    assert!(!svg.contains(r#"id="none""#), "{svg}");
+    assert!(!svg.contains(r#"id="shape""#), "{svg}");
+    assert!(!svg.contains(r#"url(#none)"#), "{svg}");
+    assert!(!svg.contains(r##"href="#shape""##), "{svg}");
+    assert!(!svg.contains("shape.end"), "{svg}");
+    assert!(!svg.contains("shape.click"), "{svg}");
+    assert_eq!(svg.matches(r#"fill="none""#).count(), 3, "{svg}");
     assert_eq!(
         svg.matches(r#"data-icon="tree-view-id-fixture""#).count(),
-        2,
+        3,
         "{svg}"
     );
+
+    let document = roxmltree::Document::parse(&svg).expect("valid SVG");
+    let symbol_references = document
+        .descendants()
+        .filter(|node| {
+            node.has_tag_name("use") && node.attribute("class") == Some("treeView-node-icon")
+        })
+        .filter_map(|node| {
+            node.attributes()
+                .find(|attribute| attribute.name() == "href")
+                .and_then(|attribute| attribute.value().strip_prefix('#'))
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        symbol_references,
+        [
+            "tv-icon-m15-tree-view-icons-foo-bar-baz-3",
+            "tv-icon-m15-tree-view-icons-foo-bar-baz",
+            "tv-icon-m15-tree-view-icons-foo-bar-baz-2",
+        ],
+        "{svg}"
+    );
+    assert_eq!(
+        symbol_references
+            .iter()
+            .collect::<std::collections::BTreeSet<_>>()
+            .len(),
+        symbol_references.len(),
+        "{svg}"
+    );
+
     let ids = internal_iconify_ids(&svg);
-    assert_eq!(ids.len(), 2, "{svg}");
+    assert_eq!(ids.len(), 6, "{svg}");
     let unique = ids.iter().collect::<std::collections::BTreeSet<_>>();
     assert_eq!(unique.len(), ids.len(), "{svg}");
+
+    let defined_ids = document
+        .descendants()
+        .filter_map(|node| node.attribute("id"))
+        .collect::<std::collections::BTreeSet<_>>();
+    let local_reference_targets = document
+        .descendants()
+        .flat_map(|node| node.attributes())
+        .filter_map(|attribute| {
+            let value = attribute.value();
+            if attribute.name() == "href" {
+                value.strip_prefix('#').map(str::to_string)
+            } else {
+                value
+                    .strip_prefix("url(#")
+                    .and_then(|value| value.strip_suffix(')'))
+                    .map(str::to_string)
+            }
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        local_reference_targets
+            .iter()
+            .filter(|target| target.starts_with("IconifyId"))
+            .count(),
+        9,
+        "{svg}"
+    );
+    for target in local_reference_targets {
+        assert!(
+            defined_ids.contains(target.as_str()),
+            "reference target `{target}` has no matching id in SVG:\n{svg}"
+        );
+    }
 }
 
 #[test]

--- a/crates/merman-render/tests/svg_internal_id_test.rs
+++ b/crates/merman-render/tests/svg_internal_id_test.rs
@@ -218,6 +218,36 @@ A --> B"#,
 }
 
 #[test]
+fn tree_view_iconify_internal_ids_are_scoped_per_symbol_and_deterministic() {
+    let icon_body = r##"<defs><clipPath id="clip"><path d="M0 0H16V16H0z"/></clipPath></defs><path data-icon="tree-view-id-fixture" clip-path="url(#clip)" d="M0 0H16V16H0z"/>"##;
+    let mut registry = IconRegistry::new();
+    registry.insert("test:one", IconSvg::new(icon_body, 16.0, 16.0));
+    registry.insert("test:two", IconSvg::new(icon_body, 16.0, 16.0));
+    let options = SvgRenderOptions {
+        diagram_id: Some("m15-tree-view-icons".to_string()),
+        icon_registry: Some(Arc::new(registry)),
+        ..SvgRenderOptions::default()
+    };
+    let input = "treeView-beta\nRoot\n    One icon(test:one)\n    Two icon(test:two)\n";
+
+    let svg = render_svg_from_text_with_options(input, &options);
+    let repeated_svg = render_svg_from_text_with_options(input, &options);
+
+    assert_eq!(svg, repeated_svg);
+    assert!(!svg.contains(r#"id="clip""#), "{svg}");
+    assert!(!svg.contains(r#"url(#clip)"#), "{svg}");
+    assert_eq!(
+        svg.matches(r#"data-icon="tree-view-id-fixture""#).count(),
+        2,
+        "{svg}"
+    );
+    let ids = internal_iconify_ids(&svg);
+    assert_eq!(ids.len(), 2, "{svg}");
+    let unique = ids.iter().collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(unique.len(), ids.len(), "{svg}");
+}
+
+#[test]
 fn architecture_builtin_icon_internal_ids_are_scoped_per_node() {
     let svg = render_svg_from_text(
         r#"architecture-beta

--- a/crates/merman-render/tests/tree_view_svg_test.rs
+++ b/crates/merman-render/tests/tree_view_svg_test.rs
@@ -306,24 +306,7 @@ fn tree_view_registry_icons_preserve_viewbox_and_empty_body_semantics() {
             .any(|node| node.attribute("data-icon") == Some("tree-view-registry"))
     );
 
-    let missing_symbol = document
-        .descendants()
-        .find(|node| node.attribute("id") == Some("tv-icon-tree-view-registry-test-test-missing"))
-        .expect("missing registry icon symbol");
-    let missing_svg = missing_symbol
-        .children()
-        .find(|node| node.is_element() && node.tag_name().name() == "svg")
-        .expect("missing registry icon fallback SVG");
-    assert_eq!(missing_svg.attribute("width"), Some("14"));
-    assert_eq!(missing_svg.attribute("height"), Some("14"));
-    assert_eq!(missing_svg.attribute("viewBox"), Some("0 0 80 80"));
-    assert_eq!(
-        missing_svg
-            .descendants()
-            .find(|node| node.tag_name().name() == "tspan")
-            .and_then(|node| node.text()),
-        Some("?")
-    );
+    assert_unknown_tree_view_icon(&document, "tv-icon-tree-view-registry-test-test-missing");
 
     let empty_symbol = document
         .descendants()
@@ -353,11 +336,13 @@ fn tree_view_missing_icon_without_registry_uses_unknown_icon() {
         },
     );
     let document = roxmltree::Document::parse(&svg).expect("valid TreeView SVG");
+    assert_unknown_tree_view_icon(&document, "tv-icon-tree-view-no-registry-test-test-missing");
+}
+
+fn assert_unknown_tree_view_icon(document: &roxmltree::Document<'_>, symbol_id: &str) {
     let symbol = document
         .descendants()
-        .find(|node| {
-            node.attribute("id") == Some("tv-icon-tree-view-no-registry-test-test-missing")
-        })
+        .find(|node| node.attribute("id") == Some(symbol_id))
         .expect("missing icon symbol");
     let icon_svg = symbol
         .children()

--- a/crates/merman-render/tests/tree_view_svg_test.rs
+++ b/crates/merman-render/tests/tree_view_svg_test.rs
@@ -4,9 +4,29 @@ use common::legacy_init_theme_compat_engine;
 use merman_core::diagrams::tree_view::{TreeViewDiagramRenderModel, TreeViewNodeRenderModel};
 use merman_core::{Engine, MAX_DIAGRAM_NESTING_DEPTH, ParseOptions};
 use merman_render::model::LayoutDiagram;
-use merman_render::svg::{SvgRenderOptions, render_layout_svg_parts_for_render_model_with_config};
+use merman_render::svg::{
+    IconRegistry, IconSvg, SvgRenderOptions, render_layout_svg_parts_for_render_model_with_config,
+};
 use merman_render::tree_view::layout_tree_view_diagram_typed;
 use merman_render::{LayoutOptions, layout_parsed_render_layout_only};
+use std::sync::Arc;
+
+fn render_tree_view_svg_with_options(input: &str, options: SvgRenderOptions) -> String {
+    let parsed = Engine::new()
+        .parse_diagram_for_render_model_sync(input, ParseOptions::strict())
+        .unwrap()
+        .expect("TreeView diagram");
+    let layout = layout_parsed_render_layout_only(&parsed, &LayoutOptions::default()).unwrap();
+    render_layout_svg_parts_for_render_model_with_config(
+        &layout,
+        &parsed.model,
+        &parsed.meta.effective_config,
+        parsed.meta.title.as_deref(),
+        LayoutOptions::default().text_measurer.as_ref(),
+        &options,
+    )
+    .unwrap()
+}
 
 #[test]
 fn tree_view_typed_render_model_outputs_svg() {
@@ -158,23 +178,21 @@ file.txt icon(file)
 App.tsx icon(logos:react)
 "##;
 
-    let parsed = Engine::new()
-        .parse_diagram_for_render_model_sync(input, ParseOptions::strict())
-        .unwrap()
-        .unwrap();
-    let layout = layout_parsed_render_layout_only(&parsed, &LayoutOptions::default()).unwrap();
-    let svg = render_layout_svg_parts_for_render_model_with_config(
-        &layout,
-        &parsed.model,
-        &parsed.meta.effective_config,
-        parsed.meta.title.as_deref(),
-        LayoutOptions::default().text_measurer.as_ref(),
-        &SvgRenderOptions {
+    let mut registry = IconRegistry::new();
+    for icon in ["file", "folder"] {
+        registry.insert(
+            format!("mermaid-treeview:{icon}"),
+            IconSvg::new(r#"<path data-icon="registry-override"/>"#, 16.0, 16.0),
+        );
+    }
+    let svg = render_tree_view_svg_with_options(
+        input,
+        SvgRenderOptions {
             diagram_id: Some("tree-view-icon-size-test".to_string()),
+            icon_registry: Some(Arc::new(registry)),
             ..Default::default()
         },
-    )
-    .unwrap();
+    );
     let document = roxmltree::Document::parse(&svg).expect("valid TreeView SVG");
 
     for (icon, label) in [("folder", "src"), ("file", "file.txt")] {
@@ -219,17 +237,141 @@ App.tsx icon(logos:react)
 
         assert_eq!(label_x - icon_right, 4.0);
     }
+    assert!(!svg.contains("registry-override"), "{svg}");
 
     let third_party_symbol = document
         .descendants()
         .find(|node| node.attribute("id") == Some("tv-icon-tree-view-icon-size-test-logos-react"))
-        .expect("third-party residual icon definition");
+        .expect("third-party fallback icon definition");
+    let fallback_svg = third_party_symbol
+        .children()
+        .find(|node| node.is_element() && node.tag_name().name() == "svg")
+        .expect("missing icon uses the standard fallback SVG");
+    assert_eq!(fallback_svg.attribute("width"), Some("14"));
+    assert_eq!(fallback_svg.attribute("height"), Some("14"));
+    assert_eq!(fallback_svg.attribute("viewBox"), Some("0 0 80 80"));
+    assert!(
+        fallback_svg
+            .children()
+            .any(|node| node.is_element() && node.tag_name().name() == "g")
+    );
+}
+
+#[test]
+fn tree_view_registry_icons_preserve_viewbox_and_empty_body_semantics() {
+    let mut registry = IconRegistry::new();
+    registry.insert(
+        "test:rocket",
+        IconSvg::new(
+            r#"<path data-icon="tree-view-registry" d="M2 3H34V21H2z"/>"#,
+            32.0,
+            18.0,
+        )
+        .with_viewbox(2.0, 3.0, 32.0, 18.0),
+    );
+    registry.insert("test:empty", IconSvg::new("", 16.0, 16.0));
+    let svg = render_tree_view_svg_with_options(
+        "treeView-beta\nRoot\n    Rocket icon(test:rocket)\n    Rocket Again icon(test:rocket)\n    Missing icon(test:missing)\n    Empty icon(test:empty)\n",
+        SvgRenderOptions {
+            diagram_id: Some("tree-view-registry-test".to_string()),
+            icon_registry: Some(Arc::new(registry)),
+            ..Default::default()
+        },
+    );
+    let document = roxmltree::Document::parse(&svg).expect("valid TreeView SVG");
+
+    let rocket_symbol = document
+        .descendants()
+        .find(|node| node.attribute("id") == Some("tv-icon-tree-view-registry-test-test-rocket"))
+        .expect("registry icon symbol");
     assert_eq!(
-        third_party_symbol
+        document
+            .descendants()
+            .filter(|node| {
+                node.attribute("id") == Some("tv-icon-tree-view-registry-test-test-rocket")
+            })
+            .count(),
+        1
+    );
+    let rocket_svg = rocket_symbol
+        .children()
+        .find(|node| node.is_element() && node.tag_name().name() == "svg")
+        .expect("registry icon SVG");
+    assert_eq!(rocket_svg.attribute("width"), Some("14"));
+    assert_eq!(rocket_svg.attribute("height"), Some("14"));
+    assert_eq!(rocket_svg.attribute("viewBox"), Some("2 3 32 18"));
+    assert!(
+        rocket_svg
+            .descendants()
+            .any(|node| node.attribute("data-icon") == Some("tree-view-registry"))
+    );
+
+    let missing_symbol = document
+        .descendants()
+        .find(|node| node.attribute("id") == Some("tv-icon-tree-view-registry-test-test-missing"))
+        .expect("missing registry icon symbol");
+    let missing_svg = missing_symbol
+        .children()
+        .find(|node| node.is_element() && node.tag_name().name() == "svg")
+        .expect("missing registry icon fallback SVG");
+    assert_eq!(missing_svg.attribute("width"), Some("14"));
+    assert_eq!(missing_svg.attribute("height"), Some("14"));
+    assert_eq!(missing_svg.attribute("viewBox"), Some("0 0 80 80"));
+    assert_eq!(
+        missing_svg
+            .descendants()
+            .find(|node| node.tag_name().name() == "tspan")
+            .and_then(|node| node.text()),
+        Some("?")
+    );
+
+    let empty_symbol = document
+        .descendants()
+        .find(|node| node.attribute("id") == Some("tv-icon-tree-view-registry-test-test-empty"))
+        .expect("empty registry icon symbol");
+    let empty_svg = empty_symbol
+        .children()
+        .find(|node| node.is_element() && node.tag_name().name() == "svg")
+        .expect("an explicitly empty registry icon still resolves");
+    assert_eq!(empty_svg.attribute("viewBox"), Some("0 0 16 16"));
+    assert_eq!(
+        empty_svg
             .children()
             .filter(|node| node.is_element())
             .count(),
         0
+    );
+}
+
+#[test]
+fn tree_view_missing_icon_without_registry_uses_unknown_icon() {
+    let svg = render_tree_view_svg_with_options(
+        "treeView-beta\nRoot icon(test:missing)\n",
+        SvgRenderOptions {
+            diagram_id: Some("tree-view-no-registry-test".to_string()),
+            ..Default::default()
+        },
+    );
+    let document = roxmltree::Document::parse(&svg).expect("valid TreeView SVG");
+    let symbol = document
+        .descendants()
+        .find(|node| {
+            node.attribute("id") == Some("tv-icon-tree-view-no-registry-test-test-missing")
+        })
+        .expect("missing icon symbol");
+    let icon_svg = symbol
+        .children()
+        .find(|node| node.is_element() && node.tag_name().name() == "svg")
+        .expect("unknown icon SVG");
+    assert_eq!(icon_svg.attribute("width"), Some("14"));
+    assert_eq!(icon_svg.attribute("height"), Some("14"));
+    assert_eq!(icon_svg.attribute("viewBox"), Some("0 0 80 80"));
+    assert_eq!(
+        icon_svg
+            .descendants()
+            .find(|node| node.tag_name().name() == "tspan")
+            .and_then(|node| node.text()),
+        Some("?")
     );
 }
 

--- a/docs/alignment/CLI_COMPATIBILITY.md
+++ b/docs/alignment/CLI_COMPATIBILITY.md
@@ -110,8 +110,8 @@ costs, makes Rust renderers irrelevant for CLI output.
 | `-f, --pdfFit` | PDF page clipped to chart bounding box. | Implemented divergence | Top-level default PDF uses a Letter-sized page approximation; `--pdfFit` uses chart-sized `svg2pdf` output. |
 | `-q, --quiet` | Suppresses info logs. | Implemented | Markdown chart-count and artefact logs are suppressed. |
 | `-p, --puppeteerConfigFile [file]` | JSON Puppeteer launch config; must exist. | Implemented divergence | File existence and JSON parsing match upstream preflight behavior; values are accepted no-op because the Rust CLI has no Puppeteer runtime. |
-| `--iconPacks <icons...>` | Registers Iconify package loaders in browser; may fetch from unpkg. | Implemented | Loads local `node_modules/<package>/icons.json` when present, otherwise fetches `https://unpkg.com/<package>/icons.json`; package tail is used as the Iconify prefix like upstream. |
-| `--iconPacksNamesAndUrls <prefix#url...>` | Registers explicit Iconify JSON URL loaders. | Implemented | Supports HTTP(S), `file://`, and local path Iconify JSON sources; prefix before `#` overrides the JSON prefix like upstream loader registration. |
+| `--iconPacks <icons...>` | Registers Iconify package loaders in browser; may fetch from unpkg. | Implemented | Loads local `node_modules/<package>/icons.json` when present. Missing packages fetch from `https://unpkg.com/<package>/icons.json` only with `--allow-network`; the package tail is used as the Iconify prefix like upstream. |
+| `--iconPacksNamesAndUrls <prefix#url...>` | Registers explicit Iconify JSON URL loaders. | Implemented | Supports HTTP(S), `file://`, and local path Iconify JSON sources; HTTP(S) requires `--allow-network`, while local sources remain offline by default. The prefix before `#` overrides the JSON prefix like upstream loader registration. |
 | `--help`, `-h` | Print help and exit 0. | Implemented | Covered by CLI tests. |
 | `--version` | Print version and exit 0. | Implemented | Covered by CLI tests. |
 
@@ -154,7 +154,7 @@ costs, makes Rust renderers irrelevant for CLI output.
 | RaTeX math | Local CLI enables `ratex-math` by default; upstream uses browser Mermaid/KaTeX behavior. | Rust CLI should render math without extra feature friction. | Keep `--math-renderer none|ratex`; no-default build still rejects. |
 | Puppeteer config | No browser runtime in local CLI. | Browserless architecture. | Validate file for compatibility, treat runtime config as accepted no-op. |
 | PDF output | Local PDF is generated through Rust `svg2pdf`, not Chromium print-to-PDF. | Browser PDF pagination, margins, and CSS print behavior cannot be pixel-identical without Puppeteer. | Top-level default uses a Letter page approximation; `--pdfFit` uses chart-sized output. |
-| Icon pack rendering internals | Upstream uses browser DOM `getBBox()` and Iconify `replaceIDs()` when embedding icons. | Local renderer parses Iconify JSON into a Rust registry and emits deterministic nested SVGs; layout remains based on existing Rust icon node sizing. | Keep tests focused on successful real icon rendering; deepen DOM-level icon parity separately if fixture comparison exposes differences. |
+| Icon pack rendering internals | Upstream uses browser DOM `getBBox()` and Iconify `replaceIDs()` when embedding icons. | Local renderer parses Iconify JSON into a Rust registry and emits deterministic nested SVGs for Flowchart, Architecture, and TreeView; TreeView uses Mermaid's 14px icon size. | Keep tests focused on successful real icon rendering; deepen DOM-level icon parity separately if fixture comparison exposes differences. |
 
 ## Execution Model / Concurrency
 
@@ -203,7 +203,7 @@ thread pool inside Markdown mode:
 ### Phase 4: Browser-Specific Decision Points
 
 - [x] Decide `pdfFit` semantics for Rust `svg2pdf`.
-- [x] Implement Iconify icon pack support through a Rust SVG icon registry.
+- [x] Implement Iconify icon pack support through a Rust SVG icon registry for Flowchart, Architecture, and TreeView.
 - [x] Document any final divergence in the register above.
 
 ## Risks and Mitigations
@@ -213,7 +213,7 @@ thread pool inside Markdown mode:
 | Accidentally removing useful Rust-only output (`jpg`, `ascii`, `unicode`) | Medium | Medium | Keep divergence register and tests. |
 | Markdown regex drift from upstream | High | Medium | Copy upstream regex semantics into tests with fixtures. |
 | Output file naming surprises | Medium | Medium | Test exact paths for `.svg`, `.png`, `.pdf`, `.md`, and artefacts. |
-| Network icon pack behavior introduces supply-chain risk | High | Medium | Remote fetching only occurs when the user explicitly passes `--iconPacks` without a local package or an HTTP(S) `prefix#url`; tests use local JSON sources. |
+| Network icon pack behavior introduces supply-chain risk | High | Medium | Remote fetching only occurs when the user explicitly passes `--allow-network` with a missing `--iconPacks` package or an HTTP(S) `prefix#url`; tests use local JSON sources. |
 | PDF fit cannot match browser PDF exactly | Medium | High | Define Rust-specific behavior and document divergence. |
 
 ## Immediate Next Tests

--- a/docs/alignment/TREEVIEW_UPSTREAM_TEST_COVERAGE.md
+++ b/docs/alignment/TREEVIEW_UPSTREAM_TEST_COVERAGE.md
@@ -43,6 +43,14 @@ Phase 2 admission backlog: `docs/alignment/PHASE2_PARITY_BACKLOG.md`.
     layout config and resolved with Mermaid's explicit-icon-first priority
   - SVG output includes `treeView-node-dir`, custom class propagation, `treeView-node-icon`,
     `treeView-node-description`, and `treeView-highlight-bg` DOM/CSS coverage
+  - configured Iconify pack bodies render in deterministic 14-by-14 nested SVGs while preserving
+    their source viewBox; repeated nodes share one symbol definition
+  - internal Iconify IDs and references are scoped per diagram and TreeView symbol, with
+    deterministic output across repeated renders
+  - built-in `file`/`folder` bodies take precedence over registry entries, while missing packs or
+    icons use Mermaid's standard 80-by-80 unknown-icon body at the same 14px display size
+  - CLI coverage exercises the local Iconify JSON loader through `SvgRenderOptions` into TreeView;
+    renderer code performs no filesystem, package-manager, or network access
   - theme roles `iconColor`, `descriptionColor`, `highlightBg`, and `highlightStroke` are covered by
     `PresentationTheme` tests; full config-pipeline admission for those newer theme fields remains
     tracked separately from TreeView parser/model parity
@@ -118,10 +126,3 @@ Classification:
 
 - Exact Langium diagnostics and offsets.
 - Full strict DOM parity for the current Cypress image snapshot corpus.
-- Full browser/Iconify parity for third-party icon packs. Local SVG emits deterministic `<use>`
-  references and built-in `file`/`folder` icon bodies; external pack SVG body replacement remains a
-  bounded renderer residual unless fixture comparison exposes a source-backed requirement.
-- Golden refresh for the new 11.16 TreeView model fields and annotation/icon DOM. Refresh semantic,
-  layout, and upstream SVG baselines after U4 semantic/render code lands, not before. Semantic and
-  layout goldens are refreshed for the local 11.16 model; upstream SVG refresh was attempted but is
-  pending because the local Puppeteer Chrome cache is missing Chrome `131.0.6778.204`.


### PR DESCRIPTION
## Summary

TreeView now renders configured Iconify pack bodies at Mermaid's 14px icon size instead of emitting empty symbols. Missing packs or entries use Mermaid's standard unknown icon, while the built-in file and folder icons remain authoritative.

Internal SVG IDs and references are isolated per diagram and symbol, so repeated renders are deterministic and multiple icons cannot collide after symbol-name sanitization.

## What changed

- Resolve TreeView icons in built-in, configured registry, then unknown-icon order.
- Reuse the existing Flowchart unknown-icon body and keep one definition per unique TreeView icon.
- Scope `id`, local URL, `href`/XLink, SMIL, and ARIA references without rewriting unrelated namespaced metadata.
- Exercise the local CLI Iconify loader through `SvgRenderOptions` into TreeView and update current compatibility and coverage documentation.

## Verification

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p merman-render --lib --tests --all-features --no-deps -- -D warnings`
- [x] `cargo nextest run -p merman-render --test flowchart_svg_test --test tree_view_svg_test --test svg_internal_id_test` (70 passed)
- [x] `cargo nextest run -p merman-cli --test cli_compat dynamic_icon_pack` (6 passed)
- [x] `cargo run -p xtask -- compare-tree-view-svgs --check-dom --dom-mode parity --dom-decimals 3`
- [x] `cargo nextest run --workspace` (4035 passed, 5 skipped by repository configuration)
- [x] `git diff --check`
- [x] Benchmark or report updated if this affects performance (not applicable; no performance contract changed)

## Performance / parity notes

- Benchmark or report: no benchmark update required; rendering remains bounded to one registry lookup and symbol body per unique TreeView icon.
- Parity impact: existing upstream TreeView fixtures retain DOM parity; configured packs now follow Mermaid's 14px icon-body behavior.
- Security boundary: loader policy is unchanged. HTTP(S) loading still requires `--allow-network`, registered SVG bodies remain trusted input, and the renderer performs no filesystem, package-manager, or network I/O.
- Rollback risk: localized to icon definition emission and internal ID scoping; reverting this PR restores the previous empty third-party TreeView symbols.

## Follow-ups

- Keep Architecture's source-copied built-in icon table unchanged.
- Track libFuzzer and sanitizer hardening as a separate follow-up after the parity PR sequence.

## Post-Deploy Monitoring & Validation

No additional production monitoring is required because this changes library and CLI rendering behavior without a deployed service, logs, or dashboards. During the first downstream render after merge, the maintainer should verify that a configured TreeView icon contains its registered body and that an unavailable icon contains the standard fallback; invalid SVG, broken local references, or a required CI regression is the rollback trigger.
