### PR TITLE
build(tree-sitter): prepare scoped package release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
           components: clippy
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2.85.13
+        uses: taiki-e/install-action@v2.86.1
         with:
           tool: nextest
 
@@ -398,7 +398,7 @@ jobs:
         run: rustup target add aarch64-linux-android wasm32-unknown-unknown
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2.85.13
+        uses: taiki-e/install-action@v2.86.1
         with:
           tool: nextest
 
@@ -625,7 +625,7 @@ jobs:
           cache-targets: false
 
       - name: Install wasm-tools
-        uses: taiki-e/install-action@v2.85.13
+        uses: taiki-e/install-action@v2.86.1
         with:
           tool: wasm-tools
 
@@ -706,7 +706,7 @@ jobs:
           cache-targets: false
 
       - name: Install wasm-tools
-        uses: taiki-e/install-action@v2.85.13
+        uses: taiki-e/install-action@v2.86.1
         with:
           tool: wasm-tools
 

--- a/.github/workflows/mermaid-admission.yml
+++ b/.github/workflows/mermaid-admission.yml
@@ -46,7 +46,7 @@ jobs:
         run: npm install --global --ignore-scripts --registry=https://registry.npmjs.org/ npm@11.17.0
 
       - name: Install wasm-tools
-        uses: taiki-e/install-action@v2.85.13
+        uses: taiki-e/install-action@v2.86.1
         with:
           tool: wasm-tools
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -49,7 +49,7 @@ jobs:
         run: npm install --global --ignore-scripts --registry=https://registry.npmjs.org/ npm@11.17.0
 
       - name: Install wasm-tools
-        uses: taiki-e/install-action@v2.85.13
+        uses: taiki-e/install-action@v2.86.1
         with:
           tool: wasm-tools
 

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -233,7 +233,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Install wasm-tools
-        uses: taiki-e/install-action@v2.85.13
+        uses: taiki-e/install-action@v2.86.1
         with:
           tool: wasm-tools
 

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -114,7 +114,7 @@ jobs:
         uses: Swatinem/rust-cache@v2.9.2
 
       - name: Install cargo-about
-        uses: taiki-e/install-action@v2.85.13
+        uses: taiki-e/install-action@v2.86.1
         with:
           tool: cargo-about@0.9.1
 
@@ -412,7 +412,7 @@ jobs:
           cache-dependency-path: platforms/web/package-lock.json
 
       - name: Install wasm-tools
-        uses: taiki-e/install-action@v2.85.13
+        uses: taiki-e/install-action@v2.86.1
         with:
           tool: wasm-tools
 

--- a/.github/workflows/release-tree-sitter-mermaid.yml
+++ b/.github/workflows/release-tree-sitter-mermaid.yml
@@ -184,7 +184,7 @@ jobs:
         uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2.85.11
+        uses: taiki-e/install-action@v2.86.1
         with:
           tool: nextest
 

--- a/.github/workflows/release-tree-sitter-mermaid.yml
+++ b/.github/workflows/release-tree-sitter-mermaid.yml
@@ -140,6 +140,11 @@ jobs:
 
           version = sys.argv[1]
           root = Path("distribution/tree-sitter-mermaid")
+          npm_manifest = json.loads((root / "package.json").read_text())
+          if npm_manifest["name"] != "@mermanjs/tree-sitter-mermaid":
+              raise SystemExit(
+                  f"unexpected npm package name: {npm_manifest['name']}"
+              )
           cmake = re.search(
               r'project\(tree-sitter-mermaid\s+VERSION\s+"([^"]+)"',
               (root / "CMakeLists.txt").read_text(),
@@ -153,7 +158,7 @@ jobs:
               "Cargo.toml": tomllib.loads((root / "Cargo.toml").read_text())["package"][
                   "version"
               ],
-              "package.json": json.loads((root / "package.json").read_text())["version"],
+              "package.json": npm_manifest["version"],
               "tree-sitter.json": json.loads(
                   (root / "tree-sitter.json").read_text()
               )["metadata"]["version"],
@@ -421,12 +426,12 @@ jobs:
         run: |
           set -euo pipefail
           release_dir="$RUNNER_TEMP/tree-sitter-mermaid-release"
-          candidates=("$release_dir"/tree-sitter-mermaid-*.tgz)
+          candidates=("$release_dir"/mermanjs-tree-sitter-mermaid-*.tgz)
           test "${#candidates[@]}" -eq 1
           candidate="${candidates[0]}"
-          registry_copy="$RUNNER_TEMP/tree-sitter-mermaid-$VERSION-registry.tgz"
+          registry_copy="$RUNNER_TEMP/mermanjs-tree-sitter-mermaid-$VERSION-registry.tgz"
 
-          registry_url="$(npm view "tree-sitter-mermaid@$VERSION" dist.tarball 2>/dev/null || true)"
+          registry_url="$(npm view "@mermanjs/tree-sitter-mermaid@$VERSION" dist.tarball 2>/dev/null || true)"
           if [[ -n "$registry_url" ]]; then
             curl --fail --silent --show-error --location \
               --output "$registry_copy" "$registry_url"
@@ -439,7 +444,7 @@ jobs:
           npm publish "$candidate" --access public --provenance --tag "$NPM_DIST_TAG" || \
             publish_status=$?
           for _ in {1..6}; do
-            registry_url="$(npm view "tree-sitter-mermaid@$VERSION" dist.tarball 2>/dev/null || true)"
+            registry_url="$(npm view "@mermanjs/tree-sitter-mermaid@$VERSION" dist.tarball 2>/dev/null || true)"
             if [[ -n "$registry_url" ]]; then
               curl --fail --silent --show-error --location \
                 --output "$registry_copy" "$registry_url"

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -131,7 +131,7 @@ jobs:
           package-manager-cache: false
 
       - name: Install wasm-tools
-        uses: taiki-e/install-action@v2.85.13
+        uses: taiki-e/install-action@v2.86.1
         with:
           tool: wasm-tools
 

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -50,7 +50,7 @@ jobs:
         uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Install cargo-audit
-        uses: taiki-e/install-action@v2.85.13
+        uses: taiki-e/install-action@v2.86.1
         with:
           tool: cargo-audit
 
@@ -71,12 +71,12 @@ jobs:
         uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Install cargo-deny
-        uses: taiki-e/install-action@v2.85.13
+        uses: taiki-e/install-action@v2.86.1
         with:
           tool: cargo-deny
 
       - name: Install cargo-about
-        uses: taiki-e/install-action@v2.85.13
+        uses: taiki-e/install-action@v2.86.1
         with:
           tool: cargo-about@0.9.1
 

--- a/.github/workflows/tree-sitter-mermaid.yml
+++ b/.github/workflows/tree-sitter-mermaid.yml
@@ -25,7 +25,7 @@ jobs:
         uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2.85.11
+        uses: taiki-e/install-action@v2.86.1
         with:
           tool: nextest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ The next workspace release remains in development. This section records only com
 - Added production Tree-sitter syntax highlighting to the native LSP and Playground. Both adapters
   consume the canonical `tree-sitter-mermaid` grammar and portable highlight query; the Playground
   loads the distribution WASM and runs incremental syntax parsing in a dedicated browser worker.
+  The independently versioned grammar release is prepared as the `tree-sitter-mermaid` crate and
+  the `@mermanjs/tree-sitter-mermaid` npm package.
 - Added the experimental public `@mermanjs/node` alpha package group for Node.js 22 and newer on macOS arm64/x64, Linux x64 glibc/musl, and Windows x64 MSVC. The root loader selects one exact-version native package and exposes deterministic static SVG plus metadata/layout operations without a postinstall downloader or browser-WASM fallback.
 - Added `merman-cli rustdoc build/check` as a checked static-fragment workflow. Crates can commit deterministic light/dark SVG Markdown, consume it through Rust's native `include_str!`, verify freshness in CI, and build hosted documentation without adding a Merman renderer or proc macro to the consuming Cargo graph.
 

--- a/distribution/tree-sitter-mermaid/README.md
+++ b/distribution/tree-sitter-mermaid/README.md
@@ -1,87 +1,111 @@
 # tree-sitter-mermaid
 
-A tolerant, incremental Tree-sitter grammar for Mermaid source, with structured support for all 35
-public diagram families in Mermaid 11.16.1.
+A tolerant, incremental [Tree-sitter] grammar for Mermaid source. It provides structured concrete
+syntax trees and editor queries for all 35 public diagram families in Mermaid 11.16.1, including
+the ZenUML integration backed by ZenUML Core 3.50.1.
 
-This package is deliberately adjacent to Merman's semantic parser. Tree-sitter owns the concrete
-syntax tree, error recovery, incremental reparsing, and editor queries. `merman-core` remains the
-authority for strict validity, semantic models, diagnostics, IR, rendering, navigation identity,
-and refactoring safety.
+Use this package for syntax highlighting, syntax-aware selection, folding, and other editor features
+that must keep working while a document is incomplete. Use [`@mermanjs/web`] or the Merman Rust
+crates when you need strict validation, semantic models, diagnostics, rendering, navigation, or safe
+refactoring. A recovered Tree-sitter tree is useful editor state; it is not proof that Mermaid will
+accept or render the document.
 
-## Distribution
+## Packages
 
-The independently versioned `tree-sitter-mermaid` release provides:
+| Consumer | Package or artifact | Provides |
+| --- | --- | --- |
+| Node.js | [`@mermanjs/tree-sitter-mermaid`] | Native Node binding, TypeScript declarations, queries, and language WASM |
+| Browser or Worker | [`@mermanjs/tree-sitter-mermaid`] + [`web-tree-sitter`] | Language WASM and portable queries for the generic browser runtime |
+| Rust | [`tree-sitter-mermaid`] | `LANGUAGE`, `NODE_TYPES`, and the portable queries |
+| C/C++ and editors | [GitHub Release] or repository source | Generated C parser/scanner, public header, Make, CMake, and pkg-config metadata |
 
-- a Rust crate exposing `LANGUAGE`, `NODE_TYPES`, and the canonical portable queries;
-- an npm package with native Node bindings, TypeScript declarations, source-build fallback, and
-  release-built Node prebuilds;
-- `tree-sitter-mermaid.wasm` at the npm and GitHub release root for `web-tree-sitter` consumers;
-- generated C sources, a public header, Make and CMake install surfaces, and pkg-config metadata;
-- canonical portable queries plus pre-1.0 query assets for Neovim, Helix, and Zed.
-
-The language is generated explicitly for Tree-sitter ABI 15 with Tree-sitter CLI 0.26.12. The
-selected syntax baseline is Mermaid 11.16.1 with ZenUML Core 3.50.1.
+The grammar has its own version line, independent of Merman. Its npm and Cargo artifacts share that
+grammar version, but their registry names differ: the npm package is scoped under `@mermanjs`, while
+the Rust crate and C library retain the standard `tree-sitter-mermaid` name.
 
 ## Node.js
 
 ```console
-npm install tree-sitter tree-sitter-mermaid
+npm install tree-sitter @mermanjs/tree-sitter-mermaid
 ```
 
 ```js
 const Parser = require('tree-sitter');
-const Mermaid = require('tree-sitter-mermaid');
+const Mermaid = require('@mermanjs/tree-sitter-mermaid');
 
 const parser = new Parser();
 parser.setLanguage(Mermaid);
+
 const tree = parser.parse('flowchart TD\nA --> B\n');
+console.log(tree.rootNode.toString());
 ```
 
-The `tree-sitter` peer dependency is optional so browser-only consumers can install the grammar
-asset without pulling in the native Node runtime.
+The `tree-sitter` peer dependency is optional so a browser-only install does not pull in the native
+Node runtime. Node applications should use the native binding rather than the browser WASM.
 
-## Browser and workers
+Node ESM consumers use default imports for the CommonJS native bindings:
 
-Use the external `web-tree-sitter` runtime and the exported language WASM. The grammar package does
-not wrap runtime initialization, worker policy, or bundler URL resolution in a second SDK. Copy the
-exported asset to a public URL, or let the application's bundler resolve the package export.
+```js
+import Parser from 'tree-sitter';
+import Mermaid from '@mermanjs/tree-sitter-mermaid';
+```
+
+## Browser and Workers
+
+```console
+npm install web-tree-sitter @mermanjs/tree-sitter-mermaid
+```
+
+The package exports `@mermanjs/tree-sitter-mermaid/tree-sitter-mermaid.wasm`. Copy that asset to a
+public URL with your bundler, then load it with the generic `web-tree-sitter` runtime:
 
 ```js
 import { Language, Parser } from 'web-tree-sitter';
 
 await Parser.init();
-const language = await Language.load(
-  '/assets/tree-sitter-mermaid.wasm',
-);
+const language = await Language.load('/assets/tree-sitter-mermaid.wasm');
+
 const parser = new Parser();
 parser.setLanguage(language);
+const tree = parser.parse('sequenceDiagram\nAlice->>Bob: Hello\n');
 ```
 
-Merman's Playground loads this WASM and the canonical portable highlight query in a dedicated
-syntax worker. Strict diagnostics, completion, navigation, and rename still come from Merman's
-separate semantic worker; browser consumers can adopt the same split without a grammar-specific
-JavaScript SDK.
+After the npm release is published, a no-build browser prototype can pin the exact grammar version
+on jsDelivr:
 
-The package's Node API uses the native binding shown above. The repository's Node-side WASM smoke
-runs with V8's `--liftoff-only` flag because Node 24 can exhaust its optimizing-compiler memory on
-this large generated lexer; the browser smoke runs the published WASM without that flag in
-Chromium. Node applications should use the native binding rather than treating the browser asset
-as a second server-side API.
+```js
+const language = await Language.load(
+  'https://cdn.jsdelivr.net/npm/@mermanjs/tree-sitter-mermaid@0.1.0/tree-sitter-mermaid.wasm',
+);
+```
+
+The grammar package deliberately does not wrap runtime initialization, Worker lifecycle, or bundler
+URL resolution in another JavaScript SDK. Merman's Playground follows the same boundary: a syntax
+Worker runs this WASM and the portable highlight query, while a separate semantic Worker owns
+diagnostics, completion, navigation, and rename.
 
 ## Rust
+
+```console
+cargo add tree-sitter tree-sitter-mermaid
+```
 
 ```rust
 let language: tree_sitter::Language = tree_sitter_mermaid::LANGUAGE.into();
 let mut parser = tree_sitter::Parser::new();
 parser.set_language(&language)?;
-let tree = parser.parse("flowchart TD\nA --> B\n", None).unwrap();
+
+let tree = parser
+    .parse("flowchart TD\nA --> B\n", None)
+    .expect("Tree-sitter returned no tree");
+assert!(!tree.root_node().has_error());
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
-The crate intentionally does not depend on the Tree-sitter runtime. Applications select a
-compatible `tree-sitter` runtime and use the exported `tree-sitter-language::LanguageFn`.
+The crate exports a `tree-sitter-language::LanguageFn` and does not force a Tree-sitter runtime
+version on applications.
 
-## C
+## C and C++
 
 The committed parser and scanner build without the grammar generator:
 
@@ -91,32 +115,58 @@ cmake --build build
 cmake --install build --prefix /usr/local
 ```
 
-Unix-like consumers may alternatively use `make` and `make install`. Regeneration goes through the
-pinned npm `generate` script and is never part of the default C source build.
+Unix-like consumers may alternatively use `make` and `make install`.
 
-## Queries and editors
+```c
+#include <tree_sitter/api.h>
+#include <tree_sitter/tree-sitter-mermaid.h>
 
-`tree-sitter.json` points to the stable portable query set under `queries/portable/`. The
-`queries/neovim`, `queries/helix`, and `queries/zed` directories are adoption assets rather than a
-promise that npm or crates.io publication automatically updates those editors. Editor integrations
-must pin a released repository revision and its `distribution/tree-sitter-mermaid` subdirectory.
+int main(void) {
+  TSParser *parser = ts_parser_new();
+  ts_parser_set_language(parser, tree_sitter_mermaid());
+  ts_parser_delete(parser);
+  return 0;
+}
+```
 
-The portable highlight query is the package's canonical base-highlighting contract. Its package
-tests keep a compact non-header capture-class expectation for all 35 public families, exact spans
-for boundary-sensitive syntax, bounded frontmatter and directives, recovery of later siblings, and
-incremental-query equivalence with a fresh parse. These checks intentionally stop short of an exact
-capture forest or a per-editor matrix.
+## Compatibility
+
+| Contract | Version |
+| --- | --- |
+| Mermaid syntax baseline | 11.16.1 |
+| ZenUML Core syntax baseline | 3.50.1 |
+| Tree-sitter language ABI | 15 |
+| Tested Rust and Web runtime | 0.26.12 |
+| Native Node runtime contract | 0.25.x |
+
+Before 1.0, a minor release may change named nodes, fields, canonical captures, the language ABI, or
+the selected Mermaid baseline. Pin a compatible minor version for application integrations and an
+immutable release commit for editor integrations.
+
+## Queries and Editors
+
+`tree-sitter.json` selects the canonical portable queries under `queries/portable/`:
+
+- `highlights.scm` for base syntax highlighting;
+- `injections.scm` for embedded languages;
+- `locals.scm` for syntax-local scopes; and
+- `tags.scm` for syntax-level symbols.
+
+The `queries/neovim`, `queries/helix`, and `queries/zed` directories are pre-1.0 adoption assets.
+Those editors own their final query copies and release cadence, so publishing this package does not
+update an editor automatically. Downstream integrations should pin a released Merman commit and use
+`distribution/tree-sitter-mermaid` as the grammar subdirectory.
 
 ## Development
 
-Install the pinned package-local toolchain first:
+From the Merman repository root, install the pinned package-local toolchain:
 
 ```console
 npm ci --ignore-scripts --prefix distribution/tree-sitter-mermaid
 npm rebuild tree-sitter-cli --prefix distribution/tree-sitter-mermaid
 ```
 
-The normal checks are intentionally small:
+Run the ordinary grammar and binding checks:
 
 ```console
 npm run check:generated --prefix distribution/tree-sitter-mermaid
@@ -126,24 +176,27 @@ npm run test:node --prefix distribution/tree-sitter-mermaid
 npm run test:c --prefix distribution/tree-sitter-mermaid
 ```
 
-WASM freshness is a separate, slower lane:
+Language-WASM freshness and execution are separate, slower checks:
 
 ```console
 npm run check:wasm --prefix distribution/tree-sitter-mermaid
 npm run test:wasm --prefix distribution/tree-sitter-mermaid
 ```
 
-The standard Tree-sitter corpus owns CST and recovery expectations. One Rust integration test
-projects Merman's strict-valid fixture corpus into Tree-sitter and checks family root selection and
-error-free structure. Focused incremental/scanner tests cover the stateful mechanics. The package
-does not maintain a second semantic test engine, support-tier lattice, receipt graph, or duplicated
-capture forest.
+See the [development guide] and [release guide] for grammar ownership, generation, testing, and
+publication details.
 
-See `docs/development/TREE_SITTER_MERMAID.md` and `docs/release/TREE_SITTER_MERMAID.md` in the
-Merman repository for maintenance and release procedures.
-
-## License and provenance
+## License and Provenance
 
 The package is MIT licensed. Source-derived syntax and template attributions are recorded in
 `metadata/provenance.json`, `metadata/derivations.json`, `THIRD_PARTY_NOTICES.md`, and
 `THIRD_PARTY_LICENSES/`.
+
+[Tree-sitter]: https://tree-sitter.github.io/tree-sitter/
+[`@mermanjs/web`]: https://www.npmjs.com/package/@mermanjs/web
+[`@mermanjs/tree-sitter-mermaid`]: https://www.npmjs.com/package/@mermanjs/tree-sitter-mermaid
+[`web-tree-sitter`]: https://www.npmjs.com/package/web-tree-sitter
+[`tree-sitter-mermaid`]: https://crates.io/crates/tree-sitter-mermaid
+[GitHub Release]: https://github.com/Latias94/merman/releases
+[development guide]: https://github.com/Latias94/merman/blob/main/docs/development/TREE_SITTER_MERMAID.md
+[release guide]: https://github.com/Latias94/merman/blob/main/docs/release/TREE_SITTER_MERMAID.md

--- a/distribution/tree-sitter-mermaid/package-lock.json
+++ b/distribution/tree-sitter-mermaid/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "tree-sitter-mermaid",
+  "name": "@mermanjs/tree-sitter-mermaid",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tree-sitter-mermaid",
+      "name": "@mermanjs/tree-sitter-mermaid",
       "version": "0.1.0",
       "hasInstallScript": true,
       "license": "MIT",

--- a/distribution/tree-sitter-mermaid/package.json
+++ b/distribution/tree-sitter-mermaid/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tree-sitter-mermaid",
+  "name": "@mermanjs/tree-sitter-mermaid",
   "version": "0.1.0",
   "description": "Tolerant Tree-sitter grammar and editor queries for Mermaid",
   "license": "MIT",
@@ -9,6 +9,9 @@
     "directory": "distribution/tree-sitter-mermaid"
   },
   "homepage": "https://github.com/Latias94/merman/tree/main/distribution/tree-sitter-mermaid",
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "incremental",
     "mermaid",

--- a/distribution/tree-sitter-mermaid/scripts/package_smoke.py
+++ b/distribution/tree-sitter-mermaid/scripts/package_smoke.py
@@ -113,7 +113,7 @@ def run_npm_consumer(consumer: Path, tarball: Path, npm: str, node: str) -> None
         "version": "0.0.0",
         "dependencies": {
             "tree-sitter": NODE_RUNTIME_VERSION,
-            "tree-sitter-mermaid": tarball.resolve().as_uri(),
+            "@mermanjs/tree-sitter-mermaid": tarball.resolve().as_uri(),
             "web-tree-sitter": WEB_RUNTIME_VERSION,
         },
     }
@@ -131,9 +131,9 @@ def run_npm_consumer(consumer: Path, tarball: Path, npm: str, node: str) -> None
     native_smoke = r"""
 const assert = require('node:assert/strict');
 const Parser = require('tree-sitter');
-const Mermaid = require('tree-sitter-mermaid');
+const Mermaid = require('@mermanjs/tree-sitter-mermaid');
 
-const grammarMetadata = require('tree-sitter-mermaid/tree-sitter.json');
+const grammarMetadata = require('@mermanjs/tree-sitter-mermaid/tree-sitter.json');
 assert.equal(grammarMetadata.grammars[0].scope, 'source.mermaid');
 
 const source = 'flowchart TD\nA --> B\n';
@@ -145,6 +145,23 @@ assert.equal(tree.rootNode.namedChildren[0].type, 'flowchart_diagram');
 """
     run([node, "-e", native_smoke], cwd=consumer, env=environment)
 
+    esm_smoke = r"""
+import assert from 'node:assert/strict';
+import Parser from 'tree-sitter';
+import Mermaid from '@mermanjs/tree-sitter-mermaid';
+
+const parser = new Parser();
+parser.setLanguage(Mermaid);
+const tree = parser.parse('sequenceDiagram\nAlice->>Bob: Hello\n');
+assert.equal(tree.rootNode.hasError, false);
+assert.equal(tree.rootNode.namedChildren[0].type, 'sequence_diagram');
+"""
+    run(
+        [node, "--input-type=module", "-e", esm_smoke],
+        cwd=consumer,
+        env=environment,
+    )
+
     wasm_smoke = r"""
 const assert = require('node:assert/strict');
 const { Language, Parser } = require('web-tree-sitter');
@@ -152,7 +169,7 @@ const { Language, Parser } = require('web-tree-sitter');
 (async () => {
   await Parser.init();
   const language = await Language.load(
-    require.resolve('tree-sitter-mermaid/tree-sitter-mermaid.wasm'),
+    require.resolve('@mermanjs/tree-sitter-mermaid/tree-sitter-mermaid.wasm'),
   );
   assert.equal(language.abiVersion, 15);
   const wasmParser = new Parser();

--- a/docs/release/PACKAGE_SURFACES.md
+++ b/docs/release/PACKAGE_SURFACES.md
@@ -13,6 +13,7 @@ installation command.
 | Complete Rust rendering facade | `merman` | crates.io |
 | A command-line renderer, linter, and exporter | `merman-cli` | GitHub Release archive or crates.io |
 | A ready-to-run language server | `merman-lsp` | GitHub Release archive or crates.io |
+| Raw Mermaid CST, incremental parsing, and syntax queries | `tree-sitter-mermaid` on crates.io or `@mermanjs/tree-sitter-mermaid` on npm | Independent grammar release |
 | Checked Rustdoc fragments with no consumer renderer dependency | `merman-cli rustdoc` | GitHub Release archive or crates.io authoring tool |
 | One-step Rustdoc Mermaid attributes | `merman-rustdoc` | crates.io |
 | Browser SVG, analysis, ASCII, or editor SDK | one `@mermanjs/web*` package | npm package group |
@@ -74,6 +75,8 @@ The repository-owned delivery routes are:
 9. Platform VSIX artifacts for the independently versioned VS Code extension through
    `vscode-extension.yml`; Marketplace publishing needs an explicit release decision and credentials
    before it is enabled.
+10. Independent Cargo, scoped npm, and GitHub publication for `tree-sitter-mermaid` through
+    `release-tree-sitter-mermaid.yml` after both registry identities are bootstrapped.
 
 ## CI Gates
 

--- a/docs/release/PUBLISH_ORDER.md
+++ b/docs/release/PUBLISH_ORDER.md
@@ -50,14 +50,16 @@ release-order database.
 `roughr-merman` is versioned separately as `0.12.3`. The workflow reads each crate's own package
 version, so it can skip already-published crates while still keeping one dependency-ordered list.
 
-`tree-sitter-mermaid` starts at `0.1.0` as a separately packaged Cargo/npm language distribution.
-Use `release-tree-sitter-mermaid.yml`, not the generic independent-crate workflow. It builds native
-Node prebuilds, verifies the root language WASM, installs the exact npm/Cargo/C candidate, stages a
+`tree-sitter-mermaid` starts at `0.1.0` as a separately packaged language distribution. Its Cargo
+package is `tree-sitter-mermaid`; its npm package is `@mermanjs/tree-sitter-mermaid`. Use
+`release-tree-sitter-mermaid.yml`, not the generic independent-crate workflow. It builds native Node
+prebuilds, verifies the root language WASM, installs the exact npm/Cargo/C candidate, stages a
 grammar-subdirectory source archive and checksums, and publishes only when the matching immutable
 `tree-sitter-mermaid-vX.Y.Z` tag passes the protected crates.io, npm, and GitHub environments.
 Because `merman-lsp` now consumes this crate for syntax highlighting, the exact Cargo version must
-exist on crates.io before publishing a dependent workspace release. The npm package is independent
-of the workspace crates and supplies browser consumers with the same grammar WASM and queries.
+exist on crates.io before publishing a dependent workspace release. The scoped npm package is
+independent of the workspace crates and supplies browser consumers with the same grammar WASM and
+queries.
 
 ## Binding Release Chain
 

--- a/docs/release/RELEASING.md
+++ b/docs/release/RELEASING.md
@@ -28,6 +28,7 @@ is zero.
 | `release-android.yml` | `merman-android-<tag>.aar` | GitHub Release |
 | `release-web.yml` | admitted `@mermanjs/web` browser package group | npm |
 | `release-node.yml` | experimental `@mermanjs/node` loader and five native platform packages | npm |
+| `release-tree-sitter-mermaid.yml` | `tree-sitter-mermaid` crate, `@mermanjs/tree-sitter-mermaid`, language WASM, and source archive | crates.io, npm, and GitHub Release |
 | `vscode-extension.yml` | Platform-specific `merman-vscode` VSIX artifacts | GitHub Actions artifacts |
 | `homebrew.yml` | Nothing; Homebrew/core formula health check only | Homebrew |
 
@@ -56,7 +57,7 @@ produces a durable pending-recovery receipt instead of a blind retry.
 | crates.io incident yank | Dedicated `CARGO_REGISTRY_YANK_TOKEN` secret with yank permission in the `crates.io` environment |
 | pub.dev | Trusted Publishing / OIDC configured for `merman`, this repository, `release-flutter.yml`, and `flutter-v{{version}}` |
 | PyPI | Trusted Publishing / OIDC configured for `merman` and `release-python.yml` |
-| npm | Trusted Publishing / OIDC configured for every admitted `@mermanjs/web*` and `@mermanjs/node*` package, this repository, its owning release workflow, and the `npm` environment |
+| npm | Trusted Publishing / OIDC configured for every admitted `@mermanjs/web*` and `@mermanjs/node*` package plus `@mermanjs/tree-sitter-mermaid`, this repository, each owning release workflow, and the `npm` environment |
 | GitHub Release assets | `GITHUB_TOKEN` from Actions |
 | VS Code Marketplace | Not configured. Marketplace publishing would need `VSCE_PAT`, an explicit publish job, and VSIX provenance verification before enabling. |
 
@@ -102,6 +103,12 @@ need `--provenance`. For any package name that does not yet exist, first run the
 publication, publish only the verified missing tarball directly under the requested final tag with a
 maintainer's 2FA-protected credential, configure its trusted publisher, and rerun the workflow with
 publication enabled. Do not add the bootstrap credential to GitHub Actions.
+
+The independent syntax package is `@mermanjs/tree-sitter-mermaid`, owned by
+`release-tree-sitter-mermaid.yml`. Its first `0.1.0` publication uses the same verified-artifact,
+2FA-protected bootstrap boundary before Trusted Publishing is configured for that exact scoped
+name. The Rust crate remains `tree-sitter-mermaid`; the two registry packages share a version but
+not a registry name.
 
 The experimental native Node group is `@mermanjs/node`, `@mermanjs/node-darwin-arm64`,
 `@mermanjs/node-darwin-x64`, `@mermanjs/node-linux-x64-gnu`,

--- a/docs/release/TREE_SITTER_MERMAID.md
+++ b/docs/release/TREE_SITTER_MERMAID.md
@@ -9,6 +9,8 @@ publication without the protected release environment and maintainer credentials
 - Package root: `distribution/tree-sitter-mermaid`
 - Initial version: `0.1.0`
 - Tag form: `tree-sitter-mermaid-v0.1.0`
+- Cargo package: `tree-sitter-mermaid`
+- npm package: `@mermanjs/tree-sitter-mermaid`
 - Language symbol: `mermaid`
 - Language ABI: 15
 - Tree-sitter CLI/Rust/web runtime: 0.26.12
@@ -59,7 +61,8 @@ git diff --check
 One candidate release stages:
 
 - `tree-sitter-mermaid-0.1.0.crate` for crates.io;
-- an npm tarball containing Node source fallback and release-built N-API prebuilds;
+- an `@mermanjs/tree-sitter-mermaid` tarball containing Node source fallback and release-built
+  N-API prebuilds;
 - root `tree-sitter-mermaid.wasm` for npm and GitHub Releases;
 - a grammar-subdirectory source archive for editor and C consumers;
 - SHA-256 checksums and GitHub's build provenance for the staged files.
@@ -82,15 +85,17 @@ npm candidate.
 
 ## Publication and recovery
 
-crates.io and npm package names are both `tree-sitter-mermaid`. Publish only from the protected
-workflow and the exact release commit. If one registry job fails, re-run only failed jobs from the
-same workflow run. Each publish job reconciles an already-visible version or GitHub Release against
-the staged candidate bytes: an exact match is success, while any mismatch fails closed. Both
-registries reject overwriting an existing immutable version.
+The crates.io package is `tree-sitter-mermaid`; the npm package is
+`@mermanjs/tree-sitter-mermaid`. Publish only from the protected workflow and the exact release
+commit. If one registry job fails, re-run only failed jobs from the same workflow run. Each publish
+job reconciles an already-visible version or GitHub Release against the staged candidate bytes: an
+exact match is success, while any mismatch fails closed. Both registries reject overwriting an
+existing immutable version.
 
-The first npm publication may require a maintainer's short-lived 2FA-protected bootstrap credential
-before Trusted Publishing can be configured for the new package name. Do not store that bootstrap
-token in repository secrets. crates.io publication uses the protected crates.io environment.
+The first npm publication requires a maintainer's short-lived 2FA-protected bootstrap credential
+for `@mermanjs/tree-sitter-mermaid` before Trusted Publishing can be configured. Do not store that
+bootstrap token in repository secrets. crates.io publication uses the protected crates.io
+environment.
 
 Downstream Neovim, Helix, and Zed changes happen only after the immutable GitHub release exists.
 Those repositories pin the release commit and their own query copies; they do not consume the npm

--- a/docs/research/tree-sitter-mermaid-distribution-readme.md
+++ b/docs/research/tree-sitter-mermaid-distribution-readme.md
@@ -1,0 +1,429 @@
+# Tree-sitter Mermaid distribution and README research
+
+**Researched:** 2026-08-18
+
+**Merman baseline:** [`ebdd5164e`](https://github.com/Latias94/merman/tree/ebdd5164ee7998d3b7eb27197795b2ae873843c1)
+
+**Scope:** npm naming, Tree-sitter ecosystem compatibility, artifact identity, and a consumer-facing
+README for `distribution/tree-sitter-mermaid`. This is a research record, not a publication
+authorization.
+
+## Recommendation
+
+1. Publish the npm package as **`@mermanjs/tree-sitter-mermaid`**. Keep the repository/product name,
+   crates.io crate, C library, exported language symbol, and WASM filename as
+   **`tree-sitter-mermaid`**. A scoped npm name is a registry coordinate, not a different grammar
+   identity.
+2. Keep one independently versioned grammar release and align its Cargo, npm, and
+   `tree-sitter.json` versions. Do not align it to Merman's application version. Use the existing
+   monorepo tag form `tree-sitter-mermaid-v0.1.0`.
+3. Rewrite the README around four consumer paths: Node, browser/WASM, Rust, and editor/C adoption.
+   Retain the current semantic-parser boundary and provenance material, but move generator, CI, and
+   V8 troubleshooting details out of the first-use path.
+4. Do not add a badge wall or a repeated diagram gallery. Mature official grammars are generally
+   terse; they add detail only where a consumer needs a special invocation, a limitation, or a
+   measured property.
+
+## Evidence boundary
+
+Tree-sitter recommends publishing a stable grammar to GitHub, crates.io, npm, and PyPI, and treats
+node-shape changes as semantic-versioning events because downstream queries and tree traversal can
+break ([Tree-sitter publishing guide](https://tree-sitter.github.io/tree-sitter/creating-parsers/6-publishing.html)).
+Its `tree-sitter version` command updates every selected language binding together so a release has
+one grammar version across ecosystems
+([Tree-sitter version reference](https://tree-sitter.github.io/tree-sitter/cli/version.html)).
+The preferred repository convention is `tree-sitter-<language>`
+([Tree-sitter getting started guide](https://tree-sitter.github.io/tree-sitter/creating-parsers/1-getting-started.html)).
+Neither source requires the npm registry coordinate to be unscoped.
+
+The npm and crates.io availability observations below are date-bound. On 2026-08-18, the official
+registry endpoints returned `404` for both
+[`tree-sitter-mermaid`](https://registry.npmjs.org/tree-sitter-mermaid) and
+[`@mermanjs/tree-sitter-mermaid`](https://registry.npmjs.org/%40mermanjs%2Ftree-sitter-mermaid), and
+crates.io reported that
+[`tree-sitter-mermaid`](https://crates.io/api/v1/crates/tree-sitter-mermaid) did not exist. These
+names must be rechecked immediately before the first publication; availability is not a durable
+property.
+
+## What mature grammar READMEs do
+
+### High-value patterns
+
+| Source | What the README contains | Lesson for Mermaid |
+| --- | --- | --- |
+| [`tree-sitter-javascript`](https://github.com/tree-sitter/tree-sitter-javascript/blob/58404d8cf191d69f2674a8fd507bd5776f46cb11/README.md) | A one-line product definition, the language/specification boundary, and authoritative references. | State the Mermaid baseline and tolerance boundary once; link the source rather than reproducing its documentation. |
+| [`tree-sitter-typescript`](https://github.com/tree-sitter/tree-sitter-typescript/blob/75b3874edb2dc714fb1fd77a32013d0f8699989f/README.md) | A short special-case usage example because one package exports two grammars. | Show code only where package behavior is not obvious. Mermaid needs Node/WASM examples because it intentionally exposes two runtime surfaces. |
+| [`tree-sitter-rust`](https://github.com/tree-sitter/tree-sitter-rust/blob/77a3747266f4d621d0757825e6b11edcbf991ca5/README.md) | One measured performance characteristic and language references. | Include measurements only when reproducible and decision-relevant; do not turn CI counts into product claims. |
+| [`tree-sitter-grammars/template`](https://github.com/tree-sitter-grammars/template/blob/9c46d09d688d27c7aef31c2b32f50260de4e7906/README.md) | A description and reference section; registry badges are commented out until publication. | The default is a small README. Extra sections must serve a real consumer path. |
+| [`tree-sitter-yaml`](https://github.com/tree-sitter-grammars/tree-sitter-yaml/blob/a1c4812a73ec5e089de8e441fdea3a921e8d5079/README.md) | A concise README while its npm package is scoped as `@tree-sitter-grammars/tree-sitter-yaml` and its crate remains `tree-sitter-yaml`. | Scoped npm plus unscoped Cargo is established Tree-sitter practice, not an ecosystem incompatibility. |
+| [`tree-sitter-markdown`](https://github.com/tree-sitter-grammars/tree-sitter-markdown/blob/a0a00f817d02412bd92c54d316f164d827b57b5c/README.md) | Goals, explicit correctness limitations, editor direction, and special standalone/WASM usage. | Mermaid should prominently say that the CST is tolerant/editor-oriented and that `merman-core` remains the strict semantic authority. |
+
+Tree-sitter's own Web binding documentation recommends installing a grammar package from npm to
+obtain its language WASM and distinguishes that browser artifact from the faster native Node
+binding
+([Web Tree-sitter README](https://github.com/tree-sitter/tree-sitter/blob/master/lib/binding_web/README.md#getting-the-wasm-language-files)).
+That distinction is already architecturally correct in the current Mermaid README.
+
+### Mermaid-specific comparisons
+
+The existing Mermaid grammars provide useful examples, but none should be copied wholesale:
+
+| Source | Useful signal | Limitation for this README |
+| --- | --- | --- |
+| [`monaqa/tree-sitter-mermaid`](https://github.com/monaqa/tree-sitter-mermaid/blob/90ae195b31933ceb9d079abfa8a3ad0a36fee4cc/README.md) | Very concise description and an honest support checklist. It is also the Mermaid grammar currently listed in Tree-sitter's community parser index ([parser list](https://github.com/tree-sitter/tree-sitter/wiki/List-of-parsers)). | It does not explain package consumption and its checklist is tied to a much narrower grammar. A long copied checklist would become a second support database. |
+| [`pappasam/tree-sitter-mermaid`](https://github.com/pappasam/tree-sitter-mermaid/blob/1a11e2d8cf11afcfdb768f537c1a9bde294c24f9/README.md) | Clearly explains tolerant recovery and gives a concrete Neovim source-install path. | It is source/editor oriented and does not cover a native Node package, Rust crate, C install, or browser WASM. |
+| [`singularity-ng/singularity-parser-mermaid`](https://github.com/singularity-ng/singularity-parser-mermaid/blob/f5ac2752fbf0f74f9c836014b87e511303d2abae/README.md) | Shows the discoverability value of putting install commands near the top. | It repeats mutable coverage/test claims, includes a large badge set and diagram gallery, and declares registry publication even though the official npm and crates.io endpoints returned `404` on the research date. This is the clearest pattern to avoid. |
+
+## Scoped npm compatibility
+
+### Node `require` and `import`
+
+npm requires consumers to use the full scope for install and `require`, but otherwise treats the
+package like any other module
+([npm scope documentation](https://docs.npmjs.com/using-npm/scope.html),
+[npm package usage](https://docs.npmjs.com/using-npm-packages-in-your-projects/)). Therefore the
+public specifier becomes:
+
+```text
+@mermanjs/tree-sitter-mermaid
+```
+
+The current package is CommonJS, exports `module.exports = language`, and publishes explicit root,
+WASM, query, source, and metadata subpaths
+([`bindings/node/index.js`](../../distribution/tree-sitter-mermaid/bindings/node/index.js),
+[`package.json`](../../distribution/tree-sitter-mermaid/package.json)). Changing the npm `name`
+does not require changing the native binding or `tree_sitter_mermaid` C symbol. It does require
+changing every consumer-facing package specifier.
+
+The existing root export remains usable from both module systems:
+
+- CommonJS uses `require('@mermanjs/tree-sitter-mermaid')`.
+- Node ESM can use a default import because Node exposes a CommonJS module's `module.exports` as its
+  reliable default export
+  ([Node ESM interoperability](https://nodejs.org/api/esm.html#interoperability-with-commonjs)).
+- The current `exports` fallback is available to `import`; Node documents `default` as the generic
+  fallback condition and supports scoped package self-resolution
+  ([Node package exports](https://nodejs.org/api/packages.html#conditional-exports)).
+
+TypeScript's current declaration uses `export =`, so the lowest-assumption typed form remains
+`import Mermaid = require('@mermanjs/tree-sitter-mermaid')`. A JavaScript ESM example may use a
+default import. The README should not imply that named imports exist.
+
+The optional `tree-sitter` peer means a browser-only dependency does not pull the native Tree-sitter
+runtime, but it does not make npm installation free of native-package behavior: the current grammar
+manifest still has a `node-gyp-build` install hook and Node binding dependencies. Consumers that
+only need a remotely loaded language WASM can use an exact-version CDN URL without installing the
+grammar package. Bundled applications should install the package and treat the prebuilt/source
+native path as part of the package contract.
+
+The first scoped publication must be public. npm documents that scoped packages default to private
+visibility and require `--access public`; `publishConfig.access = "public"` makes that intent
+manifest-local
+([npm scoped public packages](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages/)).
+The maintained `tree-sitter-yaml` package uses exactly that scoped-name/public-access pattern
+([package manifest](https://github.com/tree-sitter-grammars/tree-sitter-yaml/blob/a1c4812a73ec5e089de8e441fdea3a921e8d5079/package.json)).
+
+### Browser WASM and jsDelivr
+
+jsDelivr mirrors any public npm package file using
+`/npm/package@version/file` and recommends pinning a production URL rather than using `latest`
+([jsDelivr usage documentation](https://github.com/jsdelivr/jsdelivr#usage-documentation)). Its
+public API has explicit scoped-package routes
+([jsDelivr OpenAPI specification](https://github.com/jsdelivr/data.jsdelivr.com/blob/master/src/public/v1/spec.yaml)).
+
+The existing Merman line already proves the namespace and WASM path combination:
+
+- npm publishes [`@mermanjs/web`](https://registry.npmjs.org/%40mermanjs%2Fweb/latest) as a public
+  package from the Merman repository;
+- its [jsDelivr package page](https://www.jsdelivr.com/package/npm/@mermanjs/web) accepts the scoped
+  name; and
+- its exact-version
+  [`merman_wasm_bg.wasm`](https://cdn.jsdelivr.net/npm/@mermanjs/web@0.7.0/pkg/merman_wasm_bg.wasm)
+  is served with `application/wasm` and cross-origin access.
+
+After `0.1.0` is published, the grammar asset URL should therefore be:
+
+```text
+https://cdn.jsdelivr.net/npm/@mermanjs/tree-sitter-mermaid@0.1.0/tree-sitter-mermaid.wasm
+```
+
+The scope appears literally in the URL; it must not be percent-encoded as `%40` in the CDN path.
+The README must pin an exact version. It should also show the npm-installed asset subpath for
+bundled applications so jsDelivr is an option, not a mandatory runtime dependency.
+
+### Tree-sitter and editor discovery
+
+The npm scope does not change Tree-sitter's language identity. Tree-sitter reads the grammar name,
+`source.mermaid`, file types, injection regex, and query paths from `tree-sitter.json`
+([Tree-sitter init reference](https://tree-sitter.github.io/tree-sitter/cli/init.html#structure-of-tree-sitterjson),
+[current Mermaid metadata](../../distribution/tree-sitter-mermaid/tree-sitter.json)). Syntax
+highlighting conventionally keeps queries in the grammar repository
+([Tree-sitter highlighting guide](https://tree-sitter.github.io/tree-sitter/3-syntax-highlighting.html#overview)).
+The community parser index also discovers grammars by repository URL and generated-parser metadata,
+not by requiring an unscoped npm package
+([Tree-sitter parser list](https://github.com/tree-sitter/tree-sitter/wiki/List-of-parsers)).
+
+Consequently:
+
+- Node and browser consumers use the scoped npm coordinate.
+- Rust consumers use the crates.io coordinate.
+- Neovim, Helix, Zed, and parser indexes continue to pin the Git repository, revision, subdirectory,
+  generated C parser, and their selected query profile.
+- Discoverability should come from the repository name, `tree-sitter`/`mermaid` keywords, the parser
+  index, release notes, and editor integrations. Publishing a second unscoped npm alias would add a
+  second release identity without improving those editor paths.
+
+## Artifact naming matrix
+
+Names should be consistent at the language level, but they should follow each ecosystem's namespace
+rules rather than being forced to identical strings.
+
+| Surface | Recommended identity | Reason |
+| --- | --- | --- |
+| Product and README title | `tree-sitter-mermaid` | Matches the Tree-sitter repository convention and language ecosystem search term. |
+| npm | `@mermanjs/tree-sitter-mermaid` | Reuses the established official Merman namespace and avoids a global unscoped ownership race. |
+| npm import/require | `@mermanjs/tree-sitter-mermaid` | npm requires the full scope at every package reference. |
+| npm tarball | `mermanjs-tree-sitter-mermaid-0.1.0.tgz` (npm-generated) | npm derives scoped tarball filenames; do not hand-rename registry artifacts. |
+| crates.io | `tree-sitter-mermaid` | crates.io has no npm-style organization scope and this follows grammar convention. |
+| Rust source path | `tree_sitter_mermaid` | Cargo's normal hyphen-to-underscore crate import mapping. |
+| CMake/pkg-config/library | `tree-sitter-mermaid` / `libtree-sitter-mermaid` | Matches the current generated C build surface and Tree-sitter templates. |
+| C header | `tree_sitter/tree-sitter-mermaid.h` | Matches the current public include path. |
+| C language function | `tree_sitter_mermaid()` | Stable generated language symbol; registry branding must not affect ABI. |
+| WASM asset | `tree-sitter-mermaid.wasm` | Runtime-neutral language asset and current package export. |
+| GitHub tag | `tree-sitter-mermaid-v0.1.0` | Avoids collisions with Merman releases in a monorepo; already selected by the release contract. |
+| GitHub release title | `tree-sitter-mermaid 0.1.0` | Human-readable product plus independent version. |
+| Source archive | `tree-sitter-mermaid-0.1.0.tar.gz` | Runtime-neutral C/editor source artifact. |
+
+The current C names are visible in
+[`CMakeLists.txt`](../../distribution/tree-sitter-mermaid/CMakeLists.txt),
+[`Makefile`](../../distribution/tree-sitter-mermaid/Makefile), and
+[`tree-sitter-mermaid.pc.in`](../../distribution/tree-sitter-mermaid/bindings/c/tree-sitter-mermaid.pc.in).
+The version-alignment and tag policy already live in the
+[Tree-sitter Mermaid release contract](../release/TREE_SITTER_MERMAID.md#release-identity).
+
+## Baseline README audit (`ebdd5164e`)
+
+### Keep
+
+The baseline
+[`README.md`](https://github.com/Latias94/merman/blob/ebdd5164ee7998d3b7eb27197795b2ae873843c1/distribution/tree-sitter-mermaid/README.md)
+already has several important strengths:
+
+- It immediately distinguishes tolerant CST/editor ownership from Merman's strict semantics, IR,
+  diagnostics, and rendering. This is the most important architectural expectation.
+- It documents native Node and browser WASM as different consumption paths instead of inventing a
+  grammar-specific JavaScript SDK.
+- It shows Rust and C entry points and explains why the crate exposes `LanguageFn` rather than
+  owning the Tree-sitter runtime.
+- It identifies the Mermaid, ZenUML, Tree-sitter CLI, and ABI baselines.
+- It explains portable versus editor-specific queries and ends with license/provenance links.
+
+### Change before publication
+
+| Priority | Gap | Recommended change |
+| --- | --- | --- |
+| P0 | Node install and `require` use the unscoped `tree-sitter-mermaid` name. | Replace every npm package reference with `@mermanjs/tree-sitter-mermaid`; keep Cargo/C names unscoped. |
+| P0 | The browser example uses a hypothetical `/assets/...` URL, so it does not prove either package export or CDN consumption. | Show one exact-version jsDelivr URL and one installed-package asset subpath. State that the CDN URL exists only after npm publication. |
+| P0 | No clean ESM example is shown. | Add a short Node ESM default-import example and retain CommonJS as the canonical native-binding example. Do not show named imports from the grammar package. |
+| P0 | The scoped package's public visibility is not visible to readers. | State that it is a public npm package; implementation should set `publishConfig.access` rather than relying only on workflow flags. |
+| P0 | “Optional peer” can be read as “browser installation never runs native package setup,” although the package has a `node-gyp-build` install hook. | Say narrowly that the optional peer avoids pulling the native Tree-sitter runtime. Recommend exact-version CDN loading to browser-only consumers who do not need an npm install. |
+| P1 | The distribution inventory precedes first use and mixes product contract with release implementation. | Replace it with a compact “Choose a runtime” table, then put installable examples first. |
+| P1 | The Node 24 `--liftoff-only` CI explanation occupies the browser consumer path. | Move it to a short troubleshooting/development note. The consumer rule is simply: native Node binding for Node, language WASM for browsers/workers. |
+| P1 | The Rust snippet omits the two dependencies needed by a clean consumer. | Include `cargo add tree-sitter@0.26.12 tree-sitter-mermaid@0.1.0` or an equivalent `Cargo.toml` fragment. |
+| P1 | Development commands assume the Merman repository root but the same README is rendered by npm/crates.io. | Label repository-root commands explicitly and link detailed maintenance/release docs instead of presenting them as package-user setup. |
+| P1 | “All 35 public families” is a high-value claim but its meaning is not adjacent to the claim. | Define it as structured, tolerant CST support at the pinned Mermaid baseline; explicitly state that it is not strict semantic validation or Mermaid.js rendering equivalence. Link the conformance/migration evidence rather than duplicating a 35-row checklist. |
+| P2 | Query test-policy details are longer than most consumers need. | Keep the canonical portable-query contract and editor-profile status; move detailed test philosophy to development docs. |
+
+No badge is recommended for the initial rewrite. In a monorepo, a repository-wide CI badge does not
+precisely state grammar health, and registry/version badges should not exist before the package
+exists. Direct registry links in the installation table are enough after publication.
+
+## Recommended README outline
+
+The target should be a compact consumer document, approximately 150-220 lines, with this order:
+
+1. **Title and two-sentence contract**
+   - “Tolerant, incremental Tree-sitter grammar for Mermaid.”
+   - Structured support baseline and the CST-versus-`merman-core` semantic boundary.
+2. **Choose a runtime**
+   - A four-row table for Node, browser/worker, Rust, and C/editor source.
+   - Package coordinate, runtime dependency, and artifact used by each row.
+3. **Node.js**
+   - Scoped install command.
+   - CommonJS parse example with `source_file`, no-error, and family-root assertions.
+   - One short ESM default-import variant.
+4. **Browser and workers**
+   - External `web-tree-sitter@0.26.12` ownership.
+   - Exact-version jsDelivr language-WASM example.
+   - Installed asset export and portable highlight-query export.
+   - One sentence about Merman Playground's syntax/semantic worker split.
+5. **Rust**
+   - Dependency fragment plus `LANGUAGE` example.
+   - List `NODE_TYPES` and four portable query constants without implementation narrative.
+6. **C and editors**
+   - CMake install commands.
+   - `tree-sitter.json`, portable query path, and links to Neovim/Helix/Zed adoption notes.
+   - Do not imply that publishing to npm automatically updates editors.
+7. **Compatibility and scope**
+   - Grammar version, ABI 15, Tree-sitter CLI/Rust/web runtime 0.26.12, native Node runtime 0.25.x,
+     Mermaid 11.16.1, and ZenUML Core 3.50.1.
+   - Tolerant syntax support is not strict Mermaid validity or rendering parity.
+8. **Development**
+   - The smallest normal check set, explicitly marked “from the Merman repository root.”
+   - Links to maintenance, migration, and release documents.
+9. **License and provenance**
+   - Retain the current exact provenance file links.
+
+## Candidate installation examples
+
+These examples should be copied into package smoke tests so documentation and the packed artifact
+cannot drift.
+
+### Native Node, CommonJS
+
+```console
+npm install tree-sitter @mermanjs/tree-sitter-mermaid
+```
+
+```js
+const Parser = require('tree-sitter');
+const Mermaid = require('@mermanjs/tree-sitter-mermaid');
+
+const parser = new Parser();
+parser.setLanguage(Mermaid);
+
+const tree = parser.parse('flowchart TD\nA --> B\n');
+if (tree.rootNode.type !== 'source_file' || tree.rootNode.hasError) {
+  throw new Error(tree.rootNode.toString());
+}
+console.log(tree.rootNode.namedChildren[0].type); // flowchart_diagram
+```
+
+This matches the assertions already used by the current
+[`binding_test.js`](../../distribution/tree-sitter-mermaid/bindings/node/binding_test.js).
+
+### Native Node, ESM
+
+```js
+import Parser from 'tree-sitter';
+import Mermaid from '@mermanjs/tree-sitter-mermaid';
+
+const parser = new Parser();
+parser.setLanguage(Mermaid);
+const tree = parser.parse('sequenceDiagram\nAlice->>Bob: Hello\n');
+```
+
+This is JavaScript ESM interoperability with the CommonJS binding. TypeScript projects that do not
+enable synthetic default imports should use `import Mermaid = require(...)`, matching the package's
+`export =` declaration.
+
+### Browser or worker
+
+```console
+npm install web-tree-sitter
+```
+
+```js
+import { Language, Parser } from 'web-tree-sitter';
+
+await Parser.init();
+const language = await Language.load(
+  'https://cdn.jsdelivr.net/npm/@mermanjs/tree-sitter-mermaid@0.1.0/tree-sitter-mermaid.wasm',
+);
+
+const parser = new Parser();
+parser.setLanguage(language);
+const tree = parser.parse('flowchart TD\nA --> B\n');
+
+console.log(language.abiVersion); // 15
+tree.delete();
+parser.delete();
+```
+
+Bundled applications should resolve or copy the exported package asset
+`@mermanjs/tree-sitter-mermaid/tree-sitter-mermaid.wasm` instead of depending on the CDN. The
+portable highlight query is exported at
+`@mermanjs/tree-sitter-mermaid/queries/portable/highlights.scm`.
+
+### Rust
+
+```console
+cargo add tree-sitter@0.26.12 tree-sitter-mermaid@0.1.0
+```
+
+```rust
+let language: tree_sitter::Language = tree_sitter_mermaid::LANGUAGE.into();
+let mut parser = tree_sitter::Parser::new();
+parser.set_language(&language)?;
+
+let tree = parser
+    .parse("flowchart TD\nA --> B\n", None)
+    .expect("Tree-sitter always returns a tree for a configured language");
+assert!(!tree.root_node().has_error());
+
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+This matches the package's existing `LanguageFn` surface
+([Rust binding](../../distribution/tree-sitter-mermaid/bindings/rust/lib.rs)).
+
+### C source install
+
+```console
+cmake -S . -B build -DBUILD_SHARED_LIBS=OFF
+cmake --build build
+cmake --install build --prefix /usr/local
+pkg-config --cflags --libs tree-sitter-mermaid
+```
+
+The README should say that these commands run from an extracted grammar source/npm package root.
+The committed parser and scanner do not require the Tree-sitter generator for this build.
+
+## Publication-readiness actions
+
+The README rewrite and npm rename should be accepted only when all of these are true:
+
+1. `package.json`, lockfile identity, release scripts/workflows, package smoke, documentation, and
+   legal projections agree on `@mermanjs/tree-sitter-mermaid` for npm.
+2. Cargo, C, language symbol, WASM filename, repository directory, and GitHub tag retain the
+   identities in the naming matrix.
+3. `npm pack` installed into a clean CommonJS consumer passes the documented native example.
+4. A clean Node ESM consumer passes the documented default-import example.
+5. The packed WASM and portable highlight query resolve through the declared npm `exports`.
+6. After the first protected npm publication, the exact-version jsDelivr WASM URL returns the
+   expected bytes, `application/wasm`, and a parseable ABI-15 language.
+7. The Tree-sitter community parser-list and editor migration work happens from the immutable GitHub
+   release revision; it does not wait for or infer an unscoped npm alias.
+
+## Source ledger
+
+All sources were accessed on 2026-08-18.
+
+- [Tree-sitter: getting started](https://tree-sitter.github.io/tree-sitter/creating-parsers/1-getting-started.html)
+- [Tree-sitter: publishing grammars](https://tree-sitter.github.io/tree-sitter/creating-parsers/6-publishing.html)
+- [Tree-sitter: synchronized binding versions](https://tree-sitter.github.io/tree-sitter/cli/version.html)
+- [Tree-sitter: `tree-sitter init` and metadata](https://tree-sitter.github.io/tree-sitter/cli/init.html)
+- [Tree-sitter: syntax highlighting](https://tree-sitter.github.io/tree-sitter/3-syntax-highlighting.html)
+- [Web Tree-sitter README](https://github.com/tree-sitter/tree-sitter/blob/master/lib/binding_web/README.md)
+- [Tree-sitter community parser list](https://github.com/tree-sitter/tree-sitter/wiki/List-of-parsers)
+- [`tree-sitter-javascript` README and package](https://github.com/tree-sitter/tree-sitter-javascript/tree/58404d8cf191d69f2674a8fd507bd5776f46cb11)
+- [`tree-sitter-typescript` README and package](https://github.com/tree-sitter/tree-sitter-typescript/tree/75b3874edb2dc714fb1fd77a32013d0f8699989f)
+- [`tree-sitter-rust` README and package](https://github.com/tree-sitter/tree-sitter-rust/tree/77a3747266f4d621d0757825e6b11edcbf991ca5)
+- [`tree-sitter-grammars/template`](https://github.com/tree-sitter-grammars/template/tree/9c46d09d688d27c7aef31c2b32f50260de4e7906)
+- [`tree-sitter-yaml`](https://github.com/tree-sitter-grammars/tree-sitter-yaml/tree/a1c4812a73ec5e089de8e441fdea3a921e8d5079)
+- [`tree-sitter-markdown`](https://github.com/tree-sitter-grammars/tree-sitter-markdown/tree/a0a00f817d02412bd92c54d316f164d827b57b5c)
+- [`monaqa/tree-sitter-mermaid`](https://github.com/monaqa/tree-sitter-mermaid/tree/90ae195b31933ceb9d079abfa8a3ad0a36fee4cc)
+- [`pappasam/tree-sitter-mermaid`](https://github.com/pappasam/tree-sitter-mermaid/tree/1a11e2d8cf11afcfdb768f537c1a9bde294c24f9)
+- [`singularity-ng/singularity-parser-mermaid`](https://github.com/singularity-ng/singularity-parser-mermaid/tree/f5ac2752fbf0f74f9c836014b87e511303d2abae)
+- [npm: scopes](https://docs.npmjs.com/using-npm/scope.html)
+- [npm: using scoped packages](https://docs.npmjs.com/using-npm-packages-in-your-projects/)
+- [npm: publishing public scoped packages](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages/)
+- [Node.js: package exports](https://nodejs.org/api/packages.html#package-entry-points)
+- [Node.js: CommonJS/ESM interoperability](https://nodejs.org/api/esm.html#interoperability-with-commonjs)
+- [jsDelivr npm usage](https://github.com/jsdelivr/jsdelivr#usage-documentation)
+- [jsDelivr public API specification](https://github.com/jsdelivr/data.jsdelivr.com/blob/master/src/public/v1/spec.yaml)
+- [Current Merman grammar README](../../distribution/tree-sitter-mermaid/README.md)
+- [Current Merman grammar npm manifest](../../distribution/tree-sitter-mermaid/package.json)
+- [Current Merman grammar Cargo manifest](../../distribution/tree-sitter-mermaid/Cargo.toml)
+- [Current Merman grammar metadata](../../distribution/tree-sitter-mermaid/tree-sitter.json)
+- [Current Merman grammar release contract](../release/TREE_SITTER_MERMAID.md)

--- a/scripts/test_release_workflow_security.py
+++ b/scripts/test_release_workflow_security.py
@@ -149,6 +149,7 @@ class WorkflowSecurityBoundaries(unittest.TestCase):
         self.assertIn("main is build-only", workflow)
         self.assertIn("publishing requires source_ref to be the matching immutable tag", workflow)
         self.assertIn("distribution/tree-sitter-mermaid", workflow)
+        self.assertIn('npm_manifest["name"] != "@mermanjs/tree-sitter-mermaid"', verify)
         self.assertIn("npm run prebuild", prebuild)
         self.assertIn("PREBUILDS_ONLY=1 npm run test:node", prebuild)
         self.assertIn("TREE_SITTER_MERMAID_REQUIRE_PREBUILDS=1", assemble)
@@ -175,7 +176,10 @@ class WorkflowSecurityBoundaries(unittest.TestCase):
         )
         self.assertIn("npm publish", publish_npm)
         self.assertIn("--provenance", publish_npm)
-        self.assertIn('npm view "tree-sitter-mermaid@$VERSION" dist.tarball', publish_npm)
+        self.assertIn(
+            'npm view "@mermanjs/tree-sitter-mermaid@$VERSION" dist.tarball',
+            publish_npm,
+        )
         self.assertIn("uses: actions/attest@v4.2.2", attest)
         self.assertIn("attestations: write", attest)
         self.assertIn("gh release create", publish_github)


### PR DESCRIPTION
## Summary

The independent Mermaid grammar can now publish under the existing `@mermanjs` npm namespace while retaining the standard `tree-sitter-mermaid` identity for Cargo, C, WASM, and release tags. Consumer documentation and release checks now describe and enforce the same package contract.

## What changed

- Align the npm manifest, package smoke, release workflow, changelog, and operator documentation on `@mermanjs/tree-sitter-mermaid`.
- Rewrite the package README around Node.js, browser Worker, Rust, C/C++, and editor adoption workflows, including the boundary with `@mermanjs/web`.
- Document the independent `0.1.0` release line and the one-time npm bootstrap required before Trusted Publishing can own the new scoped package.
- Apply Dependabot's `taiki-e/install-action` 2.86.1 update across all affected workflows.

## Verification

- [x] `cargo fmt --all -- --check` is not applicable because no Rust sources or Cargo manifests changed
- [x] Relevant tests ran: 51 workflow contract tests, `actionlint`, `zizmor --min-severity high .`, scoped npm CJS/ESM/WASM/Rust/C package smoke, and `npm pack --dry-run --json`
- [x] Benchmark or report update is not applicable because grammar and runtime behavior are unchanged

## Performance / parity notes

- Benchmark or report: Not applicable.
- Parity impact: None. The grammar, generated parser, queries, and Mermaid baseline are unchanged.
- Rollback risk: Low before first publication. Registry versions become immutable after `0.1.0` is published.

## Follow-ups

- Run the Tree-sitter build-only release workflow from the merged commit, inspect the candidate artifacts, then tag and publish `0.1.0` under explicit release authorization.
- Related: #75
