### PR TITLE
fix(playground): reveal SVG overflow on infinite canvas

### DIFF
--- a/docs/plans/2026-08-16-1459-refactor-playground-infinite-canvas-plan.md
+++ b/docs/plans/2026-08-16-1459-refactor-playground-infinite-canvas-plan.md
@@ -15,9 +15,11 @@ origin: docs/plans/2026-08-15-2329-feat-playground-host-export-plan.md
 
 Make the Playground preview behave like Mermaid Live's canvas: the whole available preview surface is the navigable workspace, the rendered SVG has no decorative paper/card boundary, and users can pan, pinch, zoom, fit, and optionally inspect the exact SVG root bounds. Keep rendering deterministic at the existing canonical `800×600` environment for both engines, keep exports finite and artifact-owned, and remove the Playground-only Host measurement and locked-environment contracts that no longer serve the clarified product goal.
 
-Success means the Visual and Compare views use the infinite-canvas presentation on desktop and mobile; an optional SVG Bounds overlay exposes rather than repairs root `viewBox` clipping; current workspace and issue links remain bounded and usable; legacy Host-bearing links safely degrade to canonical rendering; focused runtime/share/browser checks, lint, typecheck, build, and required PR CI pass.
+Success means the Visual and Compare views use the infinite-canvas presentation on desktop and mobile; Infinite Canvas reveals measurable SVG bounding-box overflow while ViewBox Frame and the optional SVG Bounds overlay expose the exact renderer-owned root viewport; current workspace and issue links remain bounded and usable; legacy Host-bearing links safely degrade to canonical rendering; focused runtime/share/browser checks, lint, typecheck, build, and required PR CI pass.
 
 This plan supersedes only the Playground-specific Host viewport, live measurement, and locked reproduction environment decisions in `docs/plans/2026-08-15-2329-feat-playground-host-export-plan.md`. Its export workbench, exact-artifact ownership, responsive SVG clone, and portable sharing decisions remain in force.
+
+On 2026-08-17, the presentation contract was refined after reproducing long Sequence titles that both Merman and pinned Mermaid.js draw outside their unchanged root `viewBox`. Infinite Canvas now reveals that visual overflow and includes it in Fit, while ViewBox Frame restores the root's original overflow behavior for exact clipping diagnosis. This amendment changes only mounted-preview presentation; renderer, artifact, and export geometry remain unchanged.
 
 ---
 
@@ -30,17 +32,17 @@ The current Playground already has a presentation camera, but it renders the SVG
 - the renderer's finite layout environment, which must stay controlled for a meaningful Merman/Mermaid.js comparison; and
 - the user's presentation camera, which may move over an effectively unbounded workspace without changing layout or output geometry.
 
-The Host mode does not resolve the Zed title-clipping report. When Mermaid.js publishes content outside its root `viewBox`, the SVG viewport clips that content regardless of the outer host's CSS size. The Playground should make this behavior easy to inspect, not hide it with a Merman-only bounds rewrite.
+The Host mode does not resolve the Zed title-clipping report. When Mermaid.js publishes content outside its root `viewBox`, changing the outer host's CSS size does not change that renderer-owned viewport. The Playground should provide an editor-oriented Infinite Canvas that reveals the overflow while retaining ViewBox Frame as an exact diagnostic, without a Merman-only bounds rewrite.
 
 ### Requirements
 
 **Canvas and render semantics**
 
 - **R1 — Infinite canvas by default.** Visual and Compare preview panes use their entire available area as the canvas. The rendered diagram has no paper background, padding, rounded card, or drop shadow imposed by the Playground. The responsive presentation clone suppresses Merman's known default white root background so the grid remains the canvas, while the published/exported artifact and non-default renderer backgrounds remain unchanged.
-- **R2 — Presentation and rendering stay separate.** Pan, pinch, wheel zoom, reset, fit, canvas resize, and bounds visibility are presentation state only. They do not trigger rendering, alter operation identity, mutate published SVG, or change export dimensions.
+- **R2 — Presentation and rendering stay separate.** Pan, pinch, wheel zoom, reset, fit, canvas resize, presentation mode, browser bounding-box measurement, and bounds visibility are presentation state only. They do not trigger rendering, alter operation identity, mutate published SVG, or change export dimensions.
 - **R3 — Deterministic render environment.** Interactive Merman and Mermaid.js operations both use the same canonical `800×600` container environment and canonical `screenAvailableWidth=800`. Benchmark continues to own its canonical environment independently.
 - **R4 — SVG Bounds is diagnostic.** A user can show or hide a lightweight overlay aligned to the mounted SVG root. The overlay changes neither the root `viewBox` nor intrinsic dimensions, serialized artifact, hit testing, navigation, fit geometry, or export.
-- **R5 — Preserve renderer semantics.** The responsive presentation clone preserves a valid engine-owned `viewBox` byte-for-byte. The Playground does not call `getBBox()` or widen bounds to conceal clipping inherited from pinned Mermaid.js.
+- **R5 — Preserve renderer semantics.** The responsive presentation clone preserves a valid engine-owned `viewBox` byte-for-byte. Infinite Canvas may measure the mounted clone with `getBBox()` to reveal overflow and fit the union of those bounds and the root viewport. ViewBox Frame restores original root overflow behavior. Browser measurements never rewrite renderer or export geometry and fall back to intrinsic root geometry when unavailable, invalid, or non-finite.
 
 **Host removal and sharing migration**
 
@@ -61,9 +63,9 @@ The Host mode does not resolve the Zed title-clipping report. When Mermaid.js pu
 
 ### Acceptance Examples
 
-- **AE1 — Default Visual canvas (R1-R5, R11).** Given a newly opened Playground, when a diagram renders in Visual, then the grid fills the preview pane, the diagram floats directly on the canvas, Fit centers it with breathing room, and no finite white card is visible.
+- **AE1 — Default Visual canvas (R1-R5, R11).** Given a newly opened Playground, when a diagram renders in Visual, then the grid fills the preview pane, the diagram floats directly on the canvas, Fit centers the union of its root viewport and measurable SVG bounding-box overflow with breathing room, and no finite white card is visible.
 - **AE2 — Presentation-only camera (R2-R3, R10).** Given a valid publication, when the user pans, zooms, resizes the Preview, or opens it on a host with a different `screen.availWidth`, then no presentation action changes the operation, both engines retain the same canonical environment, and exported dimensions remain unchanged.
-- **AE3 — Bounds diagnosis (R4-R5, R13).** Given an SVG whose title or content reaches or crosses its root `viewBox`, when SVG Bounds is enabled, then a dashed outline exactly marks the root viewport while the same clipping remains visible; disabling it restores the same artifact and camera.
+- **AE3 — Overflow and bounds diagnosis (R4-R5, R13).** Given an SVG whose title or content crosses its root `viewBox`, Infinite Canvas reveals and fits that overflow. When ViewBox Frame is selected, the original root clipping is restored; enabling SVG Bounds exactly marks that unchanged viewport. Switching modes or bounds preserves the mounted artifact and changes neither published bytes nor export geometry.
 - **AE4 — Compare parity (R1-R5).** Given Compare mode, both panes use the same infinite-canvas presentation and canonical render input. Their cameras may be controlled independently, but neither pane's allocated width becomes renderer input.
 - **AE5 — Legacy Host link (R6, R8-R9).** Given an old URL containing a Host workspace field and a complete locked environment, when it loads, then code/config/theme/page/editor/Preview mode are restored, the removed Host fields are ignored, no warning is shown solely because they are legacy, and rendering uses `800×600`.
 - **AE6 — Current issue link (R8-R9, R13).** Given Preview/Compare with SVG Bounds enabled, when the user copies and opens an issue link, then the recipient opens Preview/Compare with bounds enabled and no Host environment query fields are emitted.
@@ -95,7 +97,7 @@ The Host mode does not resolve the Zed title-clipping report. When Mermaid.js pu
 ### Key Technical Decisions
 
 - **KTD1 — One canonical Playground render input.** `CANONICAL_RENDER_VIEWPORT` remains the only interactive Playground viewport, and its width is also the canonical `screenAvailableWidth`. Operation capture creates one frozen `800×600×800` layout environment for both engines; no selected mode, live measurement, or browser screen geometry participates in operation identity. (session-settled: user-directed — chosen over retaining Host as a visible or hidden advanced mode after the user clarified that the desired behavior is an infinite presentation canvas.) Governs R2-R3, R6-R7.
-- **KTD2 — Infinite canvas is the existing camera with a different shell.** Reuse `SvgViewport`'s established transform, fitting, pointer, wheel, anchor-suppression, and responsive clone machinery. Remove the finite paper decoration and suppress only the known renderer-default white root background in the presentation clone; do not rewrite the published artifact or any non-default root background. Add a canvas-level theme contract without a new canvas library or second gesture implementation. (session-settled: user-approved — chosen over adding another Canvas/ViewBox mode because the existing camera already supplies the required unbounded navigation; source-confirmed against Mermaid Live's transparent rendered SVG over its grid canvas.) Governs R1-R2, R10-R12.
+- **KTD2 — Infinite canvas is the existing camera with a presentation-only measured boundary.** Reuse `SvgViewport`'s established transform, fitting, pointer, wheel, anchor-suppression, and responsive clone machinery. Remove the finite paper decoration and suppress only the known renderer-default white root background in the presentation clone; do not rewrite the published artifact or any non-default root background. On the mounted clone only, Infinite Canvas enables visible overflow and fits the union of a finite `getBBox()` result and the unchanged root viewport; ViewBox Frame restores original overflow behavior. Invalid measurements fall back to root geometry. Add no canvas dependency or second gesture implementation. Governs R1-R2, R5, R10-R12.
 - **KTD3 — Bounds belongs to presentation state.** Store one `showSvgBounds` preference for the Preview workspace and pass it into every `SvgViewport`. Implement the visual with a non-interactive outline on the exact content/root host so it follows camera transforms but contributes no layout insets. (session-settled: user-approved — chosen over editable `viewBox`, which would change or conceal the renderer behavior under investigation.) Governs R2, R4-R5, R13.
 - **KTD4 — Share versions keep bounded, explicit migration.** Because `s2` and `rv=1` exist only on the open branch, keep their visible prefixes while redefining the pre-merge current contract. Isolated legacy decoding covers three existing Host-bearing shapes: the original Base64 workspace hash, the `s2` workspace envelope, and the `rv=1` query lock. Each path validates within its existing budget, discards only removed environment fields, and returns the new canonical snapshot/view without warning when all remaining fields are valid. New encoders never emit Host fields. Governs R6, R8-R9.
 - **KTD5 — Canvas contrast follows the effective diagram theme, not only app chrome.** Reuse Mermaid config parsing/precedence to resolve the valid effective theme, classify every `SUPPORTED_THEMES` value into a light or dark canvas family, and keep the grid, status text, focus treatment, and Bounds outline legible. The SVG remains responsible for its own explicit background and arbitrary `themeVariables`/`themeCSS`; the Playground supplies only the surrounding presentation surface. Governs R1, R11.
@@ -204,21 +206,22 @@ sequenceDiagram
 **Approach:**
 
 1. Keep the viewport container full-size and overflow-hidden, remove `bg-white`, padding, rounded corners, and shadow from the diagram wrapper, and remove only a default `background-color: white` declaration from the responsive presentation clone. Preserve the frozen artifact and any non-default renderer background for copy/export.
-2. Preserve the existing camera state machine and fit margin. Recalculate only code that assumed paper padding; do not rewrite gesture logic.
+2. Preserve the existing camera state machine and fit margin. In Infinite Canvas, measure the mounted root's finite `getBBox()` bounds, union them with its unchanged `viewBox`, and use that presentation-only geometry for Fit and centering. Fall back to intrinsic root geometry when measurement is unavailable or invalid. ViewBox Frame continues to fit the root viewport. Do not rewrite gesture logic.
 3. Add `showSvgBounds` to the Preview-owned store state and expose one native pressed button in a stable toolbar position whenever SVG or Compare mode is selected, including loading, empty, error, source, and stale-publication states. The preference remains toggleable before an SVG mounts; its translated label explains that it applies to all mounted Visual panes. Preview resolves the canvas family and passes both controlled values to CompareView, which forwards them to its two `SvgViewport` instances; components do not introduce a second direct-store ownership path.
-4. Render a pointer-transparent dashed outline on the exact mounted SVG host/wrapper, following camera transforms without adding box size or changing fit calculations.
+4. Render a pointer-transparent dashed outline on the exact mounted SVG host/wrapper, following camera transforms without adding box size or independently changing fit calculations. Apply visible overflow only to the Infinite Canvas mounted clone and restore its original inline overflow declaration in ViewBox Frame.
 5. Resolve the effective theme through existing Mermaid config precedence, map all supported themes to a light/dark canvas family, and apply family tokens for surface, grid, status content, focus, and Bounds. Cover the config-overrides-toolbar case without attempting to infer arbitrary custom theme-variable contrast.
 6. Preserve one-finger pan inside each mobile canvas. Keep the Compare scroll owner reachable through pane headers/gutters and verify the second engine remains reachable without weakening canvas gestures.
 
 **Test scenarios:**
 
 - Visual and Compare contain no finite card classes and still fit/zoom/pan.
+- A long Sequence title that extends beyond an unchanged root `viewBox` is fully visible after Infinite Canvas Fit and clipped again in ViewBox Frame; both engines use the shared `SvgViewport` path.
 - Bounds toggling uses a translated native button with `aria-pressed`; Enter and Space update only the preference/diagnostic style and do not replace the mounted artifact or alter reported zoom.
 - Anchor navigation suppression and gesture promotion still work.
 - Every supported effective theme maps to a canvas family; a config `theme=dark` overrides a toolbar `default` selection for canvas contrast.
 - On a narrow Compare view, users can still scroll from a pane header/gutter to the second engine while one-finger drags inside a canvas continue to pan it.
 
-**Definition of done:** The canvas fills every Preview pane, SVG Bounds is accessible and non-semantic, and existing camera behavior remains intact.
+**Definition of done:** The canvas fills every Preview pane, Infinite Canvas reveals measurable SVG bounding-box overflow without mutating artifacts, ViewBox Frame preserves root clipping diagnosis, SVG Bounds is accessible and non-semantic, and existing camera behavior remains intact.
 
 ### U3 — Simplify share contracts and migrate Host-bearing links
 
@@ -267,13 +270,13 @@ sequenceDiagram
 
 **Approach:**
 
-1. Replace Host mode browser cases with one desktop infinite-canvas/bounds/share scenario and one mobile gesture/safe-area scenario.
+1. Replace Host mode browser cases with one desktop infinite-canvas/bounds/share scenario, one focused overflow-versus-ViewBox regression, and one mobile gesture/safe-area scenario.
 2. Assert export isolation using existing export coverage rather than duplicating encoder tests.
 3. Run focused unit tests first, then lint/typecheck/build and the affected Chromium desktop/mobile suites. Run non-Chromium smoke only if changed behavior crosses its existing lane.
 
 **Test scenarios:**
 
-- Desktop Visual/Compare show full-surface canvas, bounds toggle, canonical render metadata, and usable share links.
+- Desktop Visual/Compare show full-surface canvas, bounds toggle, canonical render metadata, usable share links, and the shared overflow-aware Fit behavior without changing either engine's root `viewBox`.
 - Mobile Preview supports pan/pinch/fit/bounds/export without overflow or safe-area collision; a single WebKit mobile smoke covers layout, tap activation, and shared pointer-handler state, without claiming native touch delivery.
 - PNG/JPEG/SVG output excludes grid, bounds, and camera transforms.
 - Source search finds no stale active Host product strings or dead viewport ownership outside the labeled legacy decoder/fixture compatibility points.
@@ -288,7 +291,7 @@ Run in dependency order and avoid redundant full-suite reruns:
 
 1. **Pure contracts:** `npm run test:runtime` from `playground/`, covering canonical capture, store snapshots, share migration, and coordinator identity.
 2. **Static gates:** `npm run lint`, `npm run test:browser:typecheck`, and `npm run build` from `playground/`.
-3. **Desktop browser:** the affected tests in `playground/tests/render.presentation.spec.ts` against the built Playground, including infinite shell, Bounds keyboard/pressed semantics, legacy link hydration, and export isolation.
+3. **Desktop browser:** the affected tests in `playground/tests/render.presentation.spec.ts` against the built Playground, including infinite shell, overflow-aware Fit versus exact ViewBox clipping, Bounds keyboard/pressed semantics, legacy link hydration, and export isolation.
 4. **Mobile browser:** the affected tests in `playground/tests/mobile.interactions.spec.ts`, including pan/pinch, Compare scroll reachability, reachable controls, safe areas, and no horizontal overflow. Run the detailed matrix in Chromium and one focused iPhone/WebKit smoke for layout, tap activation, and shared pointer-handler state; retain native touch delivery in the real-device residual checklist.
 5. **Regression ownership:** reuse existing export coverage; do not add DOM simulation dependencies, per-theme browser cases, or duplicate the same behavior across multiple suites.
 6. **PR gate:** every required GitHub check for PR #67 is green and no unresolved change-request thread remains.
@@ -299,7 +302,7 @@ Run in dependency order and avoid redundant full-suite reruns:
 | --- | --- |
 | Canonical operation for both engines | runtime/coordinator unit test |
 | No render on canvas/camera changes | focused coordinator + browser request-count assertion |
-| Infinite shell, exact bounds overlay, and pressed semantics | Chromium presentation test |
+| Infinite shell, bounding-box overflow Fit, exact ViewBox clipping, bounds overlay, and pressed semantics | Chromium presentation test |
 | Legacy Host link degradation | Base64/`s2`/`rv=1` share unit tests + one browser hydration case |
 | Finite export unaffected | existing export unit/browser coverage |
 | Mobile gesture and safe-area behavior | mobile Chromium test |
@@ -320,7 +323,7 @@ Run in dependency order and avoid redundant full-suite reruns:
 ## Definition of Done
 
 - The Playground has no visible or hidden Canonical/Host mode selection, live Host measurement, or locked environment state.
-- Visual and Compare use a full-surface, theme-aware infinite canvas with existing pan/zoom/pinch/fit behavior.
+- Visual and Compare use a full-surface, theme-aware infinite canvas whose Fit includes finite browser `getBBox()` overflow while ViewBox Frame preserves exact root clipping diagnosis.
 - SVG Bounds can be toggled accessibly and is absent from artifacts and exports.
 - Merman and Mermaid.js receive the same canonical `800×600` interactive environment; lower-level container sizing APIs remain intact.
 - New workspace and issue links omit Host geometry; only issue links carry current page/editor/Preview/Bounds state, and old Base64/`s2`/`rv=1` Host-bearing links safely restore supported fields.

--- a/docs/plans/2026-08-16-1459-refactor-playground-infinite-canvas-plan.md
+++ b/docs/plans/2026-08-16-1459-refactor-playground-infinite-canvas-plan.md
@@ -15,7 +15,7 @@ origin: docs/plans/2026-08-15-2329-feat-playground-host-export-plan.md
 
 Make the Playground preview behave like Mermaid Live's canvas: the whole available preview surface is the navigable workspace, the rendered SVG has no decorative paper/card boundary, and users can pan, pinch, zoom, fit, and optionally inspect the exact SVG root bounds. Keep rendering deterministic at the existing canonical `800×600` environment for both engines, keep exports finite and artifact-owned, and remove the Playground-only Host measurement and locked-environment contracts that no longer serve the clarified product goal.
 
-Success means the Visual and Compare views use the infinite-canvas presentation on desktop and mobile; Infinite Canvas reveals measurable SVG bounding-box overflow while ViewBox Frame and the optional SVG Bounds overlay expose the exact renderer-owned root viewport; current workspace and issue links remain bounded and usable; legacy Host-bearing links safely degrade to canonical rendering; focused runtime/share/browser checks, lint, typecheck, build, and required PR CI pass.
+Success means the Visual and Compare views use the infinite-canvas presentation on desktop and mobile; Infinite Canvas reveals measurable SVG overflow connected to the renderer-owned root viewport while ViewBox Frame and the optional SVG Bounds overlay expose that exact viewport; current workspace and issue links remain bounded and usable; legacy Host-bearing links safely degrade to canonical rendering; focused runtime/share/browser checks, lint, typecheck, build, and required PR CI pass.
 
 This plan supersedes only the Playground-specific Host viewport, live measurement, and locked reproduction environment decisions in `docs/plans/2026-08-15-2329-feat-playground-host-export-plan.md`. Its export workbench, exact-artifact ownership, responsive SVG clone, and portable sharing decisions remain in force.
 
@@ -42,7 +42,7 @@ The Host mode does not resolve the Zed title-clipping report. When Mermaid.js pu
 - **R2 — Presentation and rendering stay separate.** Pan, pinch, wheel zoom, reset, fit, canvas resize, presentation mode, browser bounding-box measurement, and bounds visibility are presentation state only. They do not trigger rendering, alter operation identity, mutate published SVG, or change export dimensions.
 - **R3 — Deterministic render environment.** Interactive Merman and Mermaid.js operations both use the same canonical `800×600` container environment and canonical `screenAvailableWidth=800`. Benchmark continues to own its canonical environment independently.
 - **R4 — SVG Bounds is diagnostic.** A user can show or hide a lightweight overlay aligned to the mounted SVG root. The overlay changes neither the root `viewBox` nor intrinsic dimensions, serialized artifact, hit testing, navigation, fit geometry, or export.
-- **R5 — Preserve renderer semantics.** The responsive presentation clone preserves a valid engine-owned `viewBox` byte-for-byte. Infinite Canvas may measure the mounted clone with `getBBox()` to reveal overflow and fit the union of those bounds and the root viewport. ViewBox Frame restores original root overflow behavior. Browser measurements never rewrite renderer or export geometry and fall back to intrinsic root geometry when unavailable, invalid, or non-finite.
+- **R5 — Preserve renderer semantics.** The responsive presentation clone preserves a valid engine-owned `viewBox` byte-for-byte. Infinite Canvas may measure mounted SVG graphics to reveal overflow connected to the root viewport and fit their union. Disconnected root-clipped decorations stay outside Fit. ViewBox Frame restores original root overflow behavior. Browser measurements never rewrite renderer or export geometry and fall back to intrinsic root geometry when unavailable, invalid, or non-finite.
 
 **Host removal and sharing migration**
 
@@ -63,7 +63,7 @@ The Host mode does not resolve the Zed title-clipping report. When Mermaid.js pu
 
 ### Acceptance Examples
 
-- **AE1 — Default Visual canvas (R1-R5, R11).** Given a newly opened Playground, when a diagram renders in Visual, then the grid fills the preview pane, the diagram floats directly on the canvas, Fit centers the union of its root viewport and measurable SVG bounding-box overflow with breathing room, and no finite white card is visible.
+- **AE1 — Default Visual canvas (R1-R5, R11).** Given a newly opened Playground, when a diagram renders in Visual, then the grid fills the preview pane, the diagram floats directly on the canvas, Fit centers the union of its root viewport and connected measurable SVG overflow with breathing room, and no finite white card is visible.
 - **AE2 — Presentation-only camera (R2-R3, R10).** Given a valid publication, when the user pans, zooms, resizes the Preview, or opens it on a host with a different `screen.availWidth`, then no presentation action changes the operation, both engines retain the same canonical environment, and exported dimensions remain unchanged.
 - **AE3 — Overflow and bounds diagnosis (R4-R5, R13).** Given an SVG whose title or content crosses its root `viewBox`, Infinite Canvas reveals and fits that overflow. When ViewBox Frame is selected, the original root clipping is restored; enabling SVG Bounds exactly marks that unchanged viewport. Switching modes or bounds preserves the mounted artifact and changes neither published bytes nor export geometry.
 - **AE4 — Compare parity (R1-R5).** Given Compare mode, both panes use the same infinite-canvas presentation and canonical render input. Their cameras may be controlled independently, but neither pane's allocated width becomes renderer input.
@@ -97,7 +97,7 @@ The Host mode does not resolve the Zed title-clipping report. When Mermaid.js pu
 ### Key Technical Decisions
 
 - **KTD1 — One canonical Playground render input.** `CANONICAL_RENDER_VIEWPORT` remains the only interactive Playground viewport, and its width is also the canonical `screenAvailableWidth`. Operation capture creates one frozen `800×600×800` layout environment for both engines; no selected mode, live measurement, or browser screen geometry participates in operation identity. (session-settled: user-directed — chosen over retaining Host as a visible or hidden advanced mode after the user clarified that the desired behavior is an infinite presentation canvas.) Governs R2-R3, R6-R7.
-- **KTD2 — Infinite canvas is the existing camera with a presentation-only measured boundary.** Reuse `SvgViewport`'s established transform, fitting, pointer, wheel, anchor-suppression, and responsive clone machinery. Remove the finite paper decoration and suppress only the known renderer-default white root background in the presentation clone; do not rewrite the published artifact or any non-default root background. On the mounted clone only, Infinite Canvas enables visible overflow and fits the union of a finite `getBBox()` result and the unchanged root viewport; ViewBox Frame restores original overflow behavior. Invalid measurements fall back to root geometry. Add no canvas dependency or second gesture implementation. Governs R1-R2, R5, R10-R12.
+- **KTD2 — Infinite canvas is the existing camera with a presentation-only measured boundary.** Reuse `SvgViewport`'s established transform, fitting, pointer, wheel, anchor-suppression, and responsive clone machinery. Remove the finite paper decoration and suppress only the known renderer-default white root background in the presentation clone; do not rewrite the published artifact or any non-default root background. On the mounted clone only, Infinite Canvas enables visible overflow and fits finite graphics connected to the unchanged root viewport; disconnected root-clipped decorations remain outside Fit. ViewBox Frame restores original overflow behavior. Invalid measurements fall back to root geometry. Add no canvas dependency or second gesture implementation. Governs R1-R2, R5, R10-R12.
 - **KTD3 — Bounds belongs to presentation state.** Store one `showSvgBounds` preference for the Preview workspace and pass it into every `SvgViewport`. Implement the visual with a non-interactive outline on the exact content/root host so it follows camera transforms but contributes no layout insets. (session-settled: user-approved — chosen over editable `viewBox`, which would change or conceal the renderer behavior under investigation.) Governs R2, R4-R5, R13.
 - **KTD4 — Share versions keep bounded, explicit migration.** Because `s2` and `rv=1` exist only on the open branch, keep their visible prefixes while redefining the pre-merge current contract. Isolated legacy decoding covers three existing Host-bearing shapes: the original Base64 workspace hash, the `s2` workspace envelope, and the `rv=1` query lock. Each path validates within its existing budget, discards only removed environment fields, and returns the new canonical snapshot/view without warning when all remaining fields are valid. New encoders never emit Host fields. Governs R6, R8-R9.
 - **KTD5 — Canvas contrast follows the effective diagram theme, not only app chrome.** Reuse Mermaid config parsing/precedence to resolve the valid effective theme, classify every `SUPPORTED_THEMES` value into a light or dark canvas family, and keep the grid, status text, focus treatment, and Bounds outline legible. The SVG remains responsible for its own explicit background and arbitrary `themeVariables`/`themeCSS`; the Playground supplies only the surrounding presentation surface. Governs R1, R11.
@@ -206,7 +206,7 @@ sequenceDiagram
 **Approach:**
 
 1. Keep the viewport container full-size and overflow-hidden, remove `bg-white`, padding, rounded corners, and shadow from the diagram wrapper, and remove only a default `background-color: white` declaration from the responsive presentation clone. Preserve the frozen artifact and any non-default renderer background for copy/export.
-2. Preserve the existing camera state machine and fit margin. In Infinite Canvas, measure the mounted root's finite `getBBox()` bounds, union them with its unchanged `viewBox`, and use that presentation-only geometry for Fit and centering. Fall back to intrinsic root geometry when measurement is unavailable or invalid. ViewBox Frame continues to fit the root viewport. Do not rewrite gesture logic.
+2. Preserve the existing camera state machine and fit margin. In Infinite Canvas, measure finite mounted SVG graphics in root user space, expand from the unchanged `viewBox` only through intersecting geometry, and use that connected presentation-only union for Fit and centering. This reveals titles and content crossing the viewport without admitting disconnected markers that rely on root clipping. Fall back to intrinsic root geometry when measurement is unavailable or invalid. ViewBox Frame continues to fit the root viewport. Do not rewrite gesture logic.
 3. Add `showSvgBounds` to the Preview-owned store state and expose one native pressed button in a stable toolbar position whenever SVG or Compare mode is selected, including loading, empty, error, source, and stale-publication states. The preference remains toggleable before an SVG mounts; its translated label explains that it applies to all mounted Visual panes. Preview resolves the canvas family and passes both controlled values to CompareView, which forwards them to its two `SvgViewport` instances; components do not introduce a second direct-store ownership path.
 4. Render a pointer-transparent dashed outline on the exact mounted SVG host/wrapper, following camera transforms without adding box size or independently changing fit calculations. Apply visible overflow only to the Infinite Canvas mounted clone and restore its original inline overflow declaration in ViewBox Frame.
 5. Resolve the effective theme through existing Mermaid config precedence, map all supported themes to a light/dark canvas family, and apply family tokens for surface, grid, status content, focus, and Bounds. Cover the config-overrides-toolbar case without attempting to infer arbitrary custom theme-variable contrast.
@@ -216,12 +216,13 @@ sequenceDiagram
 
 - Visual and Compare contain no finite card classes and still fit/zoom/pan.
 - A long Sequence title that extends beyond an unchanged root `viewBox` is fully visible after Infinite Canvas Fit and clipped again in ViewBox Frame; both engines use the shared `SvgViewport` path.
+- A Gantt marker positioned far outside its date range remains excluded from Fit while the in-range diagram stays readable in Visual and Compare.
 - Bounds toggling uses a translated native button with `aria-pressed`; Enter and Space update only the preference/diagnostic style and do not replace the mounted artifact or alter reported zoom.
 - Anchor navigation suppression and gesture promotion still work.
 - Every supported effective theme maps to a canvas family; a config `theme=dark` overrides a toolbar `default` selection for canvas contrast.
 - On a narrow Compare view, users can still scroll from a pane header/gutter to the second engine while one-finger drags inside a canvas continue to pan it.
 
-**Definition of done:** The canvas fills every Preview pane, Infinite Canvas reveals measurable SVG bounding-box overflow without mutating artifacts, ViewBox Frame preserves root clipping diagnosis, SVG Bounds is accessible and non-semantic, and existing camera behavior remains intact.
+**Definition of done:** The canvas fills every Preview pane, Infinite Canvas reveals connected measurable SVG overflow without mutating artifacts, ViewBox Frame preserves root clipping diagnosis, SVG Bounds is accessible and non-semantic, and existing camera behavior remains intact.
 
 ### U3 — Simplify share contracts and migrate Host-bearing links
 
@@ -302,7 +303,7 @@ Run in dependency order and avoid redundant full-suite reruns:
 | --- | --- |
 | Canonical operation for both engines | runtime/coordinator unit test |
 | No render on canvas/camera changes | focused coordinator + browser request-count assertion |
-| Infinite shell, bounding-box overflow Fit, exact ViewBox clipping, bounds overlay, and pressed semantics | Chromium presentation test |
+| Infinite shell, connected overflow Fit, exact ViewBox clipping, bounds overlay, and pressed semantics | Chromium presentation test |
 | Legacy Host link degradation | Base64/`s2`/`rv=1` share unit tests + one browser hydration case |
 | Finite export unaffected | existing export unit/browser coverage |
 | Mobile gesture and safe-area behavior | mobile Chromium test |
@@ -323,7 +324,7 @@ Run in dependency order and avoid redundant full-suite reruns:
 ## Definition of Done
 
 - The Playground has no visible or hidden Canonical/Host mode selection, live Host measurement, or locked environment state.
-- Visual and Compare use a full-surface, theme-aware infinite canvas whose Fit includes finite browser `getBBox()` overflow while ViewBox Frame preserves exact root clipping diagnosis.
+- Visual and Compare use a full-surface, theme-aware infinite canvas whose Fit includes finite browser-measured overflow connected to the root viewport while ViewBox Frame preserves exact root clipping diagnosis.
 - SVG Bounds can be toggled accessibly and is absent from artifacts and exports.
 - Merman and Mermaid.js receive the same canonical `800×600` interactive environment; lower-level container sizing APIs remain intact.
 - New workspace and issue links omit Host geometry; only issue links carry current page/editor/Preview/Bounds state, and old Base64/`s2`/`rv=1` Host-bearing links safely restore supported fields.

--- a/docs/workstreams/web-wasm-playground/DESIGN.md
+++ b/docs/workstreams/web-wasm-playground/DESIGN.md
@@ -127,16 +127,18 @@ either link is clipboard-only.
 Renderer geometry, operation viewport, responsive presentation, and export dimensions remain
 separate owners. Visual and Compare share two presentation shells over the same mounted artifact
 and camera state. Infinite Canvas uses the full available grid surface without a finite paper edge.
-Its mounted clone reveals browser-measured `getBBox()` overflow, and Fit uses the union of those
-bounds and the renderer-owned root viewport. ViewBox Frame restores the root's original overflow
+Its mounted clone reveals browser-measured overflow from SVG graphics connected to the root
+viewport, and Fit uses the union of those bounds and the renderer-owned viewport. Disconnected
+root-clipped decorations remain outside Fit so an intentionally off-range marker cannot collapse
+the diagram. ViewBox Frame restores the root's original overflow
 behavior, removes the grid, and outlines the exact mounted SVG viewport with a finite surface and
 shadow; it adds no padding, rounding, or renderer geometry. The responsive presentation clone
 preserves a valid renderer `viewBox` byte-for-byte. An SVG without `viewBox`, or one whose browser
 bounds cannot be measured safely, falls back to preview-local intrinsic geometry. The clone
 suppresses the known Merman default white root background so the selected presentation shell owns
 the surface; the frozen artifact, exports, and non-default root backgrounds remain unchanged. SVG
-Bounds is an independent pointer-transparent outline on the mounted root. `getBBox()` bounds remain
-a presentation-only camera input: neither mode exposes arbitrary `viewBox` editing, mutates export
+Bounds is an independent pointer-transparent outline on the mounted root. Connected browser bounds
+remain a presentation-only camera input: neither mode exposes arbitrary `viewBox` editing, mutates export
 geometry, or claims to repair renderer-owned bounds.
 
 ## Export Workbench

--- a/docs/workstreams/web-wasm-playground/DESIGN.md
+++ b/docs/workstreams/web-wasm-playground/DESIGN.md
@@ -127,14 +127,17 @@ either link is clipboard-only.
 Renderer geometry, operation viewport, responsive presentation, and export dimensions remain
 separate owners. Visual and Compare share two presentation shells over the same mounted artifact
 and camera state. Infinite Canvas uses the full available grid surface without a finite paper edge.
-ViewBox Frame removes the grid and outlines the exact mounted SVG viewport with a finite surface and
+Its mounted clone reveals browser-measured `getBBox()` overflow, and Fit uses the union of those
+bounds and the renderer-owned root viewport. ViewBox Frame restores the root's original overflow
+behavior, removes the grid, and outlines the exact mounted SVG viewport with a finite surface and
 shadow; it adds no padding, rounding, or renderer geometry. The responsive presentation clone
-preserves a valid renderer `viewBox` byte-for-byte. An SVG without `viewBox` may use only
-preview-local intrinsic width and height. The clone suppresses the known Merman default white root
-background so the selected presentation shell owns the surface; the frozen artifact, exports, and
-non-default root backgrounds remain unchanged. SVG Bounds is an independent pointer-transparent
-outline on the mounted root; neither control synthesizes browser bounds, exposes arbitrary
-`viewBox` editing, mutates export geometry, or claims to repair renderer-owned title clipping.
+preserves a valid renderer `viewBox` byte-for-byte. An SVG without `viewBox`, or one whose browser
+bounds cannot be measured safely, falls back to preview-local intrinsic geometry. The clone
+suppresses the known Merman default white root background so the selected presentation shell owns
+the surface; the frozen artifact, exports, and non-default root backgrounds remain unchanged. SVG
+Bounds is an independent pointer-transparent outline on the mounted root. `getBBox()` bounds remain
+a presentation-only camera input: neither mode exposes arbitrary `viewBox` editing, mutates export
+geometry, or claims to repair renderer-owned bounds.
 
 ## Export Workbench
 

--- a/docs/workstreams/web-wasm-playground/MERMAID_COMPARE_MODE.md
+++ b/docs/workstreams/web-wasm-playground/MERMAID_COMPARE_MODE.md
@@ -99,13 +99,15 @@ host dimensions or camera coordinates; legacy Host-bearing links restore support
 degrade to canonical rendering. Neither copy action mutates the current URL or active operation.
 
 Preview presentation preserves each engine's valid SVG `viewBox` byte-for-byte. Infinite Canvas
-floats the diagram on a full-surface grid, reveals measurable SVG bounding-box overflow on the
-mounted clone, and fits the union of browser `getBBox()` bounds and the renderer-owned root viewport.
+floats the diagram on a full-surface grid, reveals measurable overflow from SVG graphics connected
+to the renderer-owned root viewport, and fits their union. Disconnected decorations that the root
+viewport intentionally clips remain outside Fit, preventing an off-range marker from collapsing the
+diagram.
 ViewBox Frame restores the root's original overflow behavior, removes the grid, and gives the exact
 mounted SVG viewport a finite outline and shadow. Both modes share the same artifact and camera state. The responsive clone
 suppresses Merman's known default white root background without changing the frozen artifact,
 exports, or non-default root backgrounds. A missing-`viewBox` artifact, failed measurement, or
-non-finite browser result falls back to preview-local intrinsic dimensions. `getBBox()` bounds are
+non-finite browser result falls back to preview-local intrinsic dimensions. Connected browser bounds are
 never promoted into renderer or export geometry. The optional SVG Bounds outline follows the mounted root
 and affects neither fit nor export. This shared presentation path applies equally to Merman and
 Mermaid.js; ViewBox Frame remains the diagnostic mode for engine-owned root clipping.

--- a/docs/workstreams/web-wasm-playground/MERMAID_COMPARE_MODE.md
+++ b/docs/workstreams/web-wasm-playground/MERMAID_COMPARE_MODE.md
@@ -99,14 +99,16 @@ host dimensions or camera coordinates; legacy Host-bearing links restore support
 degrade to canonical rendering. Neither copy action mutates the current URL or active operation.
 
 Preview presentation preserves each engine's valid SVG `viewBox` byte-for-byte. Infinite Canvas
-floats the diagram on a full-surface grid; ViewBox Frame removes the grid and gives the exact mounted
-SVG viewport a finite outline and shadow. Both modes share the same artifact and camera state. The
-responsive clone suppresses Merman's known default white root background without changing the
-frozen artifact, exports, or non-default root backgrounds. A missing-`viewBox` artifact may retain
-preview-local intrinsic dimensions, but browser bounds are never promoted into renderer geometry.
-The optional SVG Bounds outline follows the mounted root and affects neither fit nor export.
-Browser-dependent title or root-viewBox clipping visible in pinned Mermaid therefore remains
-visible in both panes; the Playground does not hide it with a Merman-only bounds workaround.
+floats the diagram on a full-surface grid, reveals measurable SVG bounding-box overflow on the
+mounted clone, and fits the union of browser `getBBox()` bounds and the renderer-owned root viewport.
+ViewBox Frame restores the root's original overflow behavior, removes the grid, and gives the exact
+mounted SVG viewport a finite outline and shadow. Both modes share the same artifact and camera state. The responsive clone
+suppresses Merman's known default white root background without changing the frozen artifact,
+exports, or non-default root backgrounds. A missing-`viewBox` artifact, failed measurement, or
+non-finite browser result falls back to preview-local intrinsic dimensions. `getBBox()` bounds are
+never promoted into renderer or export geometry. The optional SVG Bounds outline follows the mounted root
+and affects neither fit nor export. This shared presentation path applies equally to Merman and
+Mermaid.js; ViewBox Frame remains the diagnostic mode for engine-owned root clipping.
 
 Each Compare pane has one export launcher. The workbench keeps the engine identity visible and
 does not retarget when a newer render completes. Mermaid raster output uses the pane's validated

--- a/playground/src/components/SvgViewport.tsx
+++ b/playground/src/components/SvgViewport.tsx
@@ -24,6 +24,16 @@ interface Point {
   readonly y: number;
 }
 
+interface FitGeometry {
+  readonly centerOffset: Point;
+  readonly dimensions: SvgDimensions;
+}
+
+interface RootOverflowSnapshot {
+  readonly priority: string;
+  readonly value: string;
+}
+
 const SVG_VIEWPORT_CONTROLLER = Symbol("svg-viewport-controller");
 
 export interface SvgViewportController {
@@ -149,6 +159,7 @@ interface AppliedTransform {
 interface MountedPresentation {
   readonly key: number | null;
   onReady?: (at: number) => void;
+  readonly originalRootOverflow: RootOverflowSnapshot | null;
   readonly preview: PreparedSvgPreview;
   readonly root: ShadowRoot;
 }
@@ -225,6 +236,7 @@ export function SvgViewport({
   const suppressNextAnchorClickRef = useRef(false);
   const [mountFailure, setMountFailure] = useState<SvgMountFailure | null>(null);
   const navigationEnabledRef = useRef(navigationEnabled);
+  const presentationModeRef = useRef(presentationMode);
   const previewRef = useRef(preview);
   const lastAppliedRef = useRef<AppliedTransform | null>(null);
   const mountedPresentationRef = useRef<MountedPresentation | null>(null);
@@ -251,6 +263,7 @@ export function SvgViewport({
   });
   previewRef.current = preview;
   navigationEnabledRef.current = navigationEnabled;
+  presentationModeRef.current = presentationMode;
   const presentationError =
     prepared.error ??
     (mountFailure?.preview === preview ? mountFailure.error : null);
@@ -414,27 +427,32 @@ export function SvgViewport({
     const intrinsicSize = currentPreview.dimensions;
     let nextZoom: number;
     let scaleBaseZoom: number;
+    let centerOffset: Point = { x: 0, y: 0 };
 
     if (intrinsicSize) {
+      const fitGeometry = resolveFitGeometry(
+        mountedPresentationRef.current,
+        currentPreview,
+        presentationModeRef.current,
+        intrinsicSize
+      );
+      centerOffset = fitGeometry.centerOffset;
       const insets = measureElementInsets(content);
       const availableSvgWidth = Math.max(availableWidth - insets.width, 1);
       const availableSvgHeight = Math.max(availableHeight - insets.height, 1);
       nextZoom = Math.min(
         1,
-        availableSvgWidth / intrinsicSize.width,
-        availableSvgHeight / intrinsicSize.height
+        availableSvgWidth / fitGeometry.dimensions.width,
+        availableSvgHeight / fitGeometry.dimensions.height
       );
       if (!isPositiveFinite(nextZoom)) return false;
       if (currentPreview.rootSizing === "responsive") {
-        shadowHost.style.width = `${Math.max(
-          1,
-          intrinsicSize.width * nextZoom
-        )}px`;
-        shadowHost.style.height = `${Math.max(
-          1,
-          intrinsicSize.height * nextZoom
-        )}px`;
-        scaleBaseZoom = nextZoom;
+        scaleBaseZoom = resolveResponsiveSvgBaseZoom(
+          intrinsicSize,
+          nextZoom
+        );
+        shadowHost.style.width = `${intrinsicSize.width * scaleBaseZoom}px`;
+        shadowHost.style.height = `${intrinsicSize.height * scaleBaseZoom}px`;
       } else {
         shadowHost.style.width = `${intrinsicSize.width}px`;
         shadowHost.style.height = `${intrinsicSize.height}px`;
@@ -459,7 +477,10 @@ export function SvgViewport({
     state.autoFit = true;
     state.fitZoom = nextZoom;
     state.fittedPreview = currentPreview;
-    state.position = { x: 0, y: 0 };
+    state.position = {
+      x: -centerOffset.x * nextZoom,
+      y: -centerOffset.y * nextZoom,
+    };
     state.scaleBaseZoom = scaleBaseZoom;
     state.zoom = nextZoom;
     scheduleTransform();
@@ -544,11 +565,22 @@ export function SvgViewport({
     root.replaceChildren(node);
     stabilizeInheritedSvgColor(node, host);
     setNavigableAnchorsEnabled(root, navigationEnabledRef.current);
+    const svg = node instanceof SVGSVGElement ? node : null;
+    const originalRootOverflow = svg ? readRootOverflow(svg) : null;
+    applySvgPresentationMode(svg, originalRootOverflow, presentationModeRef.current);
+    const cleanupMountedNode = () => {
+      restoreRootOverflow(svg, originalRootOverflow);
+      root.replaceChildren();
+    };
     const requested = requestedPresentationRef.current;
-    if (requested.preview !== preview) return;
+    if (requested.preview !== preview) {
+      cleanupMountedNode();
+      return;
+    }
     mountedPresentationRef.current = {
       key: requested.key,
       onReady: requested.onReady,
+      originalRootOverflow,
       preview,
       root,
     };
@@ -559,7 +591,7 @@ export function SvgViewport({
       if (mounted?.preview === preview && mounted.root === root) {
         mountedPresentationRef.current = null;
       }
-      root.replaceChildren();
+      cleanupMountedNode();
     };
   }, [cancelGesture, preview, scheduleFit, scheduleTransform]);
 
@@ -567,6 +599,21 @@ export function SvgViewport({
     const root = mountedPresentationRef.current?.root;
     if (root) setNavigableAnchorsEnabled(root, navigationEnabled);
   }, [navigationEnabled, preview]);
+
+  useLayoutEffect(() => {
+    const mounted = mountedPresentationRef.current;
+    if (!mounted || mounted.preview !== preview) return;
+    applySvgPresentationMode(
+      mounted.root.querySelector("svg"),
+      mounted.originalRootOverflow,
+      presentationMode
+    );
+    if (stateRef.current.autoFit) {
+      scheduleFit();
+    } else {
+      schedulePresentationReady();
+    }
+  }, [presentationMode, preview, scheduleFit, schedulePresentationReady]);
 
   useLayoutEffect(() => {
     requestedPresentationRef.current = {
@@ -983,6 +1030,150 @@ function setNavigableAnchorsEnabled(root: ShadowRoot, enabled: boolean): void {
     }
     anchor.setAttribute("aria-disabled", "true");
   }
+}
+
+function resolveFitGeometry(
+  mounted: MountedPresentation | null,
+  preview: PreparedSvgPreview,
+  presentationMode: SvgPresentationMode,
+  intrinsicSize: SvgDimensions
+): FitGeometry {
+  const fallback = {
+    centerOffset: { x: 0, y: 0 },
+    dimensions: intrinsicSize,
+  } satisfies FitGeometry;
+  if (
+    presentationMode !== "infinite" ||
+    mounted?.preview !== preview
+  ) {
+    return fallback;
+  }
+
+  const svg = mounted.root.querySelector("svg");
+  return svg ? measureVisualFitGeometry(svg, intrinsicSize) ?? fallback : fallback;
+}
+
+function measureVisualFitGeometry(
+  svg: SVGSVGElement,
+  intrinsicSize: SvgDimensions
+): FitGeometry | null {
+  const viewBox = svg.viewBox.baseVal;
+  if (
+    !isFiniteRectangle(viewBox.x, viewBox.y, viewBox.width, viewBox.height) ||
+    viewBox.width <= 0 ||
+    viewBox.height <= 0
+  ) {
+    return null;
+  }
+
+  let visualBounds: DOMRect;
+  try {
+    visualBounds = svg.getBBox();
+  } catch {
+    return null;
+  }
+  if (
+    !isFiniteRectangle(
+      visualBounds.x,
+      visualBounds.y,
+      visualBounds.width,
+      visualBounds.height
+    )
+  ) {
+    return null;
+  }
+
+  const left = Math.min(viewBox.x, visualBounds.x);
+  const top = Math.min(viewBox.y, visualBounds.y);
+  const right = Math.max(
+    viewBox.x + viewBox.width,
+    visualBounds.x + visualBounds.width
+  );
+  const bottom = Math.max(
+    viewBox.y + viewBox.height,
+    visualBounds.y + visualBounds.height
+  );
+  const scaleX = intrinsicSize.width / viewBox.width;
+  const scaleY = intrinsicSize.height / viewBox.height;
+  const width = (right - left) * scaleX;
+  const height = (bottom - top) * scaleY;
+  const centerOffset = {
+    x:
+      ((left + right) / 2 - (viewBox.x + viewBox.width / 2)) * scaleX,
+    y:
+      ((top + bottom) / 2 - (viewBox.y + viewBox.height / 2)) * scaleY,
+  };
+  if (
+    !isPositiveFinite(width) ||
+    !isPositiveFinite(height) ||
+    !Number.isFinite(centerOffset.x) ||
+    !Number.isFinite(centerOffset.y)
+  ) {
+    return null;
+  }
+
+  return {
+    centerOffset,
+    dimensions: { width, height },
+  };
+}
+
+function resolveResponsiveSvgBaseZoom(
+  intrinsicSize: SvgDimensions,
+  fitZoom: number
+): number {
+  const minimumBaseZoom = Math.max(
+    1 / intrinsicSize.width,
+    1 / intrinsicSize.height
+  );
+  return Number.isFinite(minimumBaseZoom)
+    ? Math.max(fitZoom, minimumBaseZoom)
+    : fitZoom;
+}
+
+function applySvgPresentationMode(
+  svg: SVGSVGElement | null,
+  originalOverflow: RootOverflowSnapshot | null,
+  presentationMode: SvgPresentationMode
+): void {
+  if (!svg) return;
+  if (presentationMode === "infinite") {
+    svg.style.setProperty("overflow", "visible", "important");
+    return;
+  }
+  restoreRootOverflow(svg, originalOverflow);
+}
+
+function readRootOverflow(svg: SVGSVGElement): RootOverflowSnapshot {
+  return {
+    priority: svg.style.getPropertyPriority("overflow"),
+    value: svg.style.getPropertyValue("overflow"),
+  };
+}
+
+function restoreRootOverflow(
+  svg: SVGSVGElement | null,
+  originalOverflow: RootOverflowSnapshot | null
+): void {
+  if (!svg) return;
+  if (originalOverflow?.value) {
+    svg.style.setProperty(
+      "overflow",
+      originalOverflow.value,
+      originalOverflow.priority
+    );
+  } else {
+    svg.style.removeProperty("overflow");
+  }
+}
+
+function isFiniteRectangle(
+  x: number,
+  y: number,
+  width: number,
+  height: number
+): boolean {
+  return [x, y, width, height].every(Number.isFinite);
 }
 
 function measureRenderedContent(content: HTMLDivElement): SvgDimensions | null {

--- a/playground/src/components/SvgViewport.tsx
+++ b/playground/src/components/SvgViewport.tsx
@@ -29,6 +29,13 @@ interface FitGeometry {
   readonly dimensions: SvgDimensions;
 }
 
+interface SvgBounds {
+  readonly bottom: number;
+  readonly left: number;
+  readonly right: number;
+  readonly top: number;
+}
+
 interface RootOverflowSnapshot {
   readonly priority: string;
   readonly value: string;
@@ -1066,33 +1073,15 @@ function measureVisualFitGeometry(
     return null;
   }
 
-  let visualBounds: DOMRect;
-  try {
-    visualBounds = svg.getBBox();
-  } catch {
-    return null;
-  }
-  if (
-    !isFiniteRectangle(
-      visualBounds.x,
-      visualBounds.y,
-      visualBounds.width,
-      visualBounds.height
-    )
-  ) {
-    return null;
-  }
+  const visualBounds = measureConnectedVisualBounds(svg, {
+    bottom: viewBox.y + viewBox.height,
+    left: viewBox.x,
+    right: viewBox.x + viewBox.width,
+    top: viewBox.y,
+  });
+  if (!visualBounds) return null;
 
-  const left = Math.min(viewBox.x, visualBounds.x);
-  const top = Math.min(viewBox.y, visualBounds.y);
-  const right = Math.max(
-    viewBox.x + viewBox.width,
-    visualBounds.x + visualBounds.width
-  );
-  const bottom = Math.max(
-    viewBox.y + viewBox.height,
-    visualBounds.y + visualBounds.height
-  );
+  const { bottom, left, right, top } = visualBounds;
   const scaleX = intrinsicSize.width / viewBox.width;
   const scaleY = intrinsicSize.height / viewBox.height;
   const width = (right - left) * scaleX;
@@ -1115,6 +1104,145 @@ function measureVisualFitGeometry(
   return {
     centerOffset,
     dimensions: { width, height },
+  };
+}
+
+function measureConnectedVisualBounds(
+  svg: SVGSVGElement,
+  rootBounds: SvgBounds
+): SvgBounds | null {
+  const rootTransform = svg.getCTM();
+  if (!rootTransform) return null;
+
+  let toRoot: DOMMatrix;
+  try {
+    toRoot = rootTransform.inverse();
+  } catch {
+    return null;
+  }
+
+  let connectedBounds = rootBounds;
+  let pending = Array.from(svg.querySelectorAll<SVGGraphicsElement>("*"))
+    .filter(isMeasurableSvgGraphic)
+    .flatMap((element) => {
+      const bounds = measureSvgGraphicInRootSpace(element, toRoot);
+      return bounds ? [bounds] : [];
+    });
+
+  while (pending.length > 0) {
+    const disconnected: SvgBounds[] = [];
+    let foundConnection = false;
+    for (const candidate of pending) {
+      if (!boundsIntersect(connectedBounds, candidate)) {
+        disconnected.push(candidate);
+        continue;
+      }
+      connectedBounds = unionBounds(connectedBounds, candidate);
+      foundConnection = true;
+    }
+    if (!foundConnection) break;
+    pending = disconnected;
+  }
+
+  return connectedBounds;
+}
+
+function isMeasurableSvgGraphic(element: SVGGraphicsElement): boolean {
+  if (
+    element.localName === "a" ||
+    element.localName === "g" ||
+    element.localName === "svg" ||
+    element.localName === "switch"
+  ) {
+    return false;
+  }
+
+  for (
+    let ancestor = element.parentElement;
+    ancestor && ancestor instanceof SVGElement;
+    ancestor = ancestor.parentElement
+  ) {
+    if (
+      ancestor.localName === "clipPath" ||
+      ancestor.localName === "defs" ||
+      ancestor.localName === "marker" ||
+      ancestor.localName === "mask" ||
+      ancestor.localName === "pattern" ||
+      ancestor.localName === "symbol"
+    ) {
+      return false;
+    }
+  }
+
+  const style = getComputedStyle(element);
+  return (
+    style.display !== "none" &&
+    style.visibility !== "hidden" &&
+    style.visibility !== "collapse"
+  );
+}
+
+function measureSvgGraphicInRootSpace(
+  element: SVGGraphicsElement,
+  rootInverse: DOMMatrix
+): SvgBounds | null {
+  try {
+    const box = element.getBBox();
+    const elementTransform = element.getCTM();
+    if (
+      !elementTransform ||
+      !isFiniteRectangle(box.x, box.y, box.width, box.height) ||
+      box.width < 0 ||
+      box.height < 0
+    ) {
+      return null;
+    }
+
+    const transform = rootInverse.multiply(elementTransform);
+    const corners = [
+      transformSvgPoint(transform, box.x, box.y),
+      transformSvgPoint(transform, box.x + box.width, box.y),
+      transformSvgPoint(transform, box.x, box.y + box.height),
+      transformSvgPoint(
+        transform,
+        box.x + box.width,
+        box.y + box.height
+      ),
+    ];
+    const left = Math.min(...corners.map((point) => point.x));
+    const right = Math.max(...corners.map((point) => point.x));
+    const top = Math.min(...corners.map((point) => point.y));
+    const bottom = Math.max(...corners.map((point) => point.y));
+    return [left, right, top, bottom].every(Number.isFinite)
+      ? { bottom, left, right, top }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function transformSvgPoint(matrix: DOMMatrix, x: number, y: number): Point {
+  return {
+    x: matrix.a * x + matrix.c * y + matrix.e,
+    y: matrix.b * x + matrix.d * y + matrix.f,
+  };
+}
+
+function boundsIntersect(left: SvgBounds, right: SvgBounds): boolean {
+  return (
+    left.left <= right.right &&
+    left.right >= right.left &&
+    left.top <= right.bottom &&
+    left.bottom >= right.top
+  );
+}
+
+function unionBounds(left: SvgBounds, right: SvgBounds): SvgBounds {
+  return {
+    bottom: Math.max(left.bottom, right.bottom),
+    left: Math.min(left.left, right.left),
+    right: Math.max(left.right, right.right),
+    top: Math.min(left.top, right.top),
   };
 }
 

--- a/playground/tests/render.presentation.spec.ts
+++ b/playground/tests/render.presentation.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Locator, type Page } from "@playwright/test";
 
 import {
   monitorBrowserErrors,
@@ -243,6 +243,81 @@ test("Visual and Compare switch between Infinite Canvas and ViewBox Frame as pre
     )
     .toBe(true);
 
+  errors.assertNone();
+});
+
+test("Infinite Canvas reveals visual overflow while ViewBox Frame preserves root clipping", async ({
+  page,
+}) => {
+  const errors = monitorBrowserErrors(page);
+  await openPlayground(page);
+  await renderSource(
+    page,
+    [
+      "sequenceDiagram",
+      "    title A diagram title that is quite long and might affect vertical bounds",
+      "    Alice->>Bob: hi",
+    ].join("\n")
+  );
+
+  const viewport = page.locator('[data-merman-svg-viewport="true"]').first();
+  const infinite = await sequenceTitlePresentation(viewport);
+  expect(infinite.titleBounds.right).toBeGreaterThan(infinite.viewBox.right);
+  expect(infinite.rootOverflow).toBe("visible");
+  expect(infinite.titleRect.left).toBeGreaterThanOrEqual(
+    infinite.viewportRect.left - 1
+  );
+  expect(infinite.titleRect.right).toBeLessThanOrEqual(
+    infinite.viewportRect.right + 1
+  );
+
+  await page
+    .getByRole("button", { name: "ViewBox Frame", exact: true })
+    .click();
+  const framed = await sequenceTitlePresentation(viewport);
+  expect(framed.viewBox).toEqual(infinite.viewBox);
+  expect(framed.titleBounds).toEqual(infinite.titleBounds);
+  expect(framed.rootOverflow).toBe("hidden");
+
+  await page
+    .getByRole("button", { name: "Infinite Canvas", exact: true })
+    .click();
+  const extremeOverflow = viewport.locator(".preview-container > div").first();
+  await extremeOverflow.evaluate((element) => {
+    const svg = element.shadowRoot?.querySelector<SVGSVGElement>("svg");
+    if (!svg) throw new Error("Missing mounted Sequence SVG.");
+    const rect = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "rect"
+    );
+    rect.dataset.testExtremeOverflow = "true";
+    rect.setAttribute("x", String(svg.viewBox.baseVal.x));
+    rect.setAttribute("y", String(svg.viewBox.baseVal.y));
+    rect.setAttribute("width", "2000000");
+    rect.setAttribute("height", "1");
+    rect.setAttribute("opacity", "0");
+    svg.append(rect);
+  });
+  await page.getByRole("button", { name: "Fit", exact: true }).click();
+  await expect
+    .poll(() =>
+      extremeOverflow.evaluate((element) => {
+        const rect = element.shadowRoot?.querySelector<SVGRectElement>(
+          '[data-test-extreme-overflow="true"]'
+        );
+        const canvas = element.closest(
+          '[data-merman-svg-viewport="true"]'
+        );
+        if (!rect || !canvas) return false;
+        const rectBounds = rect.getBoundingClientRect();
+        const canvasBounds = canvas.getBoundingClientRect();
+        return (
+          rectBounds.left >= canvasBounds.left - 1 &&
+          rectBounds.right <= canvasBounds.right + 1
+        );
+      })
+    )
+    .toBe(true);
   errors.assertNone();
 });
 
@@ -701,6 +776,38 @@ function fontOnlyConfig(theme: string): string {
 async function renderSource(page: Page, source: string): Promise<void> {
   await replaceEditorSource(page, source);
   await waitForPreviewSvg(page);
+}
+
+async function sequenceTitlePresentation(viewport: Locator) {
+  const viewportRect = await viewport.evaluate((element) => {
+    const bounds = element.getBoundingClientRect();
+    return { left: bounds.left, right: bounds.right };
+  });
+  const host = viewport.locator(".preview-container > div").first();
+  return host.evaluate((element, measuredViewport) => {
+    const svg = element.shadowRoot?.querySelector<SVGSVGElement>("svg");
+    const title = [...(svg?.querySelectorAll<SVGTextElement>("text") ?? [])].find(
+      (text) => text.textContent?.startsWith("A diagram title that is quite long")
+    );
+    if (!svg || !title) throw new Error("Missing Sequence title SVG geometry.");
+
+    const viewBox = svg.viewBox.baseVal;
+    const titleBounds = title.getBBox();
+    const titleRect = title.getBoundingClientRect();
+    return {
+      rootOverflow: getComputedStyle(svg).overflow,
+      titleBounds: {
+        left: titleBounds.x,
+        right: titleBounds.x + titleBounds.width,
+      },
+      titleRect: { left: titleRect.left, right: titleRect.right },
+      viewBox: {
+        left: viewBox.x,
+        right: viewBox.x + viewBox.width,
+      },
+      viewportRect: measuredViewport,
+    };
+  }, viewportRect);
 }
 
 function previewHost(page: Page) {

--- a/playground/tests/render.presentation.spec.ts
+++ b/playground/tests/render.presentation.spec.ts
@@ -298,7 +298,9 @@ test("Infinite Canvas reveals visual overflow while ViewBox Frame preserves root
     rect.setAttribute("opacity", "0");
     svg.append(rect);
   });
-  await page.getByRole("button", { name: "Fit", exact: true }).click();
+  await page
+    .getByRole("button", { name: "Fit to view", exact: true })
+    .click();
   await expect
     .poll(() =>
       extremeOverflow.evaluate((element) => {

--- a/playground/tests/svg-geometry.spec.ts
+++ b/playground/tests/svg-geometry.spec.ts
@@ -3,6 +3,11 @@ import { expect, test } from "@playwright/test";
 import { createServer, type ViteDevServer } from "vite";
 
 import { GENERATED_EXAMPLES } from "../src/generated/examples.ts";
+import {
+  monitorBrowserErrors,
+  replaceEditorSource,
+  waitForPreviewSvg,
+} from "./helpers/playground";
 
 let sourceServer: ViteDevServer | null = null;
 let sourceOrigin = "";
@@ -30,6 +35,36 @@ test.beforeAll(async () => {
 test.afterAll(async () => {
   await sourceServer?.close();
   sourceServer = null;
+});
+
+test("ViewBox Frame restores root clipping after StrictMode effect replay", async ({
+  page,
+}) => {
+  const errors = monitorBrowserErrors(page);
+  await page.goto(sourceOrigin);
+  await replaceEditorSource(
+    page,
+    [
+      "sequenceDiagram",
+      "    title A diagram title that is quite long and might affect vertical bounds",
+      "    Alice->>Bob: hi",
+    ].join("\n")
+  );
+  await waitForPreviewSvg(page);
+
+  const host = page.locator(".preview-container > div").first();
+  const rootOverflow = () =>
+    host.evaluate((element) => {
+      const svg = element.shadowRoot?.querySelector<SVGSVGElement>("svg");
+      return svg ? getComputedStyle(svg).overflow : null;
+    });
+  await expect.poll(rootOverflow).toBe("visible");
+
+  await page
+    .getByRole("button", { name: "ViewBox Frame", exact: true })
+    .click();
+  await expect.poll(rootOverflow).toBe("hidden");
+  errors.assertNone();
 });
 
 test("raster export changes only the root canvas and encodes explicit alpha or JPEG background", async ({


### PR DESCRIPTION
## Summary

Long Sequence titles and other finite SVG content drawn outside the renderer-owned root `viewBox` are now visible and correctly fitted in Infinite Canvas. ViewBox Frame still restores the original clipping behavior for exact diagnosis, while the frozen artifact and export geometry remain unchanged.

The fit path unions finite browser `getBBox()` bounds with the unchanged root viewport, preserves mounted artifact identity and camera behavior, and handles StrictMode node reuse plus extreme finite-overflow scaling.

Session-settled decisions carried from planning: keep one canonical render input, preserve the renderer-owned `viewBox` with presentation-only measurement, and use focused browser coverage instead of duplicating the full matrix.

## Validation

- `npm run lint`
- `npm run test:browser:typecheck`
- `npm run build:prepared`
- Focused Chromium desktop coverage for Visual/Compare mode propagation, normal and extreme overflow Fit, StrictMode replay, and touch pan/pinch

## Related

Related: zed-industries/zed#62410
