### PR TITLE
fix(release): keep host build scripts executable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ on:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
+      - '!flutter-v*'
   workflow_dispatch:
     inputs:
       release_tag:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,6 +180,9 @@ debug-assertions = false
 overflow-checks = false
 rpath = false
 
+[profile.native-distribution.build-override]
+strip = "none"
+
 [profile.wasm-size]
 inherits = "release"
 opt-level = "z"

--- a/scripts/test_artifact_profile_recipe.py
+++ b/scripts/test_artifact_profile_recipe.py
@@ -87,6 +87,7 @@ class ArtifactProfileRecipeTests(unittest.TestCase):
                 "debug-assertions": False,
                 "overflow-checks": False,
                 "rpath": False,
+                "build-override": {"strip": "none"},
             },
         )
 

--- a/scripts/test_release_workflow_security.py
+++ b/scripts/test_release_workflow_security.py
@@ -116,6 +116,10 @@ class WorkflowSecurityBoundaries(unittest.TestCase):
                     text.count("uses: actions/checkout@"),
                 )
 
+    def test_workspace_release_ignores_flutter_package_tags(self) -> None:
+        text = read(WORKFLOW_ROOT / "release.yml")
+        self.assertIn("      - '!flutter-v*'\n", text)
+
     def test_crates_publish_uses_trusted_receipt_operator_and_immutable_source(self) -> None:
         text = read(WORKFLOW_ROOT / "release-crates.yml")
         self.assertIn("ref: ${{ github.workflow_sha }}", text)


### PR DESCRIPTION
## Summary

Unblocks the Flutter Native Assets release on Apple Silicon GitHub runners and keeps Flutter package tags isolated from workspace publication. Cargo no longer strips host build scripts and proc macros under the size-oriented native distribution profile, while published target libraries keep the existing symbol-stripping policy.

## What changed

- Add a `native-distribution.build-override` that sets `strip = "none"` for host build dependencies.
- Exclude `flutter-v*` from the workspace cargo-dist release trigger.
- Lock both release boundaries in focused contract tests.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `python3 -m unittest scripts.test_release_workflow_security scripts.test_artifact_profile_recipe` (35 tests)
- [x] `cargo metadata --locked --no-deps --format-version 1`
- [x] `actionlint .github/workflows/release.yml`
- [x] Reproduced the Android Flutter slice successfully on macOS ARM64 with Rust 1.95.0 and NDK 29
- [ ] Benchmark or report updated if this affects performance (not applicable)

## Performance / parity notes

- Benchmark or report: Not applicable; published native artifact optimization settings are unchanged.
- Parity impact: None.
- Rollback risk: Low. The Cargo override applies only to host-side build dependencies, and the tag exclusion narrows an unrelated workflow trigger.

## Follow-ups

- Rerun the Flutter channel preflight, then publish `flutter-v0.8.0-alpha.5` from the reviewed merge commit.
