### PR TITLE
fix(playground): separate preview surface themes

### DIFF
--- a/playground/src/components/CompareView.tsx
+++ b/playground/src/components/CompareView.tsx
@@ -192,7 +192,7 @@ function ComparePane({
           <p
             id={statusId}
             aria-live="polite"
-            className="preview-canvas-status-muted shrink-0 text-xs"
+            className="shrink-0 text-xs text-muted-foreground"
             role="status"
           >
             {status.label}

--- a/playground/src/styles/globals.css
+++ b/playground/src/styles/globals.css
@@ -148,8 +148,9 @@
   --preview-canvas-status: oklch(0.2 0.018 165);
   --preview-canvas-status-muted: oklch(0.43 0.02 165);
   --preview-canvas-border: oklch(0.74 0.025 165);
-  --preview-canvas-focus: oklch(0.48 0.14 210);
   --preview-canvas-bounds: oklch(0.56 0.18 45);
+  --preview-transparency-surface: oklch(0.97 0.004 160);
+  --preview-transparency-cell: oklch(0.91 0.008 160);
   --preview-viewbox-shadow: oklch(0.2 0.018 165 / 0.16);
 }
 
@@ -159,8 +160,9 @@
   --preview-canvas-status: oklch(0.94 0.008 220);
   --preview-canvas-status-muted: oklch(0.75 0.018 220);
   --preview-canvas-border: oklch(0.42 0.025 220);
-  --preview-canvas-focus: oklch(0.76 0.13 210);
   --preview-canvas-bounds: oklch(0.78 0.17 70);
+  --preview-transparency-surface: oklch(0.18 0.014 255);
+  --preview-transparency-cell: oklch(0.23 0.018 240);
   --preview-viewbox-shadow: oklch(0 0 0 / 0.42);
 }
 
@@ -178,44 +180,32 @@
 }
 
 .preview-container[data-svg-presentation-mode="viewbox"] {
-  background-color: var(--preview-canvas-surface);
+  background-color: var(--preview-transparency-surface);
+  background-image: conic-gradient(
+    var(--preview-transparency-cell) 25%,
+    var(--preview-transparency-surface) 0 50%,
+    var(--preview-transparency-cell) 0 75%,
+    var(--preview-transparency-surface) 0
+  );
+  background-size: 16px 16px;
   outline: 1px solid var(--preview-canvas-border);
   box-shadow: 0 14px 36px var(--preview-viewbox-shadow);
 }
 
 .preview-canvas-frame {
-  border-color: var(--preview-canvas-border);
-  background-color: color-mix(
-    in oklab,
-    var(--preview-canvas-surface) 94%,
-    transparent
-  );
+  border-color: var(--border);
+  background-color: var(--preview-canvas-surface);
   color: var(--preview-canvas-status);
 }
 
 .preview-canvas-frame:focus-visible {
-  box-shadow: inset 0 0 0 2px var(--preview-canvas-focus);
+  box-shadow: inset 0 0 0 2px var(--ring);
 }
 
 .preview-canvas-toolbar {
-  border-color: var(--preview-canvas-border);
-  background-color: color-mix(
-    in oklab,
-    var(--preview-canvas-surface) 88%,
-    var(--preview-canvas-status) 12%
-  );
-}
-
-.preview-canvas-toolbar .text-muted-foreground {
-  color: var(--preview-canvas-status-muted);
-}
-
-.preview-canvas-toolbar .bg-muted {
-  background-color: color-mix(
-    in oklab,
-    var(--preview-canvas-surface) 82%,
-    var(--preview-canvas-status) 18%
-  );
+  border-color: var(--border);
+  background-color: var(--card);
+  color: var(--card-foreground);
 }
 
 .preview-canvas-status {

--- a/playground/tests/render.presentation.spec.ts
+++ b/playground/tests/render.presentation.spec.ts
@@ -98,7 +98,10 @@ test("Visual and Compare switch between Infinite Canvas and ViewBox Frame as pre
 }) => {
   const errors = monitorBrowserErrors(page);
   await openPlayground(page);
-  await waitForPreviewSvg(page);
+  await renderSource(
+    page,
+    `${fontOnlyConfig("default")}\nflowchart LR\n  A --> B`,
+  );
 
   const viewport = page.locator('[data-merman-svg-viewport="true"]').first();
   expect(await viewport.boundingBox()).toEqual(
@@ -106,7 +109,7 @@ test("Visual and Compare switch between Infinite Canvas and ViewBox Frame as pre
   );
   await expect(viewport).toHaveAttribute(
     "data-preview-canvas-tone",
-    /^(light|dark)$/u,
+    "light",
   );
   await expect(viewport).toHaveAttribute(
     "data-svg-presentation-mode",
@@ -115,6 +118,7 @@ test("Visual and Compare switch between Infinite Canvas and ViewBox Frame as pre
   await expect(viewport).not.toHaveCSS("background-image", "none");
   const content = viewport.locator(".preview-container");
   await expect(content).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+  await expect(content).toHaveCSS("background-image", "none");
   await expect(content).toHaveCSS("padding", "0px");
   await expect(content).toHaveCSS("border-radius", "0px");
   await expect(content).toHaveCSS("box-shadow", "none");
@@ -157,6 +161,10 @@ test("Visual and Compare switch between Infinite Canvas and ViewBox Frame as pre
     "viewbox",
   );
   await expect(viewport).toHaveCSS("background-image", "none");
+  await expect(content).not.toHaveCSS("background-image", "none");
+  const lightTransparencyGrid = await content.evaluate(
+    (element) => getComputedStyle(element).backgroundImage,
+  );
   await expect(content).toHaveCSS("outline-style", "solid");
   await expect(content).not.toHaveCSS("box-shadow", "none");
   expect(await artifactMarker()).toBe("stable");
@@ -183,13 +191,23 @@ test("Visual and Compare switch between Infinite Canvas and ViewBox Frame as pre
 
   await page.keyboard.press("Enter");
   await expect(boundsToggle).toHaveAttribute("aria-pressed", "true");
+  await renderSource(
+    page,
+    `${fontOnlyConfig("dark")}\nflowchart LR\n  A --> B`,
+  );
+  await expect(viewport).toHaveAttribute("data-preview-canvas-tone", "dark");
+  const darkTransparencyGrid = await content.evaluate(
+    (element) => getComputedStyle(element).backgroundImage,
+  );
+  expect(darkTransparencyGrid).not.toBe("none");
+  expect(darkTransparencyGrid).not.toBe(lightTransparencyGrid);
   await page.getByRole("tab", { name: "Compare", exact: true }).click();
   const compareCanvas = page.locator(
     '[data-merman-compare-scroll-owner="true"]',
   );
   await expect(compareCanvas).toHaveAttribute(
     "data-preview-canvas-tone",
-    /^(light|dark)$/u,
+    "dark",
   );
   await expect(compareCanvas).toHaveAttribute(
     "data-svg-presentation-mode",
@@ -217,6 +235,7 @@ test("Visual and Compare switch between Infinite Canvas and ViewBox Frame as pre
           return (
             content instanceof HTMLElement &&
             getComputedStyle(element).backgroundImage === "none" &&
+            getComputedStyle(content).backgroundImage !== "none" &&
             getComputedStyle(content).outlineStyle === "solid"
           );
         }),


### PR DESCRIPTION
## Summary

This follows #67 by making the two preview surfaces communicate different things clearly. Infinite Canvas keeps the effective Mermaid theme as its workspace, while ViewBox Frame now shows a theme-aware transparency checker behind the actual SVG.

Compare headers, status text, borders, and focus treatment now follow the application theme instead of borrowing the diagram canvas colors. The mounted artifact, camera state, Bounds overlay, and export bytes remain unchanged.

## Validation

- `npm run test:prepared --prefix playground`
- `npm run lint --prefix playground`
- `npm run build:prepared --prefix playground`
- Focused Chromium desktop presentation test
- Focused Chromium 320px mobile interaction test
- Manual inspection of light ViewBox, dark Compare, and 320px mobile layouts
- Independent code review completed with no actionable findings

## Related

- Related: #67
- Related: zed-industries/zed#62410

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required because this changes static Playground presentation CSS and browser assertions only.

- Validation window: pull-request Pages CI and the first Pages deployment after merge
- Healthy signals: the Pages build, Chromium suite, and Firefox/WebKit smoke checks remain green; ViewBox transparency remains visible without changing exported artifacts
- Failure signals: browser-test failures, unreadable Compare chrome, or a missing ViewBox transparency pattern
- Rollback trigger and mitigation: revert this PR if the deployed Playground regresses preview readability or browser compatibility
- Owner: repository maintainer
