### PR TITLE
fix(gantt): avoid char-boundary panic in date parsing

### DIFF
--- a/crates/merman-core/src/diagrams/gantt/date.rs
+++ b/crates/merman-core/src/diagrams/gantt/date.rs
@@ -134,12 +134,9 @@ struct DayjsParsedParts {
     unix_ms: Option<i64>,
 }
 
-/// Splits `s` at `byte_idx`, clamping down to the nearest valid char boundary
-/// so this never panics on multi-byte (e.g. non-ASCII task label) input.
-///
-/// Callers that expect an ASCII-digit run at this position still validate the
-/// result afterwards (`is_ascii_digit`/`parse`), so a clamped, shorter-than-
-/// requested `head` is simply rejected by that validation instead of panicking.
+// Clamps `byte_idx` down to the nearest valid char boundary before splitting,
+// so this never panics on multi-byte input; callers already reject a
+// shorter-than-requested `head` via their existing length/digit checks.
 fn split_at_char_boundary(s: &str, byte_idx: usize) -> (&str, &str) {
     let mut idx = byte_idx.min(s.len());
     while idx > 0 && !s.is_char_boundary(idx) {

--- a/crates/merman-core/src/diagrams/gantt/date.rs
+++ b/crates/merman-core/src/diagrams/gantt/date.rs
@@ -134,6 +134,20 @@ struct DayjsParsedParts {
     unix_ms: Option<i64>,
 }
 
+/// Splits `s` at `byte_idx`, clamping down to the nearest valid char boundary
+/// so this never panics on multi-byte (e.g. non-ASCII task label) input.
+///
+/// Callers that expect an ASCII-digit run at this position still validate the
+/// result afterwards (`is_ascii_digit`/`parse`), so a clamped, shorter-than-
+/// requested `head` is simply rejected by that validation instead of panicking.
+fn split_at_char_boundary(s: &str, byte_idx: usize) -> (&str, &str) {
+    let mut idx = byte_idx.min(s.len());
+    while idx > 0 && !s.is_char_boundary(idx) {
+        idx -= 1;
+    }
+    s.split_at(idx)
+}
+
 pub(super) fn parse_dayjs_like_strict(date_format: &str, s: &str) -> Option<DateTimeFixed> {
     let fmt = date_format.trim();
     if fmt.is_empty() {
@@ -169,8 +183,8 @@ pub(super) fn parse_dayjs_like_strict(date_format: &str, s: &str) -> Option<Date
         if s.len() < digits {
             return None;
         }
-        let (head, tail) = s.split_at(digits);
-        if !head.chars().all(|c| c.is_ascii_digit()) {
+        let (head, tail) = split_at_char_boundary(s, digits);
+        if head.len() != digits || !head.chars().all(|c| c.is_ascii_digit()) {
             return None;
         }
         let v = head.parse().ok()?;
@@ -675,14 +689,14 @@ fn parse_js_like_ymd_datetime(s: &str) -> Option<DateTimeFixed> {
             return None;
         };
 
-        let (hh_str, rest) = rest.split_at(2.min(rest.len()));
+        let (hh_str, rest) = split_at_char_boundary(rest, 2);
         let hh = parse_u32(hh_str)? as i32;
 
         let (mm, rest) = if let Some(rest) = rest.strip_prefix(':') {
-            let (mm_str, rest) = rest.split_at(2.min(rest.len()));
+            let (mm_str, rest) = split_at_char_boundary(rest, 2);
             (parse_u32(mm_str)? as i32, rest)
         } else {
-            let (mm_str, rest) = rest.split_at(2.min(rest.len()));
+            let (mm_str, rest) = split_at_char_boundary(rest, 2);
             (parse_u32(mm_str)? as i32, rest)
         };
 
@@ -753,14 +767,14 @@ fn parse_js_like_ymd_datetime(s: &str) -> Option<DateTimeFixed> {
     let (hh_str, rest2) = split_once(rest, ':')?;
     let hour = parse_u32(hh_str)?;
     let (mm_str, mut rest3) = {
-        let (mm_str, rest) = rest2.split_at(2.min(rest2.len()));
+        let (mm_str, rest) = split_at_char_boundary(rest2, 2);
         (mm_str, rest)
     };
     let minute = parse_u32(mm_str)?;
 
     if let Some(r) = rest3.strip_prefix(':') {
         let (ss_str, mut rest4) = {
-            let (ss_str, rest) = r.split_at(2.min(r.len()));
+            let (ss_str, rest) = split_at_char_boundary(r, 2);
             (ss_str, rest)
         };
         second = parse_u32(ss_str)?;

--- a/crates/merman-core/src/diagrams/gantt/tests.rs
+++ b/crates/merman-core/src/diagrams/gantt/tests.rs
@@ -840,6 +840,29 @@ test1: id1,2013-01-01,1d
 }
 
 #[test]
+fn dayjs_strict_rejects_rather_than_panics_on_multibyte_input() {
+    // Regression test: `parse_int_exact` used to check `s.len() < digits`
+    // (a *byte* length) and then call `s.split_at(digits)` (a *byte* offset)
+    // assuming `digits` ASCII bytes == `digits` characters. With multi-byte
+    // (e.g. Japanese) text, `digits` frequently lands in the middle of a
+    // character and `split_at` panics with "byte index N is not a char
+    // boundary" instead of this function returning `None` as intended.
+    assert!(parse_dayjs_like_strict("YYYY-MM-DD", "日本語のテキスト").is_none());
+    assert!(parse_dayjs_like_strict("MM-DD", "日本-24").is_none());
+    assert!(parse_dayjs_like_strict("YYYY-MMM-DD", "２０１３-Jan-０２").is_none());
+}
+
+#[test]
+fn js_date_fallback_rejects_rather_than_panics_on_multibyte_timezone_suffix() {
+    // Regression test: `parse_timezone_offset_minutes` had the same
+    // byte-length-vs-char-boundary bug as `parse_int_exact` above, reached via
+    // `parse_js_date_fallback`'s timezone-offset tail once a valid date/time
+    // prefix is present.
+    assert!(parse_js_date_fallback("2013-01-01T00:00:00+日本語").is_err());
+    assert!(parse_js_date_fallback("2013-01-01T00:00+タ").is_err());
+}
+
+#[test]
 fn gantt_js_date_fallback_parses_iso_datetime_without_tz_as_local() {
     let model = parse(
         r#"

--- a/crates/merman-core/src/diagrams/gantt/tests.rs
+++ b/crates/merman-core/src/diagrams/gantt/tests.rs
@@ -841,12 +841,8 @@ test1: id1,2013-01-01,1d
 
 #[test]
 fn dayjs_strict_rejects_rather_than_panics_on_multibyte_input() {
-    // Regression test: `parse_int_exact` used to check `s.len() < digits`
-    // (a *byte* length) and then call `s.split_at(digits)` (a *byte* offset)
-    // assuming `digits` ASCII bytes == `digits` characters. With multi-byte
-    // (e.g. Japanese) text, `digits` frequently lands in the middle of a
-    // character and `split_at` panics with "byte index N is not a char
-    // boundary" instead of this function returning `None` as intended.
+    // `parse_int_exact` used to slice at a byte offset without checking char
+    // boundaries, panicking on multi-byte (e.g. Japanese) input.
     assert!(parse_dayjs_like_strict("YYYY-MM-DD", "日本語のテキスト").is_none());
     assert!(parse_dayjs_like_strict("MM-DD", "日本-24").is_none());
     assert!(parse_dayjs_like_strict("YYYY-MMM-DD", "２０１３-Jan-０２").is_none());
@@ -854,10 +850,8 @@ fn dayjs_strict_rejects_rather_than_panics_on_multibyte_input() {
 
 #[test]
 fn js_date_fallback_rejects_rather_than_panics_on_multibyte_timezone_suffix() {
-    // Regression test: `parse_timezone_offset_minutes` had the same
-    // byte-length-vs-char-boundary bug as `parse_int_exact` above, reached via
-    // `parse_js_date_fallback`'s timezone-offset tail once a valid date/time
-    // prefix is present.
+    // Same byte-boundary bug as above, reached via the timezone-offset tail
+    // of `parse_js_date_fallback`.
     assert!(parse_js_date_fallback("2013-01-01T00:00:00+日本語").is_err());
     assert!(parse_js_date_fallback("2013-01-01T00:00+タ").is_err());
 }


### PR DESCRIPTION
## Summary

`parse_int_exact` (used by `parse_dayjs_like_strict`, e.g. for `gantt` `dateFormat` tokens like `YYYY`/`MM`/`DD`) and `parse_timezone_offset_minutes` (used by `parse_js_date_fallback`'s ISO-timezone tail) check/clamp against a **byte** length (`s.len()`, `2.min(s.len())`) and then slice at that same byte offset with `str::split_at`, assuming the offset lands on an ASCII digit boundary. When the string being sliced contains multi-byte (non-ASCII, e.g. Japanese) text at or before that offset, the byte index frequently lands in the middle of a character, and `split_at` panics with `byte index N is not a char boundary` instead of these functions returning `None`/`Err` as intended.

This crashes any embedder that doesn't catch panics (e.g. Zed, which aborts the process on panic) whenever a date-like field ends up containing non-ASCII text — found via a real, reproducible crash where a `gantt` chart with Japanese task labels reliably crashed Zed (`zed-industries/merman`, currently pinned to `v0.6.2-with-patches`) on every render.

```rust
// panics: "byte index 4 is not a char boundary; it is inside '本' (bytes 3..6) of `日本語のテキスト`"
parse_dayjs_like_strict("YYYY-MM-DD", "日本語のテキスト");

// panics the same way via the timezone-offset tail
parse_js_date_fallback("2013-01-01T00:00:00+日本語");
```

**Before:** both calls abort the process. **After:** both return `None`/`Err`, same as any other malformed input.

## What changed

Added `split_at_char_boundary`, a small helper in `crates/merman-core/src/diagrams/gantt/date.rs` that clamps the requested byte offset down to the nearest valid char boundary before splitting. Callers already validate the resulting `head` against the expected length / ASCII-digit-ness, so a clamped (shorter-than-requested) `head` is simply rejected by that existing validation instead of panicking — behavior for all-ASCII input is unchanged.

Used at all 6 affected call sites (1 in `parse_int_exact`, 5 in `parse_js_like_ymd_datetime`/`parse_timezone_offset_minutes`).

Added two regression tests hitting the exact previously-panicking paths:
- `dayjs_strict_rejects_rather_than_panics_on_multibyte_input` (`Year4`/`Month2` token parsing, Japanese and fullwidth-digit input)
- `js_date_fallback_rejects_rather_than_panics_on_multibyte_timezone_suffix` (timezone-offset tail)

## Verification
- [ ] `cargo fmt --all --check` — not run locally (no Rust toolchain in the environment this patch was authored in); relying on CI
- [ ] Relevant tests ran — new tests added and byte offsets manually traced against the pre-fix code (confirmed each panics without the fix, returns `None`/`Err` with it), but not executed locally; relying on CI's `build-test` (ubuntu/macos/windows)
- [x] Benchmark or report updated if this affects performance — N/A, not a performance-sensitive path

## Performance / parity notes
- Benchmark or report: N/A
- Parity impact: none — output for valid (ASCII) date/time input is unchanged; only previously-panicking multi-byte input now returns `None`/`Err` instead of crashing
- Rollback risk: low — isolated helper function plus a drop-in replacement at 6 call sites, no change to existing validation/control flow for well-formed input

## Follow-ups

Will file a companion issue on `zed-industries/zed` referencing this PR so they can pull the fix in on their next upstream sync (their fork is pinned to `v0.6.2-with-patches`).
