### PR TITLE
fix(tree-sitter): compile Node binding with MSVC C11

### DIFF
--- a/.github/workflows/tree-sitter-mermaid.yml
+++ b/.github/workflows/tree-sitter-mermaid.yml
@@ -71,6 +71,9 @@ jobs:
           npm run check:generated --prefix distribution/tree-sitter-mermaid
           npm run test:generation-script --prefix distribution/tree-sitter-mermaid
 
+      - name: Verify Windows native binding
+        run: npm run build:node --prefix distribution/tree-sitter-mermaid
+
   wasm:
     runs-on: ubuntu-24.04
     timeout-minutes: 30

--- a/distribution/tree-sitter-mermaid/binding.gyp
+++ b/distribution/tree-sitter-mermaid/binding.gyp
@@ -19,10 +19,14 @@
             "-std=c11"
           ]
         }, { # OS == "win"
-          "cflags_c": [
-            "/std:c11",
-            "/utf-8"
-          ]
+          "msvs_settings": {
+            "VCCLCompilerTool": {
+              "LanguageStandard_C": "stdc11",
+              "AdditionalOptions": [
+                "/utf-8"
+              ]
+            }
+          }
         }]
       ]
     }

--- a/distribution/tree-sitter-mermaid/binding.gyp
+++ b/distribution/tree-sitter-mermaid/binding.gyp
@@ -31,9 +31,10 @@
         }, { # OS == "win"
           "msvs_settings": {
             "VCCLCompilerTool": {
-              # Node's common.gypi adds C++20 to every MSVC target. Remove it
-              # from this C-only library before selecting the C11 standard.
+              # Node's common.gypi adds a C++ standard to every MSVC target.
+              # Remove it here before selecting C11 for this C-only library.
               "AdditionalOptions!": [
+                "-std:c++17",
                 "-std:c++20"
               ],
               "LanguageStandard_C": "stdc11",

--- a/distribution/tree-sitter-mermaid/binding.gyp
+++ b/distribution/tree-sitter-mermaid/binding.gyp
@@ -3,13 +3,23 @@
     {
       "target_name": "tree_sitter_mermaid_binding",
       "dependencies": [
-        "<!(node -p \"require('node-addon-api').targets\"):node_addon_api_except"
+        "<!(node -p \"require('node-addon-api').targets\"):node_addon_api_except",
+        "tree_sitter_mermaid_parser"
       ],
       "include_dirs": [
         "src"
       ],
       "sources": [
-        "bindings/node/binding.cc",
+        "bindings/node/binding.cc"
+      ]
+    },
+    {
+      "target_name": "tree_sitter_mermaid_parser",
+      "type": "static_library",
+      "include_dirs": [
+        "src"
+      ],
+      "sources": [
         "src/parser.c",
         "src/scanner.c"
       ],
@@ -21,11 +31,22 @@
         }, { # OS == "win"
           "msvs_settings": {
             "VCCLCompilerTool": {
+              # Node's common.gypi adds C++20 to every MSVC target. Remove it
+              # from this C-only library before selecting the C11 standard.
+              "AdditionalOptions!": [
+                "-std:c++20"
+              ],
               "LanguageStandard_C": "stdc11",
               "AdditionalOptions": [
                 "/utf-8"
               ]
             }
+          }
+        }],
+        ["OS=='mac'", {
+          "xcode_settings": {
+            "GCC_C_LANGUAGE_STANDARD": "c11",
+            "MACOSX_DEPLOYMENT_TARGET": "10.7"
           }
         }]
       ]

--- a/distribution/tree-sitter-mermaid/binding.gyp
+++ b/distribution/tree-sitter-mermaid/binding.gyp
@@ -13,8 +13,17 @@
         "src/parser.c",
         "src/scanner.c"
       ],
-      "cflags_c": [
-        "-std=c11"
+      "conditions": [
+        ["OS!='win'", {
+          "cflags_c": [
+            "-std=c11"
+          ]
+        }, { # OS == "win"
+          "cflags_c": [
+            "/std:c11",
+            "/utf-8"
+          ]
+        }]
       ]
     }
   ]


### PR DESCRIPTION
## Summary

Windows native Tree-sitter builds now compile the generated C grammar and the C++ Node adapter as separate targets, so each language receives the standard required by its compiler.

## What changed
- Build `parser.c` and `scanner.c` as a C-only static library, then link it into the existing `tree_sitter_mermaid_binding.node` target.
- Keep `-std=c11` on Unix, select C11 through GYP's macOS setting, and use `VCCLCompilerTool.LanguageStandard_C=stdc11` plus `/utf-8` on MSBuild.
- Remove Node 20/22/24's inherited C++17/C++20 option from the C-only target while leaving the C++ N-API target unchanged.
- Compile the Windows Node binding in the reusable Tree-sitter workflow, instead of checking generation only.

## Verification
- [ ] `cargo fmt --all --check` (not run; no Rust files changed)
- [x] macOS `npm run build:node` and `npm run test:node`
- [x] `npm run test:generation-script` and `npm run check:generated`
- [x] Local build emits separate C static-library and C++ addon targets; Node binding smoke passes
- [x] `actionlint` and `zizmor --min-severity high`
- [x] Windows Server 2025 / Visual Studio 2026 `grammar-owner / generation-windows` passes, including the native binding build

## Performance / parity notes
- Benchmark or report: Not applicable.
- Parity impact: No grammar, parser, or runtime behavior changes.
- Rollback risk: Low; this only selects the compiler mode required by the existing C11 scanner assertions.

## Follow-ups
- Re-run the build-only release preflight after this PR merges.
