### PR TITLE
fix(node): repair cross-platform package release smokes

### DIFF
--- a/platforms/node/scripts/smoke-installed-package.mjs
+++ b/platforms/node/scripts/smoke-installed-package.mjs
@@ -1,46 +1,73 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
-import { createRequire } from "node:module";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
-const args = process.argv.slice(2);
-const project = valueAfter(args, "--project");
-const expectedVersion = valueAfter(args, "--version");
-const expectedTarget = valueAfter(args, "--target");
-if (!project || !expectedVersion || !expectedTarget) {
-  throw new Error(
-    "usage: node smoke-installed-package.mjs --project <dir> --version <version> --target <target>",
-  );
+if (isMainModule()) {
+  await main();
 }
 
-const requireFromProject = createRequire(path.join(path.resolve(project), "package.json"));
-const entrypoint = requireFromProject.resolve("@mermanjs/node");
-const packageManifest = JSON.parse(
-  await readFile(path.resolve(path.dirname(entrypoint), "..", "package.json"), "utf8"),
-);
-assert.equal(packageManifest.version, expectedVersion);
+async function main() {
+  const args = process.argv.slice(2);
+  const project = valueAfter(args, "--project");
+  const expectedVersion = valueAfter(args, "--version");
+  const expectedTarget = valueAfter(args, "--target");
+  if (!project || !expectedVersion || !expectedTarget) {
+    throw new Error(
+      "usage: node smoke-installed-package.mjs --project <dir> --version <version> --target <target>",
+    );
+  }
 
-const module = await import(pathToFileURL(entrypoint));
-const engine = await module.createNodeEngine();
-try {
-  assert.equal(engine.runtimeCatalog.package_version, expectedVersion);
-  const svg = await engine.renderSvg("flowchart TD\nA --> B");
-  assert.match(svg, /<svg\b/);
-  assert.match(svg, /<\/svg>/);
-  console.log(
-    JSON.stringify({
-      package: "@mermanjs/node",
-      version: expectedVersion,
-      target: expectedTarget,
-      svg_bytes: Buffer.byteLength(svg),
-    }),
+  const entrypoint = resolveInstalledEntrypoint(project);
+  const packageManifest = JSON.parse(
+    await readFile(path.resolve(path.dirname(entrypoint), "..", "package.json"), "utf8"),
   );
-} finally {
-  await engine.dispose();
+  assert.equal(packageManifest.version, expectedVersion);
+
+  const module = await import(pathToFileURL(entrypoint));
+  const engine = await module.createNodeEngine();
+  try {
+    assert.equal(engine.runtimeCatalog.package_version, expectedVersion);
+    const svg = await engine.renderSvg("flowchart TD\nA --> B");
+    assert.match(svg, /<svg\b/);
+    assert.match(svg, /<\/svg>/);
+    console.log(
+      JSON.stringify({
+        package: "@mermanjs/node",
+        version: expectedVersion,
+        target: expectedTarget,
+        svg_bytes: Buffer.byteLength(svg),
+      }),
+    );
+  } finally {
+    await engine.dispose();
+  }
+}
+
+export function resolveInstalledEntrypoint(project) {
+  // Resolve from the installed project with ESM import conditions. createRequire() would select
+  // CommonJS conditions and reject this intentionally ESM-only package.
+  const entrypointUrl = execFileSync(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      'process.stdout.write(import.meta.resolve("@mermanjs/node"));',
+    ],
+    {
+      cwd: path.resolve(project),
+      encoding: "utf8",
+    },
+  ).trim();
+  return fileURLToPath(entrypointUrl);
 }
 
 function valueAfter(values, flag) {
   const index = values.indexOf(flag);
   return index === -1 ? null : values[index + 1] ?? null;
+}
+
+function isMainModule() {
+  return process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 }

--- a/platforms/node/scripts/verify-packages.mjs
+++ b/platforms/node/scripts/verify-packages.mjs
@@ -11,15 +11,23 @@ import {
 
 const nodeRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
-try {
-  const descriptor = JSON.parse(await readFile(path.join(nodeRoot, "package-surfaces.json"), "utf8"));
-  await inspectPackageManifests(nodeRoot, descriptor);
-  const packedRoot = valueAfter(process.argv.slice(2), "--packed-root");
-  if (packedRoot) verifyPackedRoot(path.resolve(packedRoot), descriptor);
-  console.log("[merman-node] candidate package contracts verified");
-} catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exitCode = 1;
+if (isMainModule()) {
+  await main();
+}
+
+async function main() {
+  try {
+    const descriptor = JSON.parse(
+      await readFile(path.join(nodeRoot, "package-surfaces.json"), "utf8"),
+    );
+    await inspectPackageManifests(nodeRoot, descriptor);
+    const packedRoot = valueAfter(process.argv.slice(2), "--packed-root");
+    if (packedRoot) verifyPackedRoot(path.resolve(packedRoot), descriptor);
+    console.log("[merman-node] candidate package contracts verified");
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
 }
 
 function verifyPackedRoot(root, descriptor) {
@@ -31,7 +39,7 @@ function verifyPackedRoot(root, descriptor) {
 }
 
 function verifyPackage(packageRoot, packageName, role) {
-  const result = spawnSync("npm", ["pack", "--json", "--dry-run"], {
+  const result = spawnSync(npmExecutable(), ["pack", "--json", "--dry-run"], {
     cwd: packageRoot,
     encoding: "utf8",
   });
@@ -40,6 +48,10 @@ function verifyPackage(packageRoot, packageName, role) {
   }
   const output = JSON.parse(result.stdout);
   verifyPackedFileOwnership({ packageName, role, files: output[0]?.files ?? [] });
+}
+
+export function npmExecutable(platform = process.platform) {
+  return platform === "win32" ? "npm.cmd" : "npm";
 }
 
 function existsForTarget(root, target) {
@@ -53,4 +65,8 @@ function existsForTarget(root, target) {
 function valueAfter(args, flag) {
   const index = args.indexOf(flag);
   return index === -1 ? null : args[index + 1] ?? null;
+}
+
+function isMainModule() {
+  return process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 }

--- a/platforms/node/tests/installed-package-smoke.test.mjs
+++ b/platforms/node/tests/installed-package-smoke.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { resolveInstalledEntrypoint } from "../scripts/smoke-installed-package.mjs";
+
+test("installed-package smoke resolves the ESM-only public loader entrypoint", (context) => {
+  const project = mkdtempSync(path.join(os.tmpdir(), "merman-node-installed-smoke-"));
+  context.after(() => rmSync(project, { recursive: true, force: true }));
+
+  const packageRoot = path.join(project, "node_modules", "@mermanjs", "node");
+  mkdirSync(path.join(packageRoot, "dist"), { recursive: true });
+  writeFileSync(path.join(project, "package.json"), '{"type":"module"}\n');
+  writeFileSync(
+    path.join(packageRoot, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "@mermanjs/node",
+        version: "0.0.0-test",
+        type: "module",
+        exports: { ".": { import: "./dist/index.mjs" } },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  const expectedEntrypoint = path.join(packageRoot, "dist", "index.mjs");
+  writeFileSync(expectedEntrypoint, "export const installed = true;\n");
+
+  assert.equal(
+    realpathSync(resolveInstalledEntrypoint(project)),
+    realpathSync(expectedEntrypoint),
+  );
+});

--- a/platforms/node/tests/platform-command.test.mjs
+++ b/platforms/node/tests/platform-command.test.mjs
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { npmExecutable } from "../scripts/verify-packages.mjs";
+
+test("package verification selects the Windows npm command shim", () => {
+  assert.equal(npmExecutable("win32"), "npm.cmd");
+  assert.equal(npmExecutable("linux"), "npm");
+  assert.equal(npmExecutable("darwin"), "npm");
+});


### PR DESCRIPTION
## Summary

- resolve the installed ESM-only loader with Node import conditions instead of the CommonJS resolver
- invoke `npm.cmd` for packed-package verification on Windows
- add focused regression tests for both release failures

## Failure evidence

The first non-publishing Node package-group run built all native targets, then exposed two harness failures: Linux and macOS rejected `require.resolve()` for the import-only loader export, while Windows could not spawn the `npm` command shim.

## Validation

- `npm test --prefix platforms/node` — 84 tests passed
- `npm run --prefix platforms/node check:packages`
- focused resolver and Windows command tests on Node 24 Alpine
- `git diff --check`

No package version, public API, feature recipe, or registry state changes.