### PR TITLE
refactor(core): model Railroad repetition bounds as JS numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on *Keep a Changelog*, and this project adheres to *Semantic
 
 ### Fixes and polish
 
-- Railroad ABNF now accepts Mermaid-compatible large repetition bounds, including binary64 rounding and positive infinity; semantic JSON represents infinity as `null`.
+- Railroad ABNF now accepts Mermaid-compatible large repetition bounds, including binary64 rounding and positive infinity; semantic JSON represents infinity as `null`. #24
 - TreeView now embeds configured Iconify pack bodies at Mermaid's 14px size and shows the standard unknown icon for missing packs or entries. #23
 - Removed 37 obsolete fixture-scoped root viewport pins and tightened the no-growth guard to the 183-entry Mermaid 11.16 inventory. #22
 - Kept centered Railroad choice branches straight when equivalent lane coordinates differ only because of floating-point addition order. #22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,10 @@ The format is based on *Keep a Changelog*, and this project adheres to *Semantic
 ### Breaking changes
 
 - Updated the compatibility target from Mermaid `11.15.0` to `11.16.0`; integrations that retain semantic, layout, or SVG parity snapshots should regenerate them.
-- `RailroadAstNode::Repetition` now uses `RailroadRepeatBound` for both `min` and `max` instead of `u64` and `Option<u64>`; Rust callers should construct finite bounds with constants or `From<u64>` and use `RailroadRepeatBound::INFINITY` for an unbounded maximum.
 
 ### New and changed
 
-- Added parser and editor facts, typed layout, and SVG rendering for `cynefin-beta` and all four Railroad dialects: `railroad-beta`, `railroad-ebnf-beta`, `railroad-abnf-beta`, and `railroad-peg-beta`.
+- Added parser and editor facts, typed layout, and SVG rendering for `cynefin-beta` and all four Railroad dialects: `railroad-beta`, `railroad-ebnf-beta`, `railroad-abnf-beta`, and `railroad-peg-beta`. #21 #24
 - Added parse-only support for `swimlane-beta` through shared Flowchart semantics and Mermaid 11.16 configuration defaults; dedicated Swimlane layout and SVG admission remain deferred.
 - Aligned Mermaid 11.16 behavior across existing diagrams, including Flowchart and State self-loops, Sequence blocks and wrapping, Ishikawa recursive DOM structure, TreeView ordering, XYChart point labels, Architecture hints, Pie highlighting, Gantt timing, and config/frontmatter handling.
 - Upstream SVG tooling now verifies pinned source, renderer runtime, browser timezone and fonts, input, and SVG provenance and promotes complete family batches transactionally under cross-process locks.
@@ -21,7 +20,6 @@ The format is based on *Keep a Changelog*, and this project adheres to *Semantic
 
 ### Fixes and polish
 
-- Railroad ABNF now accepts Mermaid-compatible large repetition bounds, including binary64 rounding and positive infinity; semantic JSON represents infinity as `null`. #24
 - TreeView now embeds configured Iconify pack bodies at Mermaid's 14px size and shows the standard unknown icon for missing packs or entries. #23
 - Removed 37 obsolete fixture-scoped root viewport pins and tightened the no-growth guard to the 183-entry Mermaid 11.16 inventory. #22
 - Kept centered Railroad choice branches straight when equivalent lane coordinates differ only because of floating-point addition order. #22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on *Keep a Changelog*, and this project adheres to *Semantic
 ### Breaking changes
 
 - Updated the compatibility target from Mermaid `11.15.0` to `11.16.0`; integrations that retain semantic, layout, or SVG parity snapshots should regenerate them.
+- `RailroadAstNode::Repetition` now uses `RailroadRepeatBound` for both `min` and `max` instead of `u64` and `Option<u64>`; Rust callers should construct finite bounds with constants or `From<u64>` and use `RailroadRepeatBound::INFINITY` for an unbounded maximum.
 
 ### New and changed
 
@@ -20,10 +21,11 @@ The format is based on *Keep a Changelog*, and this project adheres to *Semantic
 
 ### Fixes and polish
 
+- Railroad ABNF now accepts Mermaid-compatible large repetition bounds, including binary64 rounding and positive infinity; semantic JSON represents infinity as `null`.
 - TreeView now embeds configured Iconify pack bodies at Mermaid's 14px size and shows the standard unknown icon for missing packs or entries. #23
 - Removed 37 obsolete fixture-scoped root viewport pins and tightened the no-growth guard to the 183-entry Mermaid 11.16 inventory. #22
 - Kept centered Railroad choice branches straight when equivalent lane coordinates differ only because of floating-point addition order. #22
-- Fixed Mermaid 11.16 edge cases in TreeView annotation boundaries, 14px built-in icons, and highlight bounds; Cynefin inline syntax, frontmatter titles, and global fonts; Architecture reserved IDs; exact Railroad ABNF overflow diagnostics; and generated XYChart axis defaults. #21
+- Fixed Mermaid 11.16 edge cases in TreeView annotation boundaries, 14px built-in icons, and highlight bounds; Cynefin inline syntax, frontmatter titles, and global fonts; Architecture reserved IDs; and generated XYChart axis defaults. #21
 - Hardened upstream SVG maintenance so full-family generation removes obsolete fixture baselines transactionally, compare/audit readers cannot race shared Mermaid CLI installs, and root-override audits consume root attributes captured from the locked compare generation. #21
 - Unified fixture importer reject/defer rollback handling so all import sources restore the same transaction state after a failed baseline or deferred-fixture operation. #21
 

--- a/crates/merman-cli/tests/cli_compat.rs
+++ b/crates/merman-cli/tests/cli_compat.rs
@@ -752,6 +752,33 @@ fn cli_lint_reports_markdown_fence_failure_as_json_from_stdin_file_name() {
 }
 
 #[test]
+fn cli_parse_meta_reports_javascript_compatible_railroad_repeat_bounds() {
+    let huge = "9".repeat(400);
+    let source = format!(
+        "railroad-abnf-beta\nrounded = 9007199254740993\"a\" ;\ninfinite = {huge}\"b\" ;\n"
+    );
+    let output = run_with_stdin(&["parse", "--meta", "-"], &source);
+
+    assert!(output.status.success(), "stderr: {:?}", output.stderr);
+    let payload: Value =
+        serde_json::from_slice(&output.stdout).expect("parse --meta stdout should be JSON");
+    assert_eq!(payload["meta"]["diagram_type"], "railroadAbnf");
+
+    let rules = payload["model"]["rules"]
+        .as_array()
+        .expect("Railroad rules should be an array");
+    assert_eq!(rules.len(), 2);
+    for field in ["min", "max"] {
+        assert_eq!(
+            rules[0]["definition"][field].as_f64(),
+            Some(9_007_199_254_740_992.0),
+            "rounded {field}"
+        );
+        assert!(rules[1]["definition"][field].is_null(), "infinite {field}");
+    }
+}
+
+#[test]
 fn cli_parse_gantt_fixed_today_makes_missing_year_dates_deterministic() {
     let output = run_with_stdin(
         &[

--- a/crates/merman-core/README.md
+++ b/crates/merman-core/README.md
@@ -18,8 +18,7 @@ Pre-0.8 migration note: `Error::DiagramParse` carries
 `diagnostic.span_kind()`, and `diagnostic.code()` when an integration can
 preserve structured parser metadata.
 
-Railroad AST migration note: `RailroadAstNode::Repetition` now uses
-`RailroadRepeatBound` for both `min` and `max`, replacing `u64` and `Option<u64>`.
+Railroad repetition bounds use `RailroadRepeatBound` for both `min` and `max`.
 Use `ZERO`, `ONE`, or `RailroadRepeatBound::from(value)` for finite bounds and
 `RailroadRepeatBound::INFINITY` for an unbounded maximum. Inspect values with
 `is_zero()`, `is_one()`, `is_infinite()`, or `as_f64()`; `TryFrom<f64>` rejects

--- a/crates/merman-core/README.md
+++ b/crates/merman-core/README.md
@@ -18,6 +18,15 @@ Pre-0.8 migration note: `Error::DiagramParse` carries
 `diagnostic.span_kind()`, and `diagnostic.code()` when an integration can
 preserve structured parser metadata.
 
+Railroad AST migration note: `RailroadAstNode::Repetition` now uses
+`RailroadRepeatBound` for both `min` and `max`, replacing `u64` and `Option<u64>`.
+Use `ZERO`, `ONE`, or `RailroadRepeatBound::from(value)` for finite bounds and
+`RailroadRepeatBound::INFINITY` for an unbounded maximum. Inspect values with
+`is_zero()`, `is_one()`, `is_infinite()`, or `as_f64()`; `TryFrom<f64>` rejects
+NaN, negative, and fractional values. Finite bounds serialize as JSON numbers,
+while infinity serializes as `null`. Integers beyond binary64's exact range may
+round to match Mermaid's JavaScript number semantics.
+
 ## What It Provides
 
 - Mermaid diagram detection and preprocessing, including front matter and directives.

--- a/crates/merman-core/src/diagrams/railroad.rs
+++ b/crates/merman-core/src/diagrams/railroad.rs
@@ -3,8 +3,10 @@ use crate::{
     EditorExpectedSyntax, EditorExpectedSyntaxKind, EditorSemanticFacts, EditorSemanticKind,
     EditorSemanticSymbol, Error, ParseMetadata, Result, SourceSpan,
 };
-use serde::{Deserialize, Serialize};
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{Value, json};
+use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RailroadDialect {
@@ -40,6 +42,174 @@ impl RailroadDialect {
             Self::Abnf => "railroad abnf",
             Self::Peg => "railroad peg",
         }
+    }
+}
+
+/// A Mermaid Railroad repetition bound stored with JavaScript number semantics.
+///
+/// Values are non-negative integral binary64 numbers or positive infinity. Positive infinity
+/// represents an unbounded maximum or an oversized ABNF bound and serializes as JSON `null`,
+/// matching `JSON.stringify(Infinity)`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RailroadRepeatBound(f64);
+
+impl Eq for RailroadRepeatBound {}
+
+impl RailroadRepeatBound {
+    /// The finite bound zero.
+    pub const ZERO: Self = Self(0.0);
+    /// The finite bound one.
+    pub const ONE: Self = Self(1.0);
+    /// The positive-infinity bound.
+    pub const INFINITY: Self = Self(f64::INFINITY);
+
+    /// Returns whether this bound is zero.
+    pub const fn is_zero(self) -> bool {
+        self.0 == 0.0
+    }
+
+    /// Returns whether this bound is one.
+    pub const fn is_one(self) -> bool {
+        self.0 == 1.0
+    }
+
+    /// Returns whether this bound is positive infinity.
+    pub const fn is_infinite(self) -> bool {
+        self.0.is_infinite()
+    }
+
+    /// Returns the validated binary64 value.
+    pub const fn as_f64(self) -> f64 {
+        self.0
+    }
+}
+
+/// An invalid value supplied to [`RailroadRepeatBound`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum RailroadRepeatBoundError {
+    /// The supplied value was NaN.
+    #[error("railroad repetition bound cannot be NaN")]
+    NotANumber,
+    /// The supplied value was negative, including negative infinity.
+    #[error("railroad repetition bound must be non-negative")]
+    Negative,
+    /// The supplied finite value had a fractional component.
+    #[error("railroad repetition bound must be an integer")]
+    Fractional,
+}
+
+impl TryFrom<f64> for RailroadRepeatBound {
+    type Error = RailroadRepeatBoundError;
+
+    fn try_from(value: f64) -> std::result::Result<Self, Self::Error> {
+        if value.is_nan() {
+            return Err(RailroadRepeatBoundError::NotANumber);
+        }
+        if value.is_sign_negative() && value != 0.0 {
+            return Err(RailroadRepeatBoundError::Negative);
+        }
+        if value == 0.0 {
+            return Ok(Self::ZERO);
+        }
+        if value.is_infinite() {
+            return Ok(Self::INFINITY);
+        }
+        if value.fract() != 0.0 {
+            return Err(RailroadRepeatBoundError::Fractional);
+        }
+        Ok(Self(value))
+    }
+}
+
+impl From<u64> for RailroadRepeatBound {
+    fn from(value: u64) -> Self {
+        Self(value as f64)
+    }
+}
+
+impl Serialize for RailroadRepeatBound {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if self.is_infinite() {
+            return serializer.serialize_none();
+        }
+
+        let integer = self.0 as u64;
+        if (integer as f64).to_bits() == self.0.to_bits() {
+            serializer.serialize_u64(integer)
+        } else {
+            serializer.serialize_f64(self.0)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for RailroadRepeatBound {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct RailroadRepeatBoundVisitor;
+
+        impl<'de> Visitor<'de> for RailroadRepeatBoundVisitor {
+            type Value = RailroadRepeatBound;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a non-negative integer or null")
+            }
+
+            fn visit_unit<E>(self) -> std::result::Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(RailroadRepeatBound::INFINITY)
+            }
+
+            fn visit_none<E>(self) -> std::result::Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(RailroadRepeatBound::INFINITY)
+            }
+
+            fn visit_u64<E>(self, value: u64) -> std::result::Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(RailroadRepeatBound::from(value))
+            }
+
+            fn visit_u128<E>(self, value: u128) -> std::result::Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                RailroadRepeatBound::try_from(value as f64).map_err(E::custom)
+            }
+
+            fn visit_i64<E>(self, value: i64) -> std::result::Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                RailroadRepeatBound::try_from(value as f64).map_err(E::custom)
+            }
+
+            fn visit_i128<E>(self, value: i128) -> std::result::Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                RailroadRepeatBound::try_from(value as f64).map_err(E::custom)
+            }
+
+            fn visit_f64<E>(self, value: f64) -> std::result::Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                RailroadRepeatBound::try_from(value).map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_any(RailroadRepeatBoundVisitor)
     }
 }
 
@@ -135,8 +305,9 @@ pub enum RailroadAstNode {
     #[serde(rename = "repetition")]
     Repetition {
         element: Box<RailroadAstNode>,
-        min: u64,
-        max: Option<u64>,
+        min: RailroadRepeatBound,
+        #[serde(default = "default_repeat_max")]
+        max: RailroadRepeatBound,
         #[serde(skip_serializing_if = "Option::is_none")]
         separator: Option<Box<RailroadAstNode>>,
         #[serde(skip_serializing, default = "zero_span")]
@@ -150,6 +321,10 @@ pub enum RailroadAstNode {
         #[serde(skip_serializing, default = "zero_span")]
         selection: SourceSpan,
     },
+}
+
+fn default_repeat_max() -> RailroadRepeatBound {
+    RailroadRepeatBound::INFINITY
 }
 
 fn zero_span() -> SourceSpan {
@@ -515,8 +690,8 @@ impl<'a> RailroadParser<'a> {
                 let end = self.expect_symbol(')', "expected ')' after oneOrMore argument")?;
                 RailroadAstNode::Repetition {
                     element: Box::new(element),
-                    min: 1,
-                    max: None,
+                    min: RailroadRepeatBound::ONE,
+                    max: RailroadRepeatBound::INFINITY,
                     separator: None,
                     span: SourceSpan::new(start, end.span.end),
                 }
@@ -527,8 +702,8 @@ impl<'a> RailroadParser<'a> {
                 let end = self.expect_symbol(')', "expected ')' after zeroOrMore argument")?;
                 RailroadAstNode::Repetition {
                     element: Box::new(element),
-                    min: 0,
-                    max: None,
+                    min: RailroadRepeatBound::ZERO,
+                    max: RailroadRepeatBound::INFINITY,
                     separator: None,
                     span: SourceSpan::new(start, end.span.end),
                 }
@@ -624,8 +799,8 @@ impl<'a> RailroadParser<'a> {
                 let span = SourceSpan::new(node.span().start, self.previous_end());
                 node = RailroadAstNode::Repetition {
                     element: Box::new(node),
-                    min: 0,
-                    max: None,
+                    min: RailroadRepeatBound::ZERO,
+                    max: RailroadRepeatBound::INFINITY,
                     separator: None,
                     span,
                 };
@@ -635,8 +810,8 @@ impl<'a> RailroadParser<'a> {
                 let span = SourceSpan::new(node.span().start, self.previous_end());
                 node = RailroadAstNode::Repetition {
                     element: Box::new(node),
-                    min: 1,
-                    max: None,
+                    min: RailroadRepeatBound::ONE,
+                    max: RailroadRepeatBound::INFINITY,
                     separator: None,
                     span,
                 };
@@ -707,8 +882,8 @@ impl<'a> RailroadParser<'a> {
             let end = self.expect_symbol('}', "expected '}' after EBNF repetition")?;
             return Ok(RailroadAstNode::Repetition {
                 element: Box::new(element),
-                min: 0,
-                max: None,
+                min: RailroadRepeatBound::ZERO,
+                max: RailroadRepeatBound::INFINITY,
                 separator: None,
                 span: SourceSpan::new(start, end.span.end),
             });
@@ -758,17 +933,10 @@ impl<'a> RailroadParser<'a> {
             return Ok(primary);
         };
 
-        let (min, max) = parse_abnf_repeat_bounds(&repeat.text).map_err(|overflow| {
-            self.error_at_span(
-                SourceSpan::new(
-                    repeat.span.start + overflow.start,
-                    repeat.span.start + overflow.end,
-                ),
-                ABNF_REPEAT_BOUND_OVERFLOW_MESSAGE,
-            )
-        })?;
+        let (min, max) = parse_abnf_repeat_bounds(&repeat.text)
+            .ok_or_else(|| self.error_at_span(repeat.span, "invalid ABNF repetition bound"))?;
         let span = SourceSpan::new(repeat.span.start, primary.span().end);
-        if min == 0 && max == Some(1) {
+        if min.is_zero() && max.is_one() {
             return Ok(RailroadAstNode::Optional {
                 element: Box::new(primary),
                 span,
@@ -894,8 +1062,8 @@ impl<'a> RailroadParser<'a> {
             return Ok(RailroadAstNode::Repetition {
                 span: SourceSpan::new(primary.span().start, self.previous_end()),
                 element: Box::new(primary),
-                min: 0,
-                max: None,
+                min: RailroadRepeatBound::ZERO,
+                max: RailroadRepeatBound::INFINITY,
                 separator: None,
             });
         }
@@ -903,8 +1071,8 @@ impl<'a> RailroadParser<'a> {
             return Ok(RailroadAstNode::Repetition {
                 span: SourceSpan::new(primary.span().start, self.previous_end()),
                 element: Box::new(primary),
-                min: 1,
-                max: None,
+                min: RailroadRepeatBound::ONE,
+                max: RailroadRepeatBound::INFINITY,
                 separator: None,
             });
         }
@@ -1879,41 +2047,30 @@ fn strip_inline_comment_aware(line: &str) -> &str {
     line
 }
 
-const ABNF_REPEAT_BOUND_OVERFLOW_MESSAGE: &str =
-    "ABNF repetition bound exceeds the supported integer range";
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct AbnfRepeatBoundOverflow {
-    start: usize,
-    end: usize,
-}
-
-fn parse_abnf_repeat_bounds(
-    repeat: &str,
-) -> std::result::Result<(u64, Option<u64>), AbnfRepeatBoundOverflow> {
-    let parse_bound = |bound: &str, start: usize| {
-        bound.parse::<u64>().map_err(|_| AbnfRepeatBoundOverflow {
-            start,
-            end: start + bound.len(),
-        })
+fn parse_abnf_repeat_bounds(repeat: &str) -> Option<(RailroadRepeatBound, RailroadRepeatBound)> {
+    let parse_bound = |bound: &str| {
+        bound
+            .parse::<f64>()
+            .ok()
+            .and_then(|value| RailroadRepeatBound::try_from(value).ok())
     };
 
     if let Some((min, max)) = repeat.split_once('*') {
         let min = if min.is_empty() {
-            0
+            RailroadRepeatBound::ZERO
         } else {
-            parse_bound(min, 0)?
+            parse_bound(min)?
         };
         let max = if max.is_empty() {
-            None
+            RailroadRepeatBound::INFINITY
         } else {
-            Some(parse_bound(max, repeat.len() - max.len())?)
+            parse_bound(max)?
         };
-        return Ok((min, max));
+        return Some((min, max));
     }
 
-    let exact = parse_bound(repeat, 0)?;
-    Ok((exact, Some(exact)))
+    let exact = parse_bound(repeat)?;
+    Some((exact, exact))
 }
 
 fn collapse_sequence(elements: Vec<RailroadAstNode>, span: SourceSpan) -> RailroadAstNode {
@@ -2180,66 +2337,38 @@ mod tests {
 
     #[test]
     fn parses_repeat_bounds() {
-        assert_eq!(parse_abnf_repeat_bounds("*"), Ok((0, None)));
-        assert_eq!(parse_abnf_repeat_bounds("1*"), Ok((1, None)));
-        assert_eq!(parse_abnf_repeat_bounds("*2"), Ok((0, Some(2))));
-        assert_eq!(parse_abnf_repeat_bounds("1*2"), Ok((1, Some(2))));
-        assert_eq!(parse_abnf_repeat_bounds("3"), Ok((3, Some(3))));
+        assert_eq!(
+            parse_abnf_repeat_bounds("*"),
+            Some((RailroadRepeatBound::ZERO, RailroadRepeatBound::INFINITY))
+        );
+        assert_eq!(
+            parse_abnf_repeat_bounds("1*"),
+            Some((RailroadRepeatBound::ONE, RailroadRepeatBound::INFINITY))
+        );
+        assert_eq!(
+            parse_abnf_repeat_bounds("*2"),
+            Some((RailroadRepeatBound::ZERO, 2.into()))
+        );
+        assert_eq!(
+            parse_abnf_repeat_bounds("1*2"),
+            Some((RailroadRepeatBound::ONE, 2.into()))
+        );
+        assert_eq!(parse_abnf_repeat_bounds("3"), Some((3.into(), 3.into())));
         assert_eq!(
             parse_abnf_repeat_bounds("18446744073709551615"),
-            Ok((u64::MAX, Some(u64::MAX)))
+            Some((u64::MAX.into(), u64::MAX.into()))
+        );
+        assert_eq!(
+            parse_abnf_repeat_bounds("18446744073709551616"),
+            Some((u64::MAX.into(), u64::MAX.into()))
         );
         assert_eq!(
             parse_abnf_repeat_bounds("00000000000000000002*00000000000000000003"),
-            Ok((2, Some(3)))
+            Some((2.into(), 3.into()))
         );
-    }
-
-    fn assert_abnf_repeat_overflow(repeat: &str, bound_start: usize, bound_end: usize) {
-        let source = format!("railroad-abnf-beta\nrule = {repeat}\"a\" ;\n");
-        let tokens = Lexer::new(&source, RailroadDialect::Abnf, "railroadAbnf")
-            .tokenize()
-            .expect("ABNF source should tokenize");
-        let error =
-            RailroadParser::new(tokens, source.len(), "railroadAbnf", RailroadDialect::Abnf)
-                .parse()
-                .expect_err("overflowing repetition bound should be rejected");
-        let Error::DiagramParse {
-            diagram_type,
-            diagnostic,
-        } = error
-        else {
-            panic!("expected railroad parse error");
-        };
-
-        let repeat_start = source.find(repeat).expect("source should contain repeat");
-        assert_eq!(diagram_type, "railroadAbnf");
-        assert_eq!(diagnostic.message(), ABNF_REPEAT_BOUND_OVERFLOW_MESSAGE);
-        assert_eq!(
-            diagnostic.span(),
-            Some(SourceSpan::new(
-                repeat_start + bound_start,
-                repeat_start + bound_end,
-            ))
-        );
-        assert_eq!(
-            diagnostic.span_kind(),
-            crate::ParseDiagnosticSpanKind::Exact
-        );
-    }
-
-    #[test]
-    fn rejects_overflowing_exact_abnf_repeat_bound() {
-        assert_abnf_repeat_overflow("18446744073709551616", 0, 20);
-    }
-
-    #[test]
-    fn rejects_overflowing_minimum_abnf_repeat_bound() {
-        assert_abnf_repeat_overflow("18446744073709551616*", 0, 20);
-    }
-
-    #[test]
-    fn rejects_overflowing_maximum_abnf_repeat_bound() {
-        assert_abnf_repeat_overflow("1*18446744073709551616", 2, 22);
+        let huge = "9".repeat(400);
+        let (min, max) = parse_abnf_repeat_bounds(&huge).expect("all-digit repeat bound");
+        assert!(min.is_infinite());
+        assert!(max.is_infinite());
     }
 }

--- a/crates/merman-core/src/tests/railroad.rs
+++ b/crates/merman-core/src/tests/railroad.rs
@@ -1,5 +1,98 @@
+use crate::diagrams::railroad::{RailroadRepeatBound, RailroadRepeatBoundError};
 use crate::*;
 use serde_json::json;
+
+#[test]
+fn railroad_repeat_bound_validates_public_construction() {
+    let negative_zero = RailroadRepeatBound::try_from(-0.0).expect("negative zero is valid");
+    assert_eq!(negative_zero, RailroadRepeatBound::ZERO);
+    assert_eq!(negative_zero.as_f64().to_bits(), 0.0f64.to_bits());
+
+    assert!(RailroadRepeatBound::ZERO.is_zero());
+    assert!(!RailroadRepeatBound::ZERO.is_one());
+    assert!(RailroadRepeatBound::ONE.is_one());
+    assert!(!RailroadRepeatBound::ONE.is_infinite());
+    assert!(RailroadRepeatBound::INFINITY.is_infinite());
+    assert_eq!(
+        RailroadRepeatBound::try_from(f64::INFINITY).unwrap(),
+        RailroadRepeatBound::INFINITY
+    );
+    assert_eq!(
+        RailroadRepeatBound::from(u64::MAX).as_f64().to_bits(),
+        (u64::MAX as f64).to_bits()
+    );
+
+    for (invalid, expected) in [
+        (f64::NAN, RailroadRepeatBoundError::NotANumber),
+        (f64::NEG_INFINITY, RailroadRepeatBoundError::Negative),
+        (-1.0, RailroadRepeatBoundError::Negative),
+        (0.5, RailroadRepeatBoundError::Fractional),
+    ] {
+        assert_eq!(
+            RailroadRepeatBound::try_from(invalid),
+            Err(expected),
+            "unexpected error for invalid repeat bound: {invalid}"
+        );
+    }
+}
+
+#[test]
+fn railroad_repeat_bound_serde_preserves_finite_and_infinite_states() {
+    for (bound, expected_json) in [
+        (RailroadRepeatBound::ZERO, "0"),
+        (RailroadRepeatBound::ONE, "1"),
+        (
+            RailroadRepeatBound::try_from(9_007_199_254_740_992.0).unwrap(),
+            "9007199254740992",
+        ),
+        (RailroadRepeatBound::INFINITY, "null"),
+    ] {
+        let encoded = serde_json::to_string(&bound).expect("repeat bound serializes");
+        assert_eq!(encoded, expected_json);
+        let decoded: RailroadRepeatBound =
+            serde_json::from_str(&encoded).expect("repeat bound deserializes");
+        assert_eq!(decoded, bound);
+    }
+
+    for bound in [
+        RailroadRepeatBound::from(u64::MAX),
+        RailroadRepeatBound::try_from(18_446_744_073_709_551_616.0).unwrap(),
+        RailroadRepeatBound::try_from(f64::MAX).unwrap(),
+    ] {
+        let encoded = serde_json::to_string(&bound).expect("large finite bound serializes");
+        let decoded: RailroadRepeatBound =
+            serde_json::from_str(&encoded).expect("large finite bound deserializes");
+        assert_eq!(decoded.as_f64().to_bits(), bound.as_f64().to_bits());
+    }
+
+    for value in [
+        json!({
+            "type": "repetition",
+            "element": { "type": "terminal", "value": "item" },
+            "min": 1
+        }),
+        json!({
+            "type": "repetition",
+            "element": { "type": "terminal", "value": "item" },
+            "min": 1,
+            "max": null
+        }),
+    ] {
+        let node: crate::diagrams::railroad::RailroadAstNode =
+            serde_json::from_value(value).expect("unbounded repetition deserializes");
+        let crate::diagrams::railroad::RailroadAstNode::Repetition { max, .. } = node else {
+            panic!("expected repetition node");
+        };
+        assert!(max.is_infinite());
+    }
+
+    for invalid_json in ["-1", "0.5", r#""1""#, "{}", "[]"] {
+        assert!(
+            serde_json::from_str::<RailroadRepeatBound>(invalid_json).is_err(),
+            "invalid repeat bound JSON was accepted: {invalid_json}"
+        );
+    }
+}
 
 #[test]
 fn parse_railroad_ir_rules_and_editor_facts() {
@@ -137,33 +230,106 @@ rule = 1*2"hello" / [ other-rule ] / %x41 ;
 }
 
 #[test]
-fn parse_railroad_abnf_preserves_supported_repeat_bound_extremes() {
+fn parse_railroad_abnf_matches_javascript_repeat_number_semantics() {
+    let huge = "9".repeat(400);
+    let source = format!(
+        r#"railroad-abnf-beta
+rule = 9007199254740991"a" / 9007199254740992"b" / 9007199254740993"c" / 18446744073709551615*"d" / 18446744073709551616*"e" / *3"f" / 2*"g" / *"h" / 5*2"i" / *1"j" / {huge}"k" / 00000000000000000002*00000000000000000003"l" / {huge}*1"m" / 1*{huge}"n" ;
+"#
+    );
+    let parsed = Engine::new()
+        .parse_diagram_sync(&source, ParseOptions::strict())
+        .unwrap()
+        .expect("all valid ABNF repetition bounds should parse");
+
+    let alternatives = parsed.model["rules"][0]["definition"]["alternatives"]
+        .as_array()
+        .expect("choice alternatives");
+    assert_eq!(alternatives.len(), 14);
+    assert_eq!(alternatives[0]["min"].as_u64(), Some(9_007_199_254_740_991));
+    assert_eq!(alternatives[0]["max"].as_u64(), Some(9_007_199_254_740_991));
+    assert_eq!(
+        alternatives[1]["min"].as_f64(),
+        Some(9_007_199_254_740_992.0)
+    );
+    assert_eq!(
+        alternatives[2]["min"].as_f64(),
+        Some(9_007_199_254_740_992.0)
+    );
+    assert_eq!(
+        alternatives[3]["min"].as_f64(),
+        Some(18_446_744_073_709_551_616.0)
+    );
+    assert_eq!(
+        alternatives[4]["min"].as_f64(),
+        Some(18_446_744_073_709_551_616.0)
+    );
+    assert_eq!(alternatives[3]["max"], json!(null));
+    assert_eq!(alternatives[4]["max"], json!(null));
+    assert_eq!(
+        (
+            alternatives[5]["min"].as_u64(),
+            alternatives[5]["max"].as_u64()
+        ),
+        (Some(0), Some(3))
+    );
+    assert_eq!(
+        (alternatives[6]["min"].as_u64(), &alternatives[6]["max"]),
+        (Some(2), &json!(null))
+    );
+    assert_eq!(
+        (alternatives[7]["min"].as_u64(), &alternatives[7]["max"]),
+        (Some(0), &json!(null))
+    );
+    assert_eq!(
+        (
+            alternatives[8]["min"].as_u64(),
+            alternatives[8]["max"].as_u64()
+        ),
+        (Some(5), Some(2))
+    );
+    assert_eq!(alternatives[9]["type"], json!("optional"));
+    assert_eq!(alternatives[10]["min"], json!(null));
+    assert_eq!(alternatives[10]["max"], json!(null));
+    assert_eq!(
+        (
+            alternatives[11]["min"].as_u64(),
+            alternatives[11]["max"].as_u64()
+        ),
+        (Some(2), Some(3))
+    );
+    assert_eq!(alternatives[12]["min"], json!(null));
+    assert_eq!(alternatives[12]["max"].as_u64(), Some(1));
+    assert_eq!(alternatives[13]["min"].as_u64(), Some(1));
+    assert_eq!(alternatives[13]["max"], json!(null));
+}
+
+#[test]
+fn parse_railroad_peg_repetitions_keep_ordinary_json_shape() {
     let parsed = Engine::new()
         .parse_diagram_sync(
-            r#"railroad-abnf-beta
-rule = 18446744073709551615*"a" / 00000000000000000002"b" ;
-"#,
+            "railroad-peg-beta\nrule <- zero* one+ ;\n",
             ParseOptions::strict(),
         )
         .unwrap()
-        .expect("ABNF repetition bounds through u64::MAX should parse");
+        .expect("railroad PEG repetitions parse");
 
     assert_eq!(
         parsed.model["rules"][0]["definition"],
         json!({
-            "type": "choice",
-            "alternatives": [
+            "type": "sequence",
+            "elements": [
                 {
                     "type": "repetition",
-                    "element": { "type": "terminal", "value": "a" },
-                    "min": u64::MAX,
+                    "element": { "type": "nonterminal", "name": "zero" },
+                    "min": 0,
                     "max": null
                 },
                 {
                     "type": "repetition",
-                    "element": { "type": "terminal", "value": "b" },
-                    "min": 2,
-                    "max": 2
+                    "element": { "type": "nonterminal", "name": "one" },
+                    "min": 1,
+                    "max": null
                 }
             ]
         })

--- a/crates/merman-render/src/railroad.rs
+++ b/crates/merman-render/src/railroad.rs
@@ -5,7 +5,7 @@ use crate::model::{
 };
 use crate::text::{TextMeasurer, TextStyle};
 use merman_core::diagrams::railroad::{
-    RailroadAstNode, RailroadDiagramRenderModel, RailroadRuleModel,
+    RailroadAstNode, RailroadDiagramRenderModel, RailroadRepeatBound, RailroadRuleModel,
 };
 
 #[derive(Debug, Clone)]
@@ -911,7 +911,7 @@ fn layout_optional(
 
 fn layout_repetition(
     element: &RailroadAstNode,
-    min: u64,
+    min: RailroadRepeatBound,
     style: &RailroadStyle,
     measurer: &dyn TextMeasurer,
 ) -> ExprLayout {
@@ -919,7 +919,7 @@ fn layout_repetition(
     let arc_radius = style.arc_radius;
     let arc_height = arc_radius * 2.0;
     let total_width = inner.width + arc_radius * 4.0;
-    let has_bypass = min == 0;
+    let has_bypass = min.is_zero();
     let total_height = inner.height + arc_height + if has_bypass { arc_height } else { 0.0 };
     let elem_x = arc_radius * 2.0;
     let elem_y = if has_bypass { arc_height } else { 0.0 };
@@ -1305,6 +1305,46 @@ mod tests {
                 .iter()
                 .any(|segment| matches!(segment, PathSegment::EllipticalArc { .. })),
             "expected an arc connector: {path}"
+        );
+    }
+
+    fn repetition_render_path_count(min: RailroadRepeatBound) -> usize {
+        let node = RailroadAstNode::Repetition {
+            element: Box::new(RailroadAstNode::Terminal {
+                value: "item".to_string(),
+                span: merman_core::SourceSpan::new(0, 0),
+                selection: merman_core::SourceSpan::new(0, 0),
+            }),
+            min,
+            max: RailroadRepeatBound::INFINITY,
+            separator: None,
+            span: merman_core::SourceSpan::new(0, 0),
+        };
+        let (render_node, _) = railroad_render_node(
+            &node,
+            &railroad_style(&serde_json::json!({})),
+            &DeterministicTextMeasurer::default(),
+        );
+        let RailroadRenderNode::Group {
+            class, children, ..
+        } = render_node
+        else {
+            panic!("expected railroad repetition render group");
+        };
+        assert_eq!(class, "railroad-repetition");
+        children
+            .iter()
+            .filter(|child| matches!(child, RailroadRenderNode::Path(_)))
+            .count()
+    }
+
+    #[test]
+    fn railroad_repetition_bypass_depends_only_on_zero_minimum() {
+        assert_eq!(repetition_render_path_count(RailroadRepeatBound::ZERO), 4);
+        assert_eq!(repetition_render_path_count(RailroadRepeatBound::ONE), 3);
+        assert_eq!(
+            repetition_render_path_count(RailroadRepeatBound::INFINITY),
+            3
         );
     }
 

--- a/docs/alignment/RAILROAD_MINIMUM.md
+++ b/docs/alignment/RAILROAD_MINIMUM.md
@@ -23,9 +23,11 @@ Upstream references at pinned Mermaid 11.16.0:
   - IR calls: `terminal`, `nonterminal`, `sequence`, `choice`, `optional`, `zeroOrMore`,
     `oneOrMore`, and `special`
   - EBNF choice, sequence, optional, repetition, exception-as-sequence, and special text
-  - ABNF alternation, concatenation, repetition bounds, optional groups, comments, and numeric values
+  - ABNF alternation, concatenation, Mermaid-compatible binary64 repetition bounds (including
+    rounding and positive infinity), optional groups, comments, and numeric values
   - PEG ordered choice, sequence, prefix predicates, suffix operators, any-char, grouping, and comments
   - common `title`, `accTitle`, and `accDescr`
+  - semantic JSON encodes finite repetition bounds as numbers and infinity as `null`
 - LSP/editor facts:
   - header, common directives, rule symbols, terminal labels, nonterminal references, and special text
   - lossy fact scanning remains available when strict parsing fails
@@ -84,6 +86,3 @@ only with a source-backed browser measurement model.
 - The upstream renderer currently ignores `compactMode`, `showMarkers`, repetition separators, and
   repetition maximums during drawing; the local compatibility renderer follows that behavior rather
   than inventing extra semantics.
-- Mermaid accepts arbitrarily long ABNF repetition lexemes through JavaScript `parseInt`, which can
-  round or become `Infinity`. Merman preserves bounds through `u64::MAX` and reports larger values
-  with an exact source span rather than silently changing the public integer AST.

--- a/docs/alignment/RAILROAD_UPSTREAM_TEST_COVERAGE.md
+++ b/docs/alignment/RAILROAD_UPSTREAM_TEST_COVERAGE.md
@@ -28,13 +28,17 @@ Scope: Mermaid tag `@11.16.0`.
   are covered by registry/detection tests.
 - Parser coverage for IR, EBNF, ABNF, and PEG variants lives in
   `crates/merman-core/src/tests/railroad.rs`.
-- Parser internals cover escaped string decoding, ABNF string slicing, and repetition bounds in
+- Parser internals cover escaped string decoding, ABNF string slicing, and JavaScript-compatible
+  binary64 repetition bounds, including rounding, unbounded maxima, and positive infinity, in
   `crates/merman-core/src/diagrams/railroad.rs`.
 - LSP/editor facts cover rules, terminals, nonterminal references, and PEG nonterminal references.
 - Typed render model projection for all four variants is covered by
   `parse_railroad_variants_expose_typed_render_models`.
 - Layout recursion for sequence, optional/repetition arcs, and connector paths is covered by
-  `railroad_layout_handles_sequence_choice_and_repetition`.
+  `railroad_layout_handles_sequence_choice_and_repetition`; zero, finite nonzero, and infinite
+  repetition minima are covered by `railroad_repetition_bypass_depends_only_on_zero_minimum`.
+- CLI `parse --meta` coverage verifies rounded finite Railroad bounds by parsed binary64 value and
+  infinity as JSON `null`; exact large-number JSON spelling is not a compatibility requirement.
 - SVG dispatch and DOM shape for rule groups, rule names, terminals, nonterminals, specials,
   connector paths, and accessible root metadata is covered by
   `render_model_dispatch_renders_railroad_svg`.
@@ -69,6 +73,3 @@ committed corpus; browser-derived root-height differences remain in the exact ro
   consume them in drawing; the local compatibility renderer follows the upstream rendering behavior.
 - The upstream 11.16 renderer does not draw repetition separator or maximum cardinality metadata;
   the local layout keeps those parser facts in the model but does not invent extra SVG semantics.
-- ABNF repetition bounds through `u64::MAX` are preserved exactly. Larger bounds produce an exact
-  overflow diagnostic instead of copying JavaScript `parseInt` rounding (or `Infinity`) into the
-  public integer AST; this is an explicit parser-acceptance residual from Mermaid 11.16.


### PR DESCRIPTION
## Summary

Railroad ABNF now accepts repetition bounds with Mermaid 11.16's JavaScript number semantics, including binary64 rounding beyond the exact-integer range and positive infinity for sufficiently large decimal tokens. Rust callers get a validated public bound type instead of an overflow-only `u64` model.

## What changed

- Replace `RailroadAstNode::Repetition`'s `u64` / `Option<u64>` fields with `RailroadRepeatBound`, whose private representation permits only non-negative integral binary64 values and positive infinity.
- Preserve ordinary semantic JSON while encoding finite bounds as numbers and infinity as `null`; omitted maxima deserialize as infinity for compatibility.
- Keep layout cardinality-free: only a zero minimum adds the repetition bypass. Update CLI coverage, migration guidance, alignment docs, and the Unreleased changelog accordingly.

## Verification

- [x] `cargo fmt --all --check`
- [x] Relevant tests ran: core Railroad 12/12, renderer Railroad 15/15, CLI large-bound contract 1/1, workspace nextest 4037 passed with 5 skipped
- [x] Benchmark or report updated if this affects performance: Railroad alignment coverage and minimum docs updated; no performance benchmark is affected
- [x] All four Railroad SVG DOM parity families pass at 3 decimal places
- [x] `git diff --check`

`cargo run -p xtask -- verify --strict` remains blocked by 59 pre-existing Rust 1.95 Clippy warnings outside this diff. The repository-wide root-parity aggregate also retains known, not-yet-admitted mismatches in other diagram families; all four Railroad family gates pass.

## Performance / parity notes

- Benchmark or report: no runtime benchmark delta; Railroad alignment documents now record binary64 rounding and infinity as admitted behavior.
- Parity impact: small finite bounds retain their semantic JSON and SVG output. Oversized ABNF bounds now match Mermaid instead of returning an overflow diagnostic.
- Rollback risk: reverting restores the previous `u64` / `Option<u64>` public AST and overflow behavior. Rust callers must migrate construction and comparisons to `RailroadRepeatBound`; ordinary JSON consumers do not need a migration.

## Follow-ups

- Keep libFuzzer and sanitizer hardening as a separate fourth follow-up so this public API/parity change remains independently reviewable.
