### PR TITLE
perf(playground): reduce startup and retained browser work

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -43,7 +43,7 @@
     "test:browser:smoke:non-chromium:built": "npm --prefix tests run test:smoke:non-chromium",
     "test:browser:typecheck": "npm --prefix tests run typecheck",
     "test:mermaid-config": "node --test --experimental-strip-types src/lib/mermaid-config.test.ts",
-    "test:runtime": "node --test --experimental-strip-types src/runtime/merman.test.ts src/runtime/render-viewport.test.ts src/runtime/render-coordinator.test.ts src/runtime/render-artifact.test.ts src/runtime/error-projection.test.ts src/runtime/artifact-actions.test.ts src/runtime/presentation-status.test.ts src/runtime/startup-boundary.test.ts src/store/index.test.ts src/lib/share.test.ts src/lib/share-view.test.ts",
+    "test:runtime": "node --test --experimental-strip-types src/runtime/merman.test.ts src/runtime/render-viewport.test.ts src/runtime/render-coordinator.test.ts src/runtime/render-artifact.test.ts src/runtime/error-projection.test.ts src/runtime/artifact-actions.test.ts src/runtime/presentation-status.test.ts src/runtime/startup-boundary.test.ts src/store/index.test.ts src/lib/share.test.ts src/lib/share-view.test.ts src/lib/svg-connected-bounds.test.ts",
     "test:mermaid-requirements": "node --test --experimental-strip-types src/runtime/mermaid-requirements.test.ts src/runtime/external-module-registrar.test.ts",
     "test:realm": "node --test --experimental-strip-types src/runtime/realm/*.test.ts src/runtime/mermaid-realm-controller.test.ts",
     "lint": "eslint .",

--- a/playground/package.json
+++ b/playground/package.json
@@ -43,7 +43,7 @@
     "test:browser:smoke:non-chromium:built": "npm --prefix tests run test:smoke:non-chromium",
     "test:browser:typecheck": "npm --prefix tests run typecheck",
     "test:mermaid-config": "node --test --experimental-strip-types src/lib/mermaid-config.test.ts",
-    "test:runtime": "node --test --experimental-strip-types src/runtime/merman.test.ts src/runtime/render-viewport.test.ts src/runtime/render-coordinator.test.ts src/runtime/render-artifact.test.ts src/runtime/error-projection.test.ts src/runtime/artifact-actions.test.ts src/runtime/presentation-status.test.ts src/store/index.test.ts src/lib/share.test.ts src/lib/share-view.test.ts",
+    "test:runtime": "node --test --experimental-strip-types src/runtime/merman.test.ts src/runtime/render-viewport.test.ts src/runtime/render-coordinator.test.ts src/runtime/render-artifact.test.ts src/runtime/error-projection.test.ts src/runtime/artifact-actions.test.ts src/runtime/presentation-status.test.ts src/runtime/startup-boundary.test.ts src/store/index.test.ts src/lib/share.test.ts src/lib/share-view.test.ts",
     "test:mermaid-requirements": "node --test --experimental-strip-types src/runtime/mermaid-requirements.test.ts src/runtime/external-module-registrar.test.ts",
     "test:realm": "node --test --experimental-strip-types src/runtime/realm/*.test.ts src/runtime/mermaid-realm-controller.test.ts",
     "lint": "eslint .",

--- a/playground/scripts/playground-build-policy.d.mts
+++ b/playground/scripts/playground-build-policy.d.mts
@@ -4,4 +4,5 @@ export const OPTIONAL_FEATURE_SOURCES: Readonly<{
   editor: "src/components/EditorFeature.tsx";
   examples: "src/components/ExampleGallery.tsx";
   viewer: "src/components/ReadOnlyEditorFeature.tsx";
+  viewerJson: "src/components/ReadOnlyJsonEditorFeature.tsx";
 }>;

--- a/playground/scripts/playground-build-policy.d.mts
+++ b/playground/scripts/playground-build-policy.d.mts
@@ -3,4 +3,5 @@ export const OPTIONAL_FEATURE_SOURCES: Readonly<{
   config: "src/components/ConfigEditorFeature.tsx";
   editor: "src/components/EditorFeature.tsx";
   examples: "src/components/ExampleGallery.tsx";
+  viewer: "src/components/ReadOnlyEditorFeature.tsx";
 }>;

--- a/playground/scripts/playground-build-policy.d.mts
+++ b/playground/scripts/playground-build-policy.d.mts
@@ -1,5 +1,6 @@
 export const OPTIONAL_FEATURE_SOURCES: Readonly<{
   benchmark: "src/components/BenchWorkbench.tsx";
   config: "src/components/ConfigEditorFeature.tsx";
+  editor: "src/components/EditorFeature.tsx";
   examples: "src/components/ExampleGallery.tsx";
 }>;

--- a/playground/scripts/playground-build-policy.mjs
+++ b/playground/scripts/playground-build-policy.mjs
@@ -20,6 +20,7 @@ export const OPTIONAL_FEATURE_SOURCES = Object.freeze({
   editor: "src/components/EditorFeature.tsx",
   examples: "src/components/ExampleGallery.tsx",
   viewer: "src/components/ReadOnlyEditorFeature.tsx",
+  viewerJson: "src/components/ReadOnlyJsonEditorFeature.tsx",
 });
 
 export const PLAYGROUND_BUILD_SOURCES = Object.freeze({
@@ -139,6 +140,16 @@ export function inspectOptionalFeatureManifest(
     if (!initialReachableKeys.has(root)) {
       violations.push(`${feature} is not dynamically reachable from ${entrySource}.`);
     }
+  }
+  const viewer = featureRoots.viewer;
+  const viewerJson = featureRoots.viewerJson;
+  if (viewer && viewerJson) {
+    forbid(
+      collectManifestClosure(graph, [viewer], "static"),
+      viewerJson,
+      "Plain read-only viewer closure",
+      violations,
+    );
   }
   return {
     graph,

--- a/playground/scripts/playground-build-policy.mjs
+++ b/playground/scripts/playground-build-policy.mjs
@@ -19,6 +19,7 @@ export const OPTIONAL_FEATURE_SOURCES = Object.freeze({
   config: "src/components/ConfigEditorFeature.tsx",
   editor: "src/components/EditorFeature.tsx",
   examples: "src/components/ExampleGallery.tsx",
+  viewer: "src/components/ReadOnlyEditorFeature.tsx",
 });
 
 export const PLAYGROUND_BUILD_SOURCES = Object.freeze({

--- a/playground/scripts/playground-build-policy.mjs
+++ b/playground/scripts/playground-build-policy.mjs
@@ -17,6 +17,7 @@ import {
 export const OPTIONAL_FEATURE_SOURCES = Object.freeze({
   benchmark: "src/components/BenchWorkbench.tsx",
   config: "src/components/ConfigEditorFeature.tsx",
+  editor: "src/components/EditorFeature.tsx",
   examples: "src/components/ExampleGallery.tsx",
 });
 

--- a/playground/scripts/playground-build-policy.test.mjs
+++ b/playground/scripts/playground-build-policy.test.mjs
@@ -140,6 +140,12 @@ function validManifest() {
       isDynamicEntry: true,
       imports: ["shared"],
     },
+    [OPTIONAL_FEATURE_SOURCES.editor]: {
+      file: "assets/editor.js",
+      src: OPTIONAL_FEATURE_SOURCES.editor,
+      isDynamicEntry: true,
+      imports: ["shared"],
+    },
     [OPTIONAL_FEATURE_SOURCES.examples]: {
       file: "assets/examples.js",
       src: OPTIONAL_FEATURE_SOURCES.examples,

--- a/playground/scripts/playground-build-policy.test.mjs
+++ b/playground/scripts/playground-build-policy.test.mjs
@@ -152,6 +152,12 @@ function validManifest() {
       isDynamicEntry: true,
       imports: ["shared"],
     },
+    [OPTIONAL_FEATURE_SOURCES.viewer]: {
+      file: "assets/viewer.js",
+      src: OPTIONAL_FEATURE_SOURCES.viewer,
+      isDynamicEntry: true,
+      imports: ["shared"],
+    },
     compare: {
       file: "assets/compare.js",
       src: PLAYGROUND_BUILD_SOURCES.compareArtifact,

--- a/playground/scripts/playground-build-policy.test.mjs
+++ b/playground/scripts/playground-build-policy.test.mjs
@@ -57,6 +57,17 @@ test("emitted policy rejects initial optional code and cross-realm artifact edge
   );
 });
 
+test("plain read-only viewer cannot own JSON activation", () => {
+  const crossed = validManifest();
+  crossed[OPTIONAL_FEATURE_SOURCES.viewer].imports.push(
+    OPTIONAL_FEATURE_SOURCES.viewerJson,
+  );
+  assert.match(
+    inspectPlaygroundEmittedGraph(crossed).violations.join("\n"),
+    /Plain read-only viewer closure reaches forbidden node/u,
+  );
+});
+
 test("emitted policy rejects Benchmark closures that reach the Compare artifact", () => {
   const featureCrossed = validManifest();
   featureCrossed[OPTIONAL_FEATURE_SOURCES.benchmark].dynamicImports.push(
@@ -157,6 +168,12 @@ function validManifest() {
       src: OPTIONAL_FEATURE_SOURCES.viewer,
       isDynamicEntry: true,
       imports: ["shared"],
+    },
+    [OPTIONAL_FEATURE_SOURCES.viewerJson]: {
+      file: "assets/viewer-json.js",
+      src: OPTIONAL_FEATURE_SOURCES.viewerJson,
+      isDynamicEntry: true,
+      imports: ["shared", OPTIONAL_FEATURE_SOURCES.viewer],
     },
     compare: {
       file: "assets/compare.js",

--- a/playground/scripts/typescript-source-graph.test.mjs
+++ b/playground/scripts/typescript-source-graph.test.mjs
@@ -125,6 +125,8 @@ test("Playground startup closure includes toolbar ownership but excludes lazy wo
 
   assert.equal(startup.has("src/components/ToolbarControls.tsx"), true);
   assert.equal(startup.has("src/components/ToolbarFeatureLaunchers.tsx"), true);
+  assert.equal(startup.has("src/components/Editor.tsx"), false);
+  assert.equal(startup.has("src/editor/monaco.ts"), false);
   assert.deepEqual(
     [...startup]
       .filter(

--- a/playground/scripts/typescript-source-graph.test.mjs
+++ b/playground/scripts/typescript-source-graph.test.mjs
@@ -126,6 +126,7 @@ test("Playground startup closure includes toolbar ownership but excludes lazy wo
   assert.equal(startup.has("src/components/ToolbarControls.tsx"), true);
   assert.equal(startup.has("src/components/ToolbarFeatureLaunchers.tsx"), true);
   assert.equal(startup.has("src/components/Editor.tsx"), false);
+  assert.equal(startup.has("src/components/ReadOnlyEditorFeature.tsx"), false);
   assert.equal(startup.has("src/editor/monaco.ts"), false);
   assert.deepEqual(
     [...startup]

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -130,8 +130,9 @@ export default function App() {
                   onFocusCapture={() => setWorkspacePane("preview")}
                   onPointerDownCapture={() => setWorkspacePane("preview")}
                 >
-                  <PreviewPanel
+                  <Preview
                     active={!isNarrowLayout || workspacePane === "preview"}
+                    className="h-full min-h-0"
                   />
                 </ResizablePanel>
               </ResizablePanelGroup>
@@ -263,12 +264,6 @@ function DeferredCodeEditor({
     >
       <CodeEditor className={className} />
     </LazyFeatureBoundary>
-  );
-}
-
-function PreviewPanel({ active }: { active: boolean }) {
-  return (
-    <Preview active={active} className="h-full min-h-0" />
   );
 }
 

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -130,7 +130,9 @@ export default function App() {
                   onFocusCapture={() => setWorkspacePane("preview")}
                   onPointerDownCapture={() => setWorkspacePane("preview")}
                 >
-                  <PreviewPanel />
+                  <PreviewPanel
+                    active={!isNarrowLayout || workspacePane === "preview"}
+                  />
                 </ResizablePanel>
               </ResizablePanelGroup>
             </div>
@@ -273,9 +275,9 @@ function DeferredCodeEditor({
   );
 }
 
-function PreviewPanel() {
+function PreviewPanel({ active }: { active: boolean }) {
   return (
-    <Preview className="h-full min-h-0" />
+    <Preview active={active} className="h-full min-h-0" />
   );
 }
 

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -106,6 +106,9 @@ export default function App() {
                   onPointerDownCapture={() => setWorkspacePane("editor")}
                 >
                   <EditorPanel
+                    activateCodeEditorImmediately={
+                      isNarrowLayout && workspacePane === "editor"
+                    }
                     editorMode={editorMode}
                     setEditorMode={setEditorMode}
                     t={t}
@@ -141,10 +144,12 @@ export default function App() {
 }
 
 function EditorPanel({
+  activateCodeEditorImmediately,
   editorMode,
   setEditorMode,
   t,
 }: {
+  activateCodeEditorImmediately: boolean;
   editorMode: "code" | "config";
   setEditorMode(mode: "code" | "config"): void;
   t(key: string): string;
@@ -186,7 +191,10 @@ function EditorPanel({
         forceMount
         className="mt-0 min-h-0 data-[state=inactive]:hidden"
       >
-        <DeferredCodeEditor className="h-full min-h-0" />
+        <DeferredCodeEditor
+          activateImmediately={activateCodeEditorImmediately}
+          className="h-full min-h-0"
+        />
       </TabsContent>
       <TabsContent
         value="config"
@@ -206,7 +214,13 @@ function EditorPanel({
   );
 }
 
-function DeferredCodeEditor({ className }: { readonly className?: string }) {
+function DeferredCodeEditor({
+  activateImmediately,
+  className,
+}: {
+  readonly activateImmediately: boolean;
+  readonly className?: string;
+}) {
   const { t } = useTranslation();
   const [activated, setActivated] = useState(
     () => playgroundStartupBoundary.reason() !== null,
@@ -221,6 +235,12 @@ function DeferredCodeEditor({ className }: { readonly className?: string }) {
       active = false;
     };
   }, []);
+
+  useEffect(() => {
+    if (!activateImmediately) return;
+    playgroundStartupBoundary.activate("editor-visible");
+    setActivated(true);
+  }, [activateImmediately]);
 
   const activateFromEditorIntent = () => {
     playgroundStartupBoundary.activate("editor-intent");

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -18,12 +18,18 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Toolbar } from "./components/Toolbar";
 import { StatusBar } from "./components/StatusBar";
-import { CodeEditor } from "./components/Editor";
 import { Preview } from "./components/Preview";
 import { ExportWorkbench } from "./components/ExportDialog";
 import { LazyFeatureBoundary } from "./components/LazyFeatureBoundary";
 import { useAppStore, type WorkspacePane } from "./store";
 import { RenderCoordinatorBridge } from "@/src/runtime/RenderCoordinatorBridge";
+import { playgroundStartupBoundary } from "@/src/runtime/startup-boundary";
+
+const CodeEditor = lazy(() =>
+  import("./components/EditorFeature").then((module) => ({
+    default: module.CodeEditor,
+  })),
+);
 
 const ConfigEditor = lazy(() =>
   import("./components/ConfigEditorFeature").then((module) => ({
@@ -180,7 +186,7 @@ function EditorPanel({
         forceMount
         className="mt-0 min-h-0 data-[state=inactive]:hidden"
       >
-        <CodeEditor className="h-full min-h-0" />
+        <DeferredCodeEditor className="h-full min-h-0" />
       </TabsContent>
       <TabsContent
         value="config"
@@ -197,6 +203,53 @@ function EditorPanel({
         )}
       </TabsContent>
     </Tabs>
+  );
+}
+
+function DeferredCodeEditor({ className }: { readonly className?: string }) {
+  const { t } = useTranslation();
+  const [activated, setActivated] = useState(
+    () => playgroundStartupBoundary.reason() !== null,
+  );
+
+  useEffect(() => {
+    let active = true;
+    void playgroundStartupBoundary.wait().then(() => {
+      if (active) setActivated(true);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const activateFromEditorIntent = () => {
+    playgroundStartupBoundary.activate("editor-intent");
+    setActivated(true);
+  };
+
+  if (!activated) {
+    return (
+      <button
+        type="button"
+        data-testid="editor-activation"
+        aria-label={t("editor.loading")}
+        className={`${className ?? ""} flex w-full items-center justify-center bg-card text-sm text-muted-foreground`}
+        onClick={activateFromEditorIntent}
+        onFocus={activateFromEditorIntent}
+        onPointerDown={activateFromEditorIntent}
+      >
+        {t("editor.loading")}
+      </button>
+    );
+  }
+
+  return (
+    <LazyFeatureBoundary
+      feature={t("layout.editor")}
+      presentation={{ kind: "panel" }}
+    >
+      <CodeEditor className={className} />
+    </LazyFeatureBoundary>
   );
 }
 

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -156,17 +156,11 @@ function EditorPanel({
   setEditorMode(mode: "code" | "config"): void;
   t(key: string): string;
 }) {
-  const [hasActivatedConfig, setHasActivatedConfig] = useState(
-    editorMode === "config",
-  );
-  const configActivated = hasActivatedConfig || editorMode === "config";
-
   return (
     <Tabs
       value={editorMode}
       onValueChange={(value) => {
         const mode = value as "code" | "config";
-        if (mode === "config") setHasActivatedConfig(true);
         setEditorMode(mode);
       }}
       activationMode="manual"
@@ -200,17 +194,14 @@ function EditorPanel({
       </TabsContent>
       <TabsContent
         value="config"
-        forceMount={configActivated ? true : undefined}
         className="mt-0 min-h-0 data-[state=inactive]:hidden"
       >
-        {configActivated && (
-          <LazyFeatureBoundary
-            feature={t("editor.configMode")}
-            presentation={{ kind: "panel" }}
-          >
-            <ConfigEditor className="h-full min-h-0" />
-          </LazyFeatureBoundary>
-        )}
+        <LazyFeatureBoundary
+          feature={t("editor.configMode")}
+          presentation={{ kind: "panel" }}
+        >
+          <ConfigEditor className="h-full min-h-0" />
+        </LazyFeatureBoundary>
       </TabsContent>
     </Tabs>
   );

--- a/playground/src/components/CompareView.tsx
+++ b/playground/src/components/CompareView.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useId, useRef, useState, type ReactNode } from "react";
-import Editor from "@monaco-editor/react";
 import {
   AlertCircle,
   Check,
@@ -29,6 +28,7 @@ import type { NavigableInlineSvg } from "@/src/runtime/render-artifact";
 import type { RenderPublicationId } from "@/src/runtime/render-coordinator";
 import { cn } from "@/lib/utils";
 import type { WorkbenchEditorThemeName } from "@/src/editor/workbench-editor-theme";
+import { ReadOnlyEditor } from "@/src/components/ReadOnlyEditor";
 
 export type CompareEngineKey = "merman" | "mermaid";
 type SvgDisplayMode = "visual" | "source";
@@ -354,6 +354,7 @@ function ComparePaneBody({
       <CompareSvgSource
         svg={artifact.svgArtifact?.svg ?? null}
         editorTheme={editorTheme}
+        feature={t("preview.viewSvgSource")}
       />
     );
   }
@@ -444,20 +445,21 @@ function CompareFailure({
 function CompareSvgSource({
   svg,
   editorTheme,
+  feature,
 }: {
   svg: string | null;
   editorTheme: WorkbenchEditorThemeName;
+  feature: string;
 }) {
   if (!svg) return null;
   return (
-    <Editor
+    <ReadOnlyEditor
+      feature={feature}
       height="100%"
       language="xml"
       value={svg}
       theme={editorTheme}
       options={{
-        readOnly: true,
-        domReadOnly: true,
         minimap: { enabled: false },
         fontSize: 12,
         scrollBeyondLastLine: false,

--- a/playground/src/components/ConfigEditor.tsx
+++ b/playground/src/components/ConfigEditor.tsx
@@ -27,6 +27,8 @@ interface ConfigEditorProps {
   className?: string;
 }
 
+const MERMAID_CONFIG_DOCUMENT_URI = "file:///merman/playground-config.json";
+
 export function ConfigEditor({ className }: ConfigEditorProps) {
   const { t } = useTranslation();
   const { mermaidConfig, setMermaidConfig, resolvedTheme } = useAppStore(
@@ -96,7 +98,9 @@ export function ConfigEditor({ className }: ConfigEditorProps) {
       <div className="min-h-0 flex-1">
         <Editor
           height="100%"
+          keepCurrentModel
           language="json"
+          path={MERMAID_CONFIG_DOCUMENT_URI}
           theme={editorTheme}
           value={mermaidConfig}
           onChange={(value) => setMermaidConfig(value || "")}
@@ -117,6 +121,7 @@ export function ConfigEditor({ className }: ConfigEditorProps) {
             scrollBeyondLastLine: false,
             padding: { top: 16, bottom: 16 },
             renderLineHighlight: "line",
+            occurrencesHighlight: "off",
             cursorBlinking: "smooth",
             smoothScrolling: true,
             tabSize: 2,

--- a/playground/src/components/ConfigEditorFeature.tsx
+++ b/playground/src/components/ConfigEditorFeature.tsx
@@ -1,7 +1,9 @@
+import { ensureLocalMonacoConfigured } from "@/src/editor/monaco";
 import { activateLocalMonacoJson } from "@/src/editor/monaco-json";
 
 import { ConfigEditor } from "./ConfigEditor";
 
+ensureLocalMonacoConfigured();
 activateLocalMonacoJson();
 
 export { ConfigEditor };

--- a/playground/src/components/ConfigEditorFeature.tsx
+++ b/playground/src/components/ConfigEditorFeature.tsx
@@ -1,9 +1,7 @@
-import { ensureLocalMonacoConfigured } from "@/src/editor/monaco";
 import { activateLocalMonacoJson } from "@/src/editor/monaco-json";
 
 import { ConfigEditor } from "./ConfigEditor";
 
-ensureLocalMonacoConfigured();
 activateLocalMonacoJson();
 
 export { ConfigEditor };

--- a/playground/src/components/Editor.tsx
+++ b/playground/src/components/Editor.tsx
@@ -14,7 +14,6 @@ import {
   type MermaidLanguageRegistration,
 } from "@/src/lib/mermaid-language";
 import { registerBrowserMermaidLanguage } from "@/src/lib/mermaid-language-browser";
-import { playgroundStartupBoundary } from "@/src/runtime/startup-boundary";
 import { useAppStore } from "@/src/store";
 
 interface CodeEditorProps {
@@ -113,25 +112,17 @@ export function CodeEditor({ className }: CodeEditorProps) {
     let active = true;
     let registration: MermaidLanguageRegistration | null = null;
     languageFailureRef.current = null;
-    void playgroundStartupBoundary
-      .wait()
-      .then(() => {
-        if (!active || languageGenerationRef.current !== generation) {
-          return null;
-        }
-        return registerBrowserMermaidLanguage(localMonaco, {
-          onRequestRejected: (rejection) => {
-            if (languageGenerationRef.current !== generation) return;
-            setRequestRejection(rejection);
-          },
-          onSemanticUnavailable: (error) =>
-            markLanguageDegraded(error, generation),
-          onSyntaxUnavailable: (error) =>
-            markLanguageDegraded(error, generation),
-        });
-      })
+    void registerBrowserMermaidLanguage(localMonaco, {
+      onRequestRejected: (rejection) => {
+        if (languageGenerationRef.current !== generation) return;
+        setRequestRejection(rejection);
+      },
+      onSemanticUnavailable: (error) =>
+        markLanguageDegraded(error, generation),
+      onSyntaxUnavailable: (error) =>
+        markLanguageDegraded(error, generation),
+    })
       .then((nextRegistration) => {
-        if (!nextRegistration) return;
         if (!active || languageGenerationRef.current !== generation) {
           nextRegistration.dispose();
           return;
@@ -248,15 +239,7 @@ export function CodeEditor({ className }: CodeEditorProps) {
   }, [disposeLanguageService, language.status]);
 
   return (
-    <div
-      className={`${className ?? ""} relative`}
-      onFocusCapture={() =>
-        playgroundStartupBoundary.activate("editor-intent")
-      }
-      onPointerDownCapture={() =>
-        playgroundStartupBoundary.activate("editor-intent")
-      }
-    >
+    <div className={`${className ?? ""} relative`}>
       <Editor
         height="100%"
         language={MERMAID_LANGUAGE_ID}

--- a/playground/src/components/Editor.tsx
+++ b/playground/src/components/Editor.tsx
@@ -14,6 +14,7 @@ import {
   type MermaidLanguageRegistration,
 } from "@/src/lib/mermaid-language";
 import { registerBrowserMermaidLanguage } from "@/src/lib/mermaid-language-browser";
+import { playgroundStartupBoundary } from "@/src/runtime/startup-boundary";
 import { useAppStore } from "@/src/store";
 
 interface CodeEditorProps {
@@ -112,15 +113,25 @@ export function CodeEditor({ className }: CodeEditorProps) {
     let active = true;
     let registration: MermaidLanguageRegistration | null = null;
     languageFailureRef.current = null;
-    void registerBrowserMermaidLanguage(localMonaco, {
-      onRequestRejected: (rejection) => {
-        if (languageGenerationRef.current !== generation) return;
-        setRequestRejection(rejection);
-      },
-      onSemanticUnavailable: (error) => markLanguageDegraded(error, generation),
-      onSyntaxUnavailable: (error) => markLanguageDegraded(error, generation),
-    })
+    void playgroundStartupBoundary
+      .wait()
+      .then(() => {
+        if (!active || languageGenerationRef.current !== generation) {
+          return null;
+        }
+        return registerBrowserMermaidLanguage(localMonaco, {
+          onRequestRejected: (rejection) => {
+            if (languageGenerationRef.current !== generation) return;
+            setRequestRejection(rejection);
+          },
+          onSemanticUnavailable: (error) =>
+            markLanguageDegraded(error, generation),
+          onSyntaxUnavailable: (error) =>
+            markLanguageDegraded(error, generation),
+        });
+      })
       .then((nextRegistration) => {
+        if (!nextRegistration) return;
         if (!active || languageGenerationRef.current !== generation) {
           nextRegistration.dispose();
           return;
@@ -237,7 +248,15 @@ export function CodeEditor({ className }: CodeEditorProps) {
   }, [disposeLanguageService, language.status]);
 
   return (
-    <div className={`${className ?? ""} relative`}>
+    <div
+      className={`${className ?? ""} relative`}
+      onFocusCapture={() =>
+        playgroundStartupBoundary.activate("editor-intent")
+      }
+      onPointerDownCapture={() =>
+        playgroundStartupBoundary.activate("editor-intent")
+      }
+    >
       <Editor
         height="100%"
         language={MERMAID_LANGUAGE_ID}

--- a/playground/src/components/EditorFeature.tsx
+++ b/playground/src/components/EditorFeature.tsx
@@ -1,0 +1,7 @@
+import { ensureLocalMonacoConfigured } from "@/src/editor/monaco";
+
+import { CodeEditor } from "./Editor";
+
+ensureLocalMonacoConfigured();
+
+export { CodeEditor };

--- a/playground/src/components/Preview.tsx
+++ b/playground/src/components/Preview.tsx
@@ -87,7 +87,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import Editor from "@monaco-editor/react";
+import { ReadOnlyEditor } from "@/src/components/ReadOnlyEditor";
 
 interface PreviewProps {
   active?: boolean;
@@ -536,7 +536,11 @@ export function Preview({ active = true, className }: PreviewProps) {
           <>
             {previewMode === "svg" &&
               (svgDisplayMode === "source" ? (
-                <SvgSourceEditor svg={svg} editorTheme={editorTheme} />
+                <SvgSourceEditor
+                  svg={svg}
+                  editorTheme={editorTheme}
+                  feature={t("preview.viewSvgSource")}
+                />
               ) : (
                 <SvgViewport
                   artifact={svgArtifact}
@@ -801,13 +805,13 @@ function AsciiArtifactView({
         data-testid="ascii-artifact-editor"
         className="min-h-0 flex-1"
       >
-        <Editor
+        <ReadOnlyEditor
+          feature={t("preview.asciiMode")}
           height="100%"
           language="plaintext"
           value={result.artifact}
           theme={editorTheme}
           options={{
-            readOnly: true,
             minimap: { enabled: false },
             fontSize: 13,
             fontFamily: "'JetBrains Mono', 'Fira Code', 'Consolas', monospace",
@@ -816,10 +820,8 @@ function AsciiArtifactView({
             wordWrap: "off",
             renderLineHighlight: "none",
             selectionHighlight: false,
-            occurrencesHighlight: "off",
             folding: false,
             padding: { top: 16, bottom: 16 },
-            domReadOnly: true,
           }}
         />
       </div>
@@ -989,7 +991,6 @@ function DiagnosticsView({
         <TabsContent
           key={tab}
           value={tab}
-          forceMount
           className="mt-0 min-h-0 data-[state=inactive]:hidden"
         >
           <DiagnosticArtifactView
@@ -1045,14 +1046,13 @@ function DiagnosticArtifactView({
     );
   }
   return (
-    <Editor
+    <ReadOnlyEditor
+      feature={t("preview.diagnosticsMode")}
       height="100%"
       language="json"
       value={artifact.json}
       theme={editorTheme}
       options={{
-        readOnly: true,
-        domReadOnly: true,
         minimap: { enabled: false },
         fontSize: 13,
         fontFamily: "'JetBrains Mono', 'Fira Code', 'Consolas', monospace",
@@ -1060,7 +1060,6 @@ function DiagnosticArtifactView({
         wordWrap: "on",
         renderLineHighlight: "none",
         selectionHighlight: false,
-        occurrencesHighlight: "off",
         folding: true,
         automaticLayout: true,
         padding: { top: 16, bottom: 16 },

--- a/playground/src/components/Preview.tsx
+++ b/playground/src/components/Preview.tsx
@@ -193,11 +193,13 @@ export function Preview({ className }: PreviewProps) {
 
   useEffect(() => {
     setRenderFeatures({
+      asciiEnabled: previewMode === "ascii",
       compareEnabled: previewMode === "compare",
       diagnosticsEnabled: previewMode === "diagnostics",
     });
     return () =>
       setRenderFeatures({
+        asciiEnabled: false,
         compareEnabled: false,
         diagnosticsEnabled: false,
       });

--- a/playground/src/components/Preview.tsx
+++ b/playground/src/components/Preview.tsx
@@ -33,6 +33,7 @@ import { MERMAID_JS_VERSION } from "@/src/runtime/mermaid-requirements";
 import {
   markRenderCoordinatorPresented,
   refreshRenderCoordinator,
+  setRenderCoordinatorEnabled,
   setRenderFeatures,
 } from "@/src/runtime/render-coordinator-browser";
 import {
@@ -89,6 +90,7 @@ import {
 import Editor from "@monaco-editor/react";
 
 interface PreviewProps {
+  active?: boolean;
   className?: string;
 }
 
@@ -106,7 +108,7 @@ const EMPTY_DIAGNOSTICS: Record<DiagnosticKey, DiagnosticArtifact> = {
   layout: { json: null, error: null, errorDetail: null, elapsedMs: null },
 };
 
-export function Preview({ className }: PreviewProps) {
+export function Preview({ active = true, className }: PreviewProps) {
   const { t } = useTranslation();
   const code = useAppStore((state) => state.code);
   const diagramTheme = useAppStore((state) => state.diagramTheme);
@@ -190,6 +192,10 @@ export function Preview({ className }: PreviewProps) {
     [canvasOperation, code, diagramTheme, mermaidConfig],
   );
   const canvasMode = previewMode === "svg" || previewMode === "compare";
+
+  useEffect(() => {
+    setRenderCoordinatorEnabled(active);
+  }, [active]);
 
   useEffect(() => {
     setRenderFeatures({

--- a/playground/src/components/PreviewArtifactViews.tsx
+++ b/playground/src/components/PreviewArtifactViews.tsx
@@ -1,4 +1,3 @@
-import Editor from "@monaco-editor/react";
 import { Maximize2, RotateCcw, ZoomIn, ZoomOut } from "lucide-react";
 import type { ReactNode } from "react";
 
@@ -13,6 +12,7 @@ import {
   type SvgViewportController,
 } from "@/src/components/SvgViewport";
 import type { WorkbenchEditorThemeName } from "@/src/editor/workbench-editor-theme";
+import { ReadOnlyEditor } from "@/src/components/ReadOnlyEditor";
 
 export function ViewportControls({
   controller,
@@ -53,9 +53,11 @@ function formatZoomPercent(zoom: number): string {
 export function SvgSourceEditor({
   svg,
   editorTheme,
+  feature,
 }: {
   svg: string | null;
   editorTheme: WorkbenchEditorThemeName;
+  feature: string;
 }) {
   if (!svg) {
     return (
@@ -66,14 +68,13 @@ export function SvgSourceEditor({
   }
 
   return (
-    <Editor
+    <ReadOnlyEditor
+      feature={feature}
       height="100%"
       language="xml"
       value={svg}
       theme={editorTheme}
       options={{
-        readOnly: true,
-        domReadOnly: true,
         minimap: { enabled: false },
         fontSize: 12,
         fontFamily: "'JetBrains Mono', 'Fira Code', 'Consolas', monospace",
@@ -81,7 +82,6 @@ export function SvgSourceEditor({
         wordWrap: "on",
         renderLineHighlight: "none",
         selectionHighlight: false,
-        occurrencesHighlight: "off",
         folding: true,
         automaticLayout: true,
         padding: { top: 16, bottom: 16 },

--- a/playground/src/components/ReadOnlyEditor.tsx
+++ b/playground/src/components/ReadOnlyEditor.tsx
@@ -8,6 +8,11 @@ const LocalReadOnlyEditor = lazy(() =>
     default: module.LocalReadOnlyEditor,
   })),
 );
+const LocalReadOnlyJsonEditor = lazy(() =>
+  import("./ReadOnlyJsonEditorFeature").then((module) => ({
+    default: module.LocalReadOnlyJsonEditor,
+  })),
+);
 
 interface ReadOnlyEditorProps
   extends Omit<
@@ -20,16 +25,20 @@ interface ReadOnlyEditorProps
 
 export function ReadOnlyEditor({
   feature,
+  language,
   options,
   ...props
 }: ReadOnlyEditorProps) {
+  const Editor =
+    language === "json" ? LocalReadOnlyJsonEditor : LocalReadOnlyEditor;
   return (
     <LazyFeatureBoundary
       feature={feature}
       presentation={{ kind: "panel" }}
     >
-      <LocalReadOnlyEditor
+      <Editor
         {...props}
+        language={language}
         options={{
           ...options,
           domReadOnly: true,

--- a/playground/src/components/ReadOnlyEditor.tsx
+++ b/playground/src/components/ReadOnlyEditor.tsx
@@ -1,0 +1,42 @@
+import { lazy } from "react";
+import type { EditorProps } from "@monaco-editor/react";
+
+import { LazyFeatureBoundary } from "@/src/components/LazyFeatureBoundary";
+
+const LocalReadOnlyEditor = lazy(() =>
+  import("./ReadOnlyEditorFeature").then((module) => ({
+    default: module.LocalReadOnlyEditor,
+  })),
+);
+
+interface ReadOnlyEditorProps
+  extends Omit<
+    EditorProps,
+    "defaultLanguage" | "defaultPath" | "defaultValue" | "keepCurrentModel" | "onChange"
+  > {
+  readonly feature: string;
+  readonly value: string;
+}
+
+export function ReadOnlyEditor({
+  feature,
+  options,
+  ...props
+}: ReadOnlyEditorProps) {
+  return (
+    <LazyFeatureBoundary
+      feature={feature}
+      presentation={{ kind: "panel" }}
+    >
+      <LocalReadOnlyEditor
+        {...props}
+        options={{
+          ...options,
+          domReadOnly: true,
+          occurrencesHighlight: "off",
+          readOnly: true,
+        }}
+      />
+    </LazyFeatureBoundary>
+  );
+}

--- a/playground/src/components/ReadOnlyEditorFeature.tsx
+++ b/playground/src/components/ReadOnlyEditorFeature.tsx
@@ -1,9 +1,7 @@
 import Editor from "@monaco-editor/react";
 
 import { ensureLocalMonacoConfigured } from "@/src/editor/monaco";
-import { activateLocalMonacoJson } from "@/src/editor/monaco-json";
 
 ensureLocalMonacoConfigured();
-activateLocalMonacoJson();
 
 export const LocalReadOnlyEditor = Editor;

--- a/playground/src/components/ReadOnlyEditorFeature.tsx
+++ b/playground/src/components/ReadOnlyEditorFeature.tsx
@@ -1,0 +1,9 @@
+import Editor from "@monaco-editor/react";
+
+import { ensureLocalMonacoConfigured } from "@/src/editor/monaco";
+import { activateLocalMonacoJson } from "@/src/editor/monaco-json";
+
+ensureLocalMonacoConfigured();
+activateLocalMonacoJson();
+
+export const LocalReadOnlyEditor = Editor;

--- a/playground/src/components/ReadOnlyJsonEditorFeature.tsx
+++ b/playground/src/components/ReadOnlyJsonEditorFeature.tsx
@@ -1,0 +1,7 @@
+import { activateLocalMonacoJson } from "@/src/editor/monaco-json";
+
+import { LocalReadOnlyEditor } from "./ReadOnlyEditorFeature";
+
+activateLocalMonacoJson();
+
+export const LocalReadOnlyJsonEditor = LocalReadOnlyEditor;

--- a/playground/src/components/SvgViewport.tsx
+++ b/playground/src/components/SvgViewport.tsx
@@ -15,6 +15,10 @@ import {
   prepareSvgForResponsivePreview,
   type SvgDimensions,
 } from "@/src/lib/svg-geometry";
+import {
+  resolveConnectedBounds,
+  type SvgBounds,
+} from "@/src/lib/svg-connected-bounds";
 import type { MermaidCanvasTone } from "@/src/lib/mermaid-canvas-tone";
 import type { SvgPresentationMode } from "@/src/lib/svg-presentation";
 import type { NavigableInlineSvg } from "@/src/runtime/render-artifact";
@@ -27,13 +31,6 @@ interface Point {
 interface FitGeometry {
   readonly centerOffset: Point;
   readonly dimensions: SvgDimensions;
-}
-
-interface SvgBounds {
-  readonly bottom: number;
-  readonly left: number;
-  readonly right: number;
-  readonly top: number;
 }
 
 interface RootOverflowSnapshot {
@@ -1121,30 +1118,13 @@ function measureConnectedVisualBounds(
     return null;
   }
 
-  let connectedBounds = rootBounds;
-  let pending = Array.from(svg.querySelectorAll<SVGGraphicsElement>("*"))
+  const candidates = Array.from(svg.querySelectorAll<SVGGraphicsElement>("*"))
     .filter(isMeasurableSvgGraphic)
     .flatMap((element) => {
       const bounds = measureSvgGraphicInRootSpace(element, toRoot);
       return bounds ? [bounds] : [];
     });
-
-  while (pending.length > 0) {
-    const disconnected: SvgBounds[] = [];
-    let foundConnection = false;
-    for (const candidate of pending) {
-      if (!boundsIntersect(connectedBounds, candidate)) {
-        disconnected.push(candidate);
-        continue;
-      }
-      connectedBounds = unionBounds(connectedBounds, candidate);
-      foundConnection = true;
-    }
-    if (!foundConnection) break;
-    pending = disconnected;
-  }
-
-  return connectedBounds;
+  return resolveConnectedBounds(rootBounds, candidates);
 }
 
 function isMeasurableSvgGraphic(element: SVGGraphicsElement): boolean {
@@ -1225,24 +1205,6 @@ function transformSvgPoint(matrix: DOMMatrix, x: number, y: number): Point {
   return {
     x: matrix.a * x + matrix.c * y + matrix.e,
     y: matrix.b * x + matrix.d * y + matrix.f,
-  };
-}
-
-function boundsIntersect(left: SvgBounds, right: SvgBounds): boolean {
-  return (
-    left.left <= right.right &&
-    left.right >= right.left &&
-    left.top <= right.bottom &&
-    left.bottom >= right.top
-  );
-}
-
-function unionBounds(left: SvgBounds, right: SvgBounds): SvgBounds {
-  return {
-    bottom: Math.max(left.bottom, right.bottom),
-    left: Math.min(left.left, right.left),
-    right: Math.max(left.right, right.right),
-    top: Math.min(left.top, right.top),
   };
 }
 

--- a/playground/src/components/ToolbarArtifactActions.tsx
+++ b/playground/src/components/ToolbarArtifactActions.tsx
@@ -78,7 +78,7 @@ export function useToolbarArtifactActions() {
   const currentMerman =
     currentBatch?.merman.status === "success" ? currentBatch.merman : null;
   const artifactActionsEnabled = currentMerman !== null;
-  const asciiAvailable = currentBatch?.ascii.status === "success";
+  const asciiAvailable = asciiSupported && currentBatch !== null;
 
   const handleOpenExport = useCallback((restoreFocus?: HTMLElement | null) => {
     if (!currentBatch) return;

--- a/playground/src/components/ToolbarArtifactActions.tsx
+++ b/playground/src/components/ToolbarArtifactActions.tsx
@@ -41,6 +41,7 @@ import {
 import { copyWorkspaceShareUrl } from "@/src/lib/share";
 import { copyIssueShareUrl } from "@/src/lib/share-view";
 import { executeArtifactAction } from "@/src/runtime/artifact-actions-browser";
+import { isAsciiExportAvailable } from "@/src/components/toolbar-artifact-availability";
 import {
   selectCompletedRenderBatch,
   selectCurrentDiagramType,
@@ -78,7 +79,7 @@ export function useToolbarArtifactActions() {
   const currentMerman =
     currentBatch?.merman.status === "success" ? currentBatch.merman : null;
   const artifactActionsEnabled = currentMerman !== null;
-  const asciiAvailable = asciiSupported && currentBatch !== null;
+  const asciiAvailable = isAsciiExportAvailable(asciiSupported, currentBatch);
 
   const handleOpenExport = useCallback((restoreFocus?: HTMLElement | null) => {
     if (!currentBatch) return;

--- a/playground/src/components/toolbar-artifact-availability.ts
+++ b/playground/src/components/toolbar-artifact-availability.ts
@@ -1,0 +1,16 @@
+import type { MermanAsciiBatchResult } from "../runtime/render-coordinator.ts";
+
+interface CurrentAsciiPublication {
+  readonly ascii: MermanAsciiBatchResult | null;
+}
+
+export function isAsciiExportAvailable(
+  asciiSupported: boolean,
+  currentBatch: CurrentAsciiPublication | null,
+): boolean {
+  return (
+    asciiSupported &&
+    currentBatch !== null &&
+    (currentBatch.ascii === null || currentBatch.ascii.status === "success")
+  );
+}

--- a/playground/src/editor/monaco-json.ts
+++ b/playground/src/editor/monaco-json.ts
@@ -1,11 +1,15 @@
 import "monaco-editor/esm/vs/language/json/monaco.contribution.js";
 import JsonWorker from "monaco-editor/esm/vs/language/json/json.worker?worker";
 
-import { registerLocalMonacoJsonWorker } from "./monaco";
+import {
+  ensureLocalMonacoConfigured,
+  registerLocalMonacoJsonWorker,
+} from "./monaco";
 
 let registration: ReturnType<typeof registerLocalMonacoJsonWorker> | null = null;
 
 export function activateLocalMonacoJson(): void {
+  ensureLocalMonacoConfigured();
   registration ??= registerLocalMonacoJsonWorker(
     () => new JsonWorker({ name: "monaco-json" }),
   );

--- a/playground/src/editor/monaco.ts
+++ b/playground/src/editor/monaco.ts
@@ -8,7 +8,6 @@ import { registerWorkbenchEditorThemes } from "./workbench-editor-theme";
 export const localMonaco = monacoApi as typeof import("monaco-editor");
 
 interface MonacoEnvironmentOwner {
-  readonly monaco: typeof localMonaco;
   dispose(): void;
 }
 
@@ -19,6 +18,7 @@ interface MonacoEnvironment {
 type MonacoWorkerFactory = () => Worker;
 
 let jsonWorkerFactory: MonacoWorkerFactory | null = null;
+let configuredOwner: MonacoEnvironmentOwner | null = null;
 
 export function registerLocalMonacoJsonWorker(
   factory: MonacoWorkerFactory,
@@ -38,7 +38,7 @@ export function registerLocalMonacoJsonWorker(
   };
 }
 
-export function configureLocalMonaco(): MonacoEnvironmentOwner {
+function configureLocalMonaco(): MonacoEnvironmentOwner {
   const target = globalThis as typeof globalThis & {
     MonacoEnvironment?: MonacoEnvironment;
   };
@@ -60,7 +60,6 @@ export function configureLocalMonaco(): MonacoEnvironmentOwner {
   loader.config({ monaco: localMonaco });
 
   return {
-    monaco: localMonaco,
     dispose() {
       if (previous) {
         target.MonacoEnvironment = previous;
@@ -69,4 +68,15 @@ export function configureLocalMonaco(): MonacoEnvironmentOwner {
       }
     },
   };
+}
+
+export function ensureLocalMonacoConfigured(): void {
+  configuredOwner ??= configureLocalMonaco();
+}
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    configuredOwner?.dispose();
+    configuredOwner = null;
+  });
 }

--- a/playground/src/lib/svg-connected-bounds.test.ts
+++ b/playground/src/lib/svg-connected-bounds.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  resolveConnectedBounds,
+  type SvgBounds,
+} from "./svg-connected-bounds.ts";
+
+test("expands through a reverse-ordered chain without including disconnected bounds", () => {
+  const root = bounds(0, 1, 0, 1);
+  const chain = Array.from({ length: 100 }, (_, index) => {
+    const step = 100 - index;
+    return bounds(step, step + 1, 0, 1);
+  });
+
+  assert.deepEqual(
+    resolveConnectedBounds(root, [
+      bounds(1_000, 1_001, 1_000, 1_001),
+      ...chain,
+    ]),
+    bounds(0, 101, 0, 1),
+  );
+});
+
+test("treats touching edges as connected", () => {
+  assert.deepEqual(
+    resolveConnectedBounds(bounds(0, 1, 0, 1), [bounds(1, 2, 1, 2)]),
+    bounds(0, 2, 0, 2),
+  );
+});
+
+test("matches the existing fixed-point algorithm across deterministic samples", () => {
+  let state = 0x5eed1234;
+  const random = () => {
+    state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+    return state / 0x1_0000_0000;
+  };
+
+  for (let sample = 0; sample < 250; sample += 1) {
+    const root = randomBounds(random);
+    const candidates = Array.from({ length: 40 }, () => randomBounds(random));
+    assert.deepEqual(
+      resolveConnectedBounds(root, candidates),
+      resolveConnectedBoundsReference(root, candidates),
+      `sample ${sample}`,
+    );
+  }
+});
+
+function resolveConnectedBoundsReference(
+  root: SvgBounds,
+  candidates: readonly SvgBounds[],
+): SvgBounds {
+  let connected = root;
+  let pending = [...candidates];
+
+  while (pending.length > 0) {
+    const disconnected: SvgBounds[] = [];
+    let foundConnection = false;
+    for (const candidate of pending) {
+      if (!boundsIntersect(connected, candidate)) {
+        disconnected.push(candidate);
+        continue;
+      }
+      connected = unionBounds(connected, candidate);
+      foundConnection = true;
+    }
+    if (!foundConnection) break;
+    pending = disconnected;
+  }
+
+  return connected;
+}
+
+function randomBounds(random: () => number): SvgBounds {
+  const left = Math.floor(random() * 40) - 20;
+  const top = Math.floor(random() * 40) - 20;
+  return bounds(
+    left,
+    left + Math.floor(random() * 8),
+    top,
+    top + Math.floor(random() * 8),
+  );
+}
+
+function bounds(
+  left: number,
+  right: number,
+  top: number,
+  bottom: number,
+): SvgBounds {
+  return { bottom, left, right, top };
+}
+
+function boundsIntersect(left: SvgBounds, right: SvgBounds): boolean {
+  return (
+    left.left <= right.right &&
+    left.right >= right.left &&
+    left.top <= right.bottom &&
+    left.bottom >= right.top
+  );
+}
+
+function unionBounds(left: SvgBounds, right: SvgBounds): SvgBounds {
+  return {
+    bottom: Math.max(left.bottom, right.bottom),
+    left: Math.min(left.left, right.left),
+    right: Math.max(left.right, right.right),
+    top: Math.min(left.top, right.top),
+  };
+}

--- a/playground/src/lib/svg-connected-bounds.ts
+++ b/playground/src/lib/svg-connected-bounds.ts
@@ -1,0 +1,111 @@
+export interface SvgBounds {
+  readonly bottom: number;
+  readonly left: number;
+  readonly right: number;
+  readonly top: number;
+}
+
+interface BoundaryFrontiers {
+  bottom: number;
+  left: number;
+  right: number;
+  top: number;
+}
+
+export function resolveConnectedBounds(
+  root: SvgBounds,
+  candidates: readonly SvgBounds[],
+): SvgBounds {
+  if (candidates.length === 0) return root;
+
+  const unmetConditions = new Uint8Array(candidates.length);
+  unmetConditions.fill(4);
+
+  const ascendingLeft = sortedCandidateIndexes(
+    candidates,
+    (candidate) => candidate.left,
+  );
+  const descendingRight = sortedCandidateIndexes(
+    candidates,
+    (candidate) => -candidate.right,
+  );
+  const ascendingTop = sortedCandidateIndexes(
+    candidates,
+    (candidate) => candidate.top,
+  );
+  const descendingBottom = sortedCandidateIndexes(
+    candidates,
+    (candidate) => -candidate.bottom,
+  );
+  const frontiers: BoundaryFrontiers = {
+    bottom: 0,
+    left: 0,
+    right: 0,
+    top: 0,
+  };
+  const ready: number[] = [];
+  let connected = root;
+
+  const satisfy = (candidateIndex: number) => {
+    const remaining = unmetConditions[candidateIndex] - 1;
+    unmetConditions[candidateIndex] = remaining;
+    if (remaining === 0) ready.push(candidateIndex);
+  };
+
+  const advanceFrontiers = () => {
+    while (
+      frontiers.left < ascendingLeft.length &&
+      candidates[ascendingLeft[frontiers.left]].left <= connected.right
+    ) {
+      satisfy(ascendingLeft[frontiers.left]);
+      frontiers.left += 1;
+    }
+    while (
+      frontiers.right < descendingRight.length &&
+      candidates[descendingRight[frontiers.right]].right >= connected.left
+    ) {
+      satisfy(descendingRight[frontiers.right]);
+      frontiers.right += 1;
+    }
+    while (
+      frontiers.top < ascendingTop.length &&
+      candidates[ascendingTop[frontiers.top]].top <= connected.bottom
+    ) {
+      satisfy(ascendingTop[frontiers.top]);
+      frontiers.top += 1;
+    }
+    while (
+      frontiers.bottom < descendingBottom.length &&
+      candidates[descendingBottom[frontiers.bottom]].bottom >= connected.top
+    ) {
+      satisfy(descendingBottom[frontiers.bottom]);
+      frontiers.bottom += 1;
+    }
+  };
+
+  advanceFrontiers();
+  for (let readyIndex = 0; readyIndex < ready.length; readyIndex += 1) {
+    connected = unionBounds(connected, candidates[ready[readyIndex]]);
+    advanceFrontiers();
+  }
+
+  return connected;
+}
+
+function sortedCandidateIndexes(
+  candidates: readonly SvgBounds[],
+  key: (candidate: SvgBounds) => number,
+): number[] {
+  return Array.from(candidates, (_, index) => index).sort(
+    (left, right) => key(candidates[left]) - key(candidates[right]),
+  );
+}
+
+function unionBounds(left: SvgBounds, right: SvgBounds): SvgBounds {
+  return {
+    bottom: Math.max(left.bottom, right.bottom),
+    left: Math.min(left.left, right.left),
+    right: Math.max(left.right, right.right),
+    top: Math.min(left.top, right.top),
+  };
+}

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -13,7 +13,6 @@ import {
   resumeRenderCoordinator,
   suspendRenderCoordinator,
 } from "./runtime/render-coordinator-browser";
-import { configureLocalMonaco } from "./editor/monaco";
 import { installUIThemeLifecycle, useAppStore } from "./store";
 import { hydrateStartupShareLocation } from "./lib/share-view";
 
@@ -21,7 +20,6 @@ hydrateStartupShareLocation(window.location, (hydration) => {
   useAppStore.getState().applyStartupShareHydration(hydration);
 });
 
-const monacoOwner = configureLocalMonaco();
 const removeThemeLifecycle = installUIThemeLifecycle();
 void ensureMermanReady().catch(() => undefined);
 const removeDocumentLifecycle = installMermanDocumentLifecycle(
@@ -46,7 +44,6 @@ if (import.meta.hot) {
     removeThemeLifecycle();
     disposeRenderCoordinator();
     disposeMermanRuntime();
-    monacoOwner.dispose();
     root.unmount();
   });
 }

--- a/playground/src/runtime/artifact-actions-browser.ts
+++ b/playground/src/runtime/artifact-actions-browser.ts
@@ -12,6 +12,7 @@ import {
 
 export const executeArtifactAction = createArtifactActionOwner({
   getRenderState: renderCoordinatorStore.getState,
+  getRuntimeState: mermanRuntimeStore.getState,
   io: {
     copyAscii: copyASCIIToClipboard,
     copySvg: copySVGToClipboard,

--- a/playground/src/runtime/artifact-actions.test.ts
+++ b/playground/src/runtime/artifact-actions.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { isAsciiExportAvailable } from "../components/toolbar-artifact-availability.ts";
 import {
   DEFAULT_WORKSPACE_SNAPSHOT,
   type WorkspaceSnapshot,
@@ -21,11 +22,41 @@ import {
 } from "./merman-operation-input.ts";
 import type {
   CompletedRenderBatch,
+  MermanAsciiBatchResult,
   RenderCoordinatorState,
   RenderPublicationId,
 } from "./render-coordinator.ts";
 import { projectNavigableInlineSvg } from "./render-artifact.ts";
 import { MERMAID_JS_VERSION } from "./mermaid-requirements.ts";
+
+test("enables ASCII export only for lazy or successful artifacts", () => {
+  const cases: ReadonlyArray<
+    readonly [string, MermanAsciiBatchResult | null, boolean]
+  > = [
+    ["lazy", null, true],
+    ["success", { artifact: "ascii", status: "success" }, true],
+    [
+      "failure",
+      {
+        error: { summary: "render failed", detail: null },
+        status: "failure",
+      },
+      false,
+    ],
+    ["unsupported", { diagramType: "flowchart", status: "unsupported" }, false],
+    [
+      "unavailable",
+      { reason: "diagram-detection-unavailable", status: "unavailable" },
+      false,
+    ],
+  ];
+
+  assert.equal(isAsciiExportAvailable(true, null), false);
+  for (const [label, ascii, expected] of cases) {
+    assert.equal(isAsciiExportAvailable(true, { ascii }), expected, label);
+  }
+  assert.equal(isAsciiExportAvailable(false, { ascii: cases[1][1] }), false);
+});
 
 test("selects copied SVG and ASCII only from the named current publication", async () => {
   const publication = completedPublication("current");
@@ -87,6 +118,71 @@ test("renders and caches ASCII only after an explicit artifact action", async ()
     "copy-ascii:ascii-on-demand",
     "download-ascii:ascii-on-demand:merman-diagram",
   ]);
+});
+
+test("on-demand ASCII failures reject before artifact I/O", async () => {
+  const completed = completedPublication("on-demand-failure");
+  const publication: CompletedRenderBatch = Object.freeze({
+    ...completed,
+    ascii: null,
+  });
+  const cases: ReadonlyArray<{
+    readonly code: ArtifactActionError["code"];
+    readonly runtime: () => MermanRuntimeState;
+    readonly stage: string | null;
+  }> = [
+    {
+      code: "runtime-unavailable",
+      runtime: () => ({ status: "idle", suspended: false }),
+      stage: null,
+    },
+    {
+      code: "runtime-version-mismatch",
+      runtime: () => readyRuntime(undefined, undefined, "different-version"),
+      stage: null,
+    },
+    {
+      code: "ascii-render-failed",
+      runtime: () =>
+        readyRuntime(undefined, () => {
+          throw new Error("ASCII render threw.");
+        }),
+      stage: "render",
+    },
+    {
+      code: "ascii-render-failed",
+      runtime: () =>
+        readyRuntime(undefined, () => ({
+          ascii: null,
+          error: { detail: null, summary: "ASCII render failed." },
+          status: "failure",
+        })),
+      stage: "render",
+    },
+  ];
+
+  for (const { code, runtime, stage } of cases) {
+    const calls: string[] = [];
+    const owner = createArtifactActionOwner({
+      getRenderState: () => publication,
+      getRuntimeState: runtime,
+      io: recordingIo(calls),
+    });
+
+    await assert.rejects(
+      owner({
+        action: "copy-ascii",
+        publicationId: publication.snapshot.publicationId,
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof ArtifactActionError);
+        assert.equal(error.code, code);
+        assert.equal(error.stage, stage);
+        return true;
+      },
+    );
+    assert.deepEqual(calls, []);
+  }
 });
 
 test("publishes ASCII actions independently from a failed Merman SVG", async () => {
@@ -317,12 +413,13 @@ function readyRuntime(
     error: null,
     status: "success",
   }),
+  packageVersion = "test-merman",
 ): MermanRuntimeState {
   return {
     status: "ready",
     suspended: false,
     facade: {
-      packageVersion: "test-merman",
+      packageVersion,
       render,
       renderAscii,
     } as MermanDomainFacade,

--- a/playground/src/runtime/artifact-actions.test.ts
+++ b/playground/src/runtime/artifact-actions.test.ts
@@ -33,6 +33,7 @@ test("selects copied SVG and ASCII only from the named current publication", asy
   const calls: string[] = [];
   const owner = createArtifactActionOwner({
     getRenderState: () => publication,
+    getRuntimeState: () => readyRuntime(),
     io: recordingIo(calls),
   });
 
@@ -46,6 +47,45 @@ test("selects copied SVG and ASCII only from the named current publication", asy
     "copy-svg:mermaid",
     "copy-ascii:ascii-current",
     "download-ascii:ascii-current:merman-diagram",
+  ]);
+});
+
+test("renders and caches ASCII only after an explicit artifact action", async () => {
+  const completed = completedPublication("on-demand");
+  const publication: CompletedRenderBatch = Object.freeze({
+    ...completed,
+    ascii: null,
+  });
+  const renderInputs: ConfiguredMermanOperationInput[] = [];
+  const calls: string[] = [];
+  const owner = createArtifactActionOwner({
+    getRenderState: () => publication,
+    getRuntimeState: () =>
+      readyRuntime(undefined, (input) => {
+        renderInputs.push(input);
+        return {
+          ascii: "ascii-on-demand",
+          error: null,
+          status: "success",
+        };
+      }),
+    io: recordingIo(calls),
+  });
+
+  await owner({
+    action: "copy-ascii",
+    publicationId: publication.snapshot.publicationId,
+  });
+  await owner({
+    action: "download-ascii",
+    publicationId: publication.snapshot.publicationId,
+  });
+
+  assert.equal(renderInputs.length, 1);
+  assert.equal(renderInputs[0], publication.snapshot.operation);
+  assert.deepEqual(calls, [
+    "copy-ascii:ascii-on-demand",
+    "download-ascii:ascii-on-demand:merman-diagram",
   ]);
 });
 
@@ -66,6 +106,7 @@ test("publishes ASCII actions independently from a failed Merman SVG", async () 
   const calls: string[] = [];
   const owner = createArtifactActionOwner({
     getRenderState: () => publication,
+    getRuntimeState: () => readyRuntime(),
     io: recordingIo(calls),
   });
 
@@ -92,6 +133,7 @@ test("rejects stale, missing, and updating publications before I/O", async () =>
   let state: RenderCoordinatorState = publication;
   const owner = createArtifactActionOwner({
     getRenderState: () => state,
+    getRuntimeState: () => readyRuntime(),
     io: recordingIo(calls),
   });
 
@@ -206,6 +248,7 @@ function completedPublication(
   id: RenderPublicationId = publicationId(1)
 ): CompletedRenderBatch {
   const operation = freezeRenderOperation({
+    asciiEnabled: true,
     compareEnabled: true,
     diagnosticsEnabled: false,
     layoutEnvironment: { containerWidth: 800, containerHeight: 600 },
@@ -268,12 +311,21 @@ function readyRuntime(
     error: null,
     renderTime: 1,
     status: "success",
-  })
+  }),
+  renderAscii: MermanDomainFacade["renderAscii"] = () => ({
+    ascii: "ascii",
+    error: null,
+    status: "success",
+  }),
 ): MermanRuntimeState {
   return {
     status: "ready",
     suspended: false,
-    facade: { packageVersion: "test-merman", render } as MermanDomainFacade,
+    facade: {
+      packageVersion: "test-merman",
+      render,
+      renderAscii,
+    } as MermanDomainFacade,
   };
 }
 

--- a/playground/src/runtime/artifact-actions.ts
+++ b/playground/src/runtime/artifact-actions.ts
@@ -77,6 +77,7 @@ export interface ArtifactActionIo {
 
 export interface ArtifactActionDependencies {
   readonly getRenderState: () => RenderCoordinatorState;
+  readonly getRuntimeState: () => MermanRuntimeState;
   readonly io: ArtifactActionIo;
 }
 
@@ -155,6 +156,7 @@ export function createExportTargetOwner({
 }
 
 export type ArtifactActionErrorCode =
+  | "ascii-render-failed"
   | "artifact-unavailable"
   | "invalid-command"
   | "publication-not-current"
@@ -193,10 +195,14 @@ type FrozenActionPlan =
 
 export function createArtifactActionOwner({
   getRenderState,
+  getRuntimeState,
   io,
 }: ArtifactActionDependencies): ArtifactActionOwner {
+  const renderedAscii = new WeakMap<CompletedRenderBatch, string>();
   return async (command: ArtifactActionCommand): Promise<void> => {
-    const plan = freezeActionPlan(command, getRenderState());
+    const plan = freezeActionPlan(command, getRenderState(), (publication) =>
+      currentAscii(publication, getRuntimeState, renderedAscii),
+    );
     switch (plan.action) {
       case "copy-ascii":
         await io.copyAscii(plan.ascii);
@@ -213,19 +219,20 @@ export function createArtifactActionOwner({
 
 function freezeActionPlan(
   command: ArtifactActionCommand,
-  renderState: RenderCoordinatorState
+  renderState: RenderCoordinatorState,
+  resolveAscii: (publication: CompletedRenderBatch) => string,
 ): FrozenActionPlan {
   const publication = currentPublication(renderState, command.publicationId);
   if (command.action === "copy-ascii") {
     return Object.freeze({
       action: command.action,
-      ascii: currentAscii(publication),
+      ascii: resolveAscii(publication),
     });
   }
   if (command.action === "download-ascii") {
     return Object.freeze({
       action: command.action,
-      ascii: currentAscii(publication),
+      ascii: resolveAscii(publication),
       filename: "merman-diagram",
     });
   }
@@ -254,11 +261,56 @@ function currentPublication(
   return state;
 }
 
-function currentAscii(publication: CompletedRenderBatch): string {
-  if (publication.ascii.status !== "success") {
+function currentAscii(
+  publication: CompletedRenderBatch,
+  getRuntimeState: () => MermanRuntimeState,
+  renderedAscii: WeakMap<CompletedRenderBatch, string>,
+): string {
+  if (publication.ascii?.status === "success") {
+    return publication.ascii.artifact;
+  }
+  if (publication.ascii !== null) {
     throw actionError("artifact-unavailable", "ASCII artifact is unavailable.");
   }
-  return publication.ascii.artifact;
+  const cached = renderedAscii.get(publication);
+  if (cached !== undefined) return cached;
+
+  const runtimeState = getRuntimeState();
+  if (runtimeState.status !== "ready") {
+    throw actionError(
+      "runtime-unavailable",
+      "Merman runtime is unavailable for ASCII rendering.",
+    );
+  }
+  if (
+    runtimeState.facade.packageVersion !==
+    publication.snapshot.operation.versions.merman
+  ) {
+    throw actionError(
+      "runtime-version-mismatch",
+      "The Merman runtime does not match this publication.",
+    );
+  }
+
+  let result;
+  try {
+    result = runtimeState.facade.renderAscii(publication.snapshot.operation);
+  } catch (error) {
+    throw new ArtifactActionError(
+      "ascii-render-failed",
+      projectError(error),
+      "render",
+    );
+  }
+  if (result.status === "failure") {
+    throw new ArtifactActionError(
+      "ascii-render-failed",
+      projectError(result.error),
+      "render",
+    );
+  }
+  renderedAscii.set(publication, result.ascii);
+  return result.ascii;
 }
 
 function currentSvg(

--- a/playground/src/runtime/merman-operation-input.ts
+++ b/playground/src/runtime/merman-operation-input.ts
@@ -56,6 +56,7 @@ export interface RenderOperationVersions {
 
 export interface FrozenRenderOperation
   extends ConfiguredMermanOperationInput {
+  readonly asciiEnabled: boolean;
   readonly compareEnabled: boolean;
   readonly configJson: string;
   readonly diagnosticsEnabled: boolean;
@@ -70,6 +71,7 @@ export interface FrozenRenderOperation
 }
 
 export interface FreezeRenderOperationInput {
+  readonly asciiEnabled: boolean;
   readonly compareEnabled: boolean;
   readonly diagnosticsEnabled: boolean;
   readonly layoutEnvironment: MermanLayoutEnvironment;
@@ -101,6 +103,7 @@ export function configuredMermanOperationInput(
 }
 
 export function freezeRenderOperation({
+  asciiEnabled,
   compareEnabled,
   diagnosticsEnabled,
   layoutEnvironment,
@@ -124,6 +127,7 @@ export function freezeRenderOperation({
   );
   return Object.freeze({
     ...configured,
+    asciiEnabled,
     compareEnabled,
     configJson: workspace.mermaidConfig,
     diagnosticsEnabled,
@@ -175,6 +179,7 @@ export function sameRenderOperation(
     (left.layoutEnvironment.screenAvailableWidth ?? null) ===
       (right.layoutEnvironment.screenAvailableWidth ?? null) &&
     left.svgPipeline === right.svgPipeline &&
+    left.asciiEnabled === right.asciiEnabled &&
     left.compareEnabled === right.compareEnabled &&
     left.diagnosticsEnabled === right.diagnosticsEnabled &&
     (left.viewport?.width ?? null) === (right.viewport?.width ?? null) &&

--- a/playground/src/runtime/merman.test.ts
+++ b/playground/src/runtime/merman.test.ts
@@ -262,6 +262,7 @@ test("coalesces callers and starts module import and WASM fetch together", async
 });
 
 function operation({
+  asciiEnabled = false,
   compareEnabled = true,
   diagnosticsEnabled = false,
   layoutEnvironment = {
@@ -273,6 +274,7 @@ function operation({
   viewport = { width: 800, height: 600 },
   workspace: workspaceOverrides = {},
 }: {
+  asciiEnabled?: boolean;
   compareEnabled?: boolean;
   diagnosticsEnabled?: boolean;
   layoutEnvironment?: FreezeRenderOperationInput["layoutEnvironment"];
@@ -286,6 +288,7 @@ function operation({
     ...workspaceOverrides,
   };
   return freezeRenderOperation({
+    asciiEnabled,
     compareEnabled,
     diagnosticsEnabled,
     layoutEnvironment,

--- a/playground/src/runtime/realm/channel-protocol.test.ts
+++ b/playground/src/runtime/realm/channel-protocol.test.ts
@@ -10,6 +10,7 @@ import {
   assertRealmInitBudget,
   createOneTimeRealmInitGate,
   createRealmToken,
+  realmEngineArtifactSourceBytes,
   utf8ByteLength,
   validateCompareRenderRequest,
   validateCompareRenderResponse,
@@ -166,6 +167,19 @@ test("engine artifact validation binds identity, bytes, and resource authority",
     }).resourceUrl,
     merman.resourceUrl
   );
+});
+
+test("validated engine artifacts own one reusable UTF-8 byte buffer", () => {
+  const artifact = validateRealmEngineArtifact(
+    ENGINE_ARTIFACT,
+    ENGINE_IDENTITY,
+  );
+  const first = realmEngineArtifactSourceBytes(artifact);
+  const second = realmEngineArtifactSourceBytes(artifact);
+
+  assert.equal(first, second);
+  assert.equal(first.byteLength, ENGINE_ARTIFACT.bytes);
+  assert.equal(new TextDecoder().decode(first), ENGINE_ARTIFACT.source);
 });
 
 test("one-time realm init gate rejects missing ports and replay", () => {

--- a/playground/src/runtime/realm/channel-protocol.ts
+++ b/playground/src/runtime/realm/channel-protocol.ts
@@ -64,6 +64,39 @@ export interface RealmEngineArtifact extends RealmEngineArtifactIdentity {
   readonly source: string;
 }
 
+const REALM_ENGINE_SOURCE_ENCODER = new TextEncoder();
+const REALM_ENGINE_SOURCE_BYTES = new WeakMap<
+  RealmEngineArtifact,
+  Uint8Array
+>();
+
+export function realmEngineArtifactSourceBytes(
+  artifact: RealmEngineArtifact,
+): Uint8Array {
+  const cached = REALM_ENGINE_SOURCE_BYTES.get(artifact);
+  if (cached) return cached;
+  if (
+    !Number.isSafeInteger(artifact.bytes) ||
+    artifact.bytes <= 0 ||
+    artifact.bytes > REALM_BUDGETS.engineArtifactBytes
+  ) {
+    throw new RealmProtocolError("Realm engine artifact byte length is invalid.");
+  }
+  const bytes = new Uint8Array(artifact.bytes);
+  const encoded = REALM_ENGINE_SOURCE_ENCODER.encodeInto(
+    artifact.source,
+    bytes,
+  );
+  if (
+    encoded.read !== artifact.source.length ||
+    encoded.written !== artifact.bytes
+  ) {
+    throw new RealmProtocolError("Realm engine artifact byte length is invalid.");
+  }
+  REALM_ENGINE_SOURCE_BYTES.set(artifact, bytes);
+  return bytes;
+}
+
 export interface RealmIdentity {
   readonly kind: RealmKind;
   readonly realmId: string;
@@ -366,9 +399,6 @@ export function validateRealmEngineArtifact(
     throw new RealmProtocolError("Realm engine artifact identity is invalid.");
   }
   const source = expectString(artifact.source, "engine artifact source");
-  if (utf8ByteLength(source) !== artifact.bytes) {
-    throw new RealmProtocolError("Realm engine artifact byte length is invalid.");
-  }
   const resourceUrl = artifact.resourceUrl;
   if (
     resourceUrl !== null &&
@@ -387,7 +417,7 @@ export function validateRealmEngineArtifact(
       "Realm engine resource URL does not match its generated policy."
     );
   }
-  return Object.freeze({
+  const validated = Object.freeze({
     schemaVersion: 1,
     id: artifact.id as RealmEngineArtifactId,
     bytes: artifact.bytes,
@@ -395,6 +425,8 @@ export function validateRealmEngineArtifact(
     resourceUrl: resourceUrl as string | null,
     source,
   });
+  realmEngineArtifactSourceBytes(validated);
+  return validated;
 }
 
 export function validateRealmReady(

--- a/playground/src/runtime/realm/engine-artifact-loader.test.ts
+++ b/playground/src/runtime/realm/engine-artifact-loader.test.ts
@@ -40,7 +40,7 @@ test("engine artifact loader construction rejects source tampering", async () =>
       { ...artifact, source: `${source}\n` },
       (module) => module
     ),
-    /digest is invalid/
+    /byte length is invalid|digest is invalid/
   );
 });
 

--- a/playground/src/runtime/realm/engine-artifact-loader.ts
+++ b/playground/src/runtime/realm/engine-artifact-loader.ts
@@ -1,6 +1,7 @@
 import { sha256 } from "@noble/hashes/sha2.js";
 import {
   RealmProtocolError,
+  realmEngineArtifactSourceBytes,
   type RealmEngineArtifact,
 } from "./channel-protocol.ts";
 
@@ -17,13 +18,14 @@ export async function verifyAndCreateRealmEngineModuleLoader<T extends object>(
   artifact: RealmEngineArtifact,
   validate: (module: Record<string, unknown>) => T
 ): Promise<() => Promise<T>> {
-  const actual = await sha256Hex(new TextEncoder().encode(artifact.source));
+  const sourceBytes = realmEngineArtifactSourceBytes(artifact);
+  const actual = await sha256Hex(sourceBytes);
   if (actual !== artifact.sha256) {
     throw new RealmProtocolError("Realm engine artifact digest is invalid.");
   }
   let modulePromise: Promise<T> | null = null;
   return () => {
-    modulePromise ??= importEngineModule(artifact, validate).catch((error) => {
+    modulePromise ??= importEngineModule(sourceBytes, validate).catch((error) => {
       modulePromise = null;
       throw error;
     });
@@ -49,12 +51,12 @@ export async function sha256Hex(
 }
 
 async function importEngineModule<T extends object>(
-  artifact: RealmEngineArtifact,
+  sourceBytes: Uint8Array,
   validate: (module: Record<string, unknown>) => T
 ): Promise<T> {
   installEphemeralStorageFacades();
   const url = URL.createObjectURL(
-    new Blob([artifact.source], { type: "text/javascript" })
+    new Blob([sourceBytes], { type: "text/javascript" })
   );
   try {
     const module = (await import(/* @vite-ignore */ url)) as Record<

--- a/playground/src/runtime/render-coordinator-browser.ts
+++ b/playground/src/runtime/render-coordinator-browser.ts
@@ -27,6 +27,7 @@ export const markRenderCoordinatorPresented = (
 export const pauseRenderCoordinator = () => renderCoordinator.pause();
 export const refreshRenderCoordinator = () => renderCoordinator.refresh();
 export const resumeRenderCoordinator = () => renderCoordinator.resume();
+export const setRenderCoordinatorEnabled = renderCoordinator.setEnabled;
 export const setRenderFeatures = renderCoordinator.setFeatures;
 export const setRenderCoordinatorInput = renderCoordinator.setInput;
 export const suspendRenderCoordinator = () => renderCoordinator.suspend();

--- a/playground/src/runtime/render-coordinator-browser.ts
+++ b/playground/src/runtime/render-coordinator-browser.ts
@@ -1,6 +1,10 @@
 import { compareMermaidRealmController } from "./mermaid-realm.ts";
 import { createRenderCoordinator } from "./render-coordinator.ts";
 import type { RenderPublicationId } from "./render-coordinator.ts";
+import { playgroundStartupBoundary } from "./startup-boundary.ts";
+
+const INITIAL_PREVIEW_PRESENTED_MARK = "merman:initial-preview-presented";
+let initialPreviewPresented = false;
 
 export const renderCoordinator = createRenderCoordinator({
   compare: compareMermaidRealmController,
@@ -12,7 +16,14 @@ export const markRenderCoordinatorPresented = (
   publicationId: RenderPublicationId,
   engine: "merman" | "mermaid",
   at: number
-) => renderCoordinator.markPresented(publicationId, engine, at);
+) => {
+  if (engine === "merman" && !initialPreviewPresented) {
+    initialPreviewPresented = true;
+    performance.mark(INITIAL_PREVIEW_PRESENTED_MARK, { startTime: at });
+    playgroundStartupBoundary.activate("preview-presented");
+  }
+  renderCoordinator.markPresented(publicationId, engine, at);
+};
 export const pauseRenderCoordinator = () => renderCoordinator.pause();
 export const refreshRenderCoordinator = () => renderCoordinator.refresh();
 export const resumeRenderCoordinator = () => renderCoordinator.resume();

--- a/playground/src/runtime/render-coordinator.test.ts
+++ b/playground/src/runtime/render-coordinator.test.ts
@@ -37,7 +37,11 @@ test("freezes one canonical environment into Merman and Mermaid inputs", async (
     },
   };
   const coordinator = createRenderCoordinator({ compare, debounceMs: 0 });
-  coordinator.setFeatures({ compareEnabled: true, diagnosticsEnabled: false });
+  coordinator.setFeatures({
+    asciiEnabled: false,
+    compareEnabled: true,
+    diagnosticsEnabled: false,
+  });
   coordinator.setInput(
     input(
       "canonical",
@@ -71,7 +75,11 @@ test("latest request publishes Merman and Mermaid as one coherent batch", async 
     compare,
     debounceMs: 0,
   });
-  coordinator.setFeatures({ compareEnabled: true, diagnosticsEnabled: false });
+  coordinator.setFeatures({
+    asciiEnabled: false,
+    compareEnabled: true,
+    diagnosticsEnabled: false,
+  });
 
   coordinator.setInput(input("first"));
   await waitFor(() => compare.calls.length === 1);
@@ -254,7 +262,11 @@ test("passes one frozen operation to every Merman projection", async () => {
     compare: fakeCompare([]),
     debounceMs: 0,
   });
-  coordinator.setFeatures({ compareEnabled: false, diagnosticsEnabled: true });
+  coordinator.setFeatures({
+    asciiEnabled: true,
+    compareEnabled: false,
+    diagnosticsEnabled: true,
+  });
   coordinator.setInput(
     input("one-operation", domainFacade, {
       presentationProfileId: "future-profile",
@@ -402,10 +414,68 @@ test("preserves producer SVG validation failures", async () => {
   assert.equal(state.merman.message, "Unsafe SVG.");
 });
 
+test("renders ASCII only after the feature is activated", async () => {
+  let asciiRenderCalls = 0;
+  let svgRenderCalls = 0;
+  const coordinator = createRenderCoordinator({
+    compare: fakeCompare([]),
+    debounceMs: 0,
+  });
+  const domainFacade: MermanDomainFacade = {
+    ...facade(),
+    render(operation) {
+      svgRenderCalls += 1;
+      return facade().render(operation);
+    },
+    renderAscii(operation) {
+      asciiRenderCalls += 1;
+      return facade().renderAscii(operation);
+    },
+  };
+
+  coordinator.setFeatures({
+    asciiEnabled: false,
+    compareEnabled: false,
+    diagnosticsEnabled: false,
+  });
+  coordinator.setInput(input("svg-only", domainFacade));
+  await waitFor(() => coordinator.store.getState().status === "success");
+  assert.equal(asciiRenderCalls, 0);
+  assert.equal(svgRenderCalls, 1);
+
+  coordinator.setFeatures({
+    asciiEnabled: true,
+    compareEnabled: false,
+    diagnosticsEnabled: false,
+  });
+  await waitFor(() => asciiRenderCalls === 1);
+  const state = coordinator.store.getState();
+  assert.equal(state.status, "success");
+  if (state.status !== "success") return;
+  assert.deepEqual(state.ascii, {
+    artifact: "svg-only",
+    status: "success",
+  });
+  assert.equal(svgRenderCalls, 2);
+
+  coordinator.setFeatures({
+    asciiEnabled: false,
+    compareEnabled: false,
+    diagnosticsEnabled: false,
+  });
+  assert.equal(coordinator.store.getState(), state);
+  assert.equal(svgRenderCalls, 2);
+});
+
 test("publishes ASCII independently when SVG validation fails", async () => {
   const coordinator = createRenderCoordinator({
     compare: fakeCompare([]),
     debounceMs: 0,
+  });
+  coordinator.setFeatures({
+    asciiEnabled: true,
+    compareEnabled: false,
+    diagnosticsEnabled: false,
   });
   coordinator.setInput(
     input("unsafe", {
@@ -441,6 +511,11 @@ test("publishes an explicit unsupported ASCII result without invoking the render
     compare: fakeCompare([]),
     debounceMs: 0,
   });
+  coordinator.setFeatures({
+    asciiEnabled: true,
+    compareEnabled: false,
+    diagnosticsEnabled: false,
+  });
   coordinator.setInput(
     input("pie", {
       ...facade(),
@@ -474,6 +549,11 @@ test("contains ASCII capability failures without failing the SVG publication", a
     compare: fakeCompare([]),
     debounceMs: 0,
   });
+  coordinator.setFeatures({
+    asciiEnabled: true,
+    compareEnabled: false,
+    diagnosticsEnabled: false,
+  });
   coordinator.setInput(
     input("flowchart", {
       ...facade(),
@@ -488,6 +568,7 @@ test("contains ASCII capability failures without failing the SVG publication", a
   assert.equal(state.status, "success");
   if (state.status !== "success") return;
   assert.equal(state.merman.status, "success");
+  assert.ok(state.ascii);
   assert.equal(state.ascii.status, "failure");
   if (state.ascii.status !== "failure") return;
   assert.equal(state.ascii.error.summary, "ASCII capability lookup failed.");
@@ -556,7 +637,11 @@ test("updating disables old pair and partial replaces the failed pane", async ()
     compare,
     debounceMs: 0,
   });
-  coordinator.setFeatures({ compareEnabled: true, diagnosticsEnabled: false });
+  coordinator.setFeatures({
+    asciiEnabled: false,
+    compareEnabled: true,
+    diagnosticsEnabled: false,
+  });
 
   coordinator.setInput(input("stable"));
   await waitFor(() => compare.calls.length === 1);
@@ -608,7 +693,11 @@ test("treats a Mermaid realm version mismatch as a protocol failure", async () =
     compare,
     debounceMs: 0,
   });
-  coordinator.setFeatures({ compareEnabled: true, diagnosticsEnabled: false });
+  coordinator.setFeatures({
+    asciiEnabled: false,
+    compareEnabled: true,
+    diagnosticsEnabled: false,
+  });
   coordinator.setInput(input("version-mismatch"));
   await waitFor(() => compare.calls.length === 1);
   realmResult.resolve({
@@ -632,7 +721,11 @@ test("marks each presented engine by rebuilding an immutable completed publicati
     compare,
     debounceMs: 0,
   });
-  coordinator.setFeatures({ compareEnabled: true, diagnosticsEnabled: false });
+  coordinator.setFeatures({
+    asciiEnabled: false,
+    compareEnabled: true,
+    diagnosticsEnabled: false,
+  });
   coordinator.setInput(input("presentation"));
   await waitFor(() => compare.calls.length === 1);
   realmResult.resolve(mermaidSuccess("presentation"));
@@ -673,7 +766,11 @@ test("a completed Mermaid failure replaces stale success without borrowing Merma
     compare,
     debounceMs: 0,
   });
-  coordinator.setFeatures({ compareEnabled: true, diagnosticsEnabled: false });
+  coordinator.setFeatures({
+    asciiEnabled: false,
+    compareEnabled: true,
+    diagnosticsEnabled: false,
+  });
 
   coordinator.setInput(input("stable"));
   await waitFor(() => compare.calls.length === 1);
@@ -710,7 +807,11 @@ test("pause waits for active work and resumes only the latest snapshot", async (
     compare,
     debounceMs: 0,
   });
-  coordinator.setFeatures({ compareEnabled: true, diagnosticsEnabled: false });
+  coordinator.setFeatures({
+    asciiEnabled: false,
+    compareEnabled: true,
+    diagnosticsEnabled: false,
+  });
   coordinator.setInput(input("active"));
   await waitFor(() => compare.calls.length === 1);
 
@@ -736,7 +837,11 @@ test("blank source and suspend reject every late completion", async () => {
     compare,
     debounceMs: 0,
   });
-  coordinator.setFeatures({ compareEnabled: true, diagnosticsEnabled: false });
+  coordinator.setFeatures({
+    asciiEnabled: false,
+    compareEnabled: true,
+    diagnosticsEnabled: false,
+  });
   coordinator.setInput(input("active"));
   await waitFor(() => compare.calls.length === 1);
 
@@ -757,7 +862,11 @@ test("request exceptions become typed failures and later work still runs", async
     compare,
     debounceMs: 0,
   });
-  coordinator.setFeatures({ compareEnabled: true, diagnosticsEnabled: false });
+  coordinator.setFeatures({
+    asciiEnabled: false,
+    compareEnabled: true,
+    diagnosticsEnabled: false,
+  });
   coordinator.setInput(input("throws", throwingFacade()));
   await waitFor(() => compare.calls.length === 1);
   rejected.reject(new Error("channel failed"));
@@ -794,7 +903,11 @@ test("synchronous compare exceptions become protocol failures and later work sti
     compare,
     debounceMs: 0,
   });
-  coordinator.setFeatures({ compareEnabled: true, diagnosticsEnabled: false });
+  coordinator.setFeatures({
+    asciiEnabled: false,
+    compareEnabled: true,
+    diagnosticsEnabled: false,
+  });
 
   coordinator.setInput(input("throws"));
   await waitFor(() => coordinator.store.getState().status === "partial");
@@ -818,11 +931,19 @@ test("superseding Compare work is cancelled before publishing the latest SVG bat
     compare,
     debounceMs: 0,
   });
-  coordinator.setFeatures({ compareEnabled: true, diagnosticsEnabled: false });
+  coordinator.setFeatures({
+    asciiEnabled: false,
+    compareEnabled: true,
+    diagnosticsEnabled: false,
+  });
   coordinator.setInput(input("compare"));
   await waitFor(() => compare.calls.length === 1);
 
-  coordinator.setFeatures({ compareEnabled: false, diagnosticsEnabled: false });
+  coordinator.setFeatures({
+    asciiEnabled: false,
+    compareEnabled: false,
+    diagnosticsEnabled: false,
+  });
   await waitFor(() => coordinator.store.getState().status === "success");
 
   const state = coordinator.store.getState();
@@ -888,6 +1009,11 @@ test("normalizes an unprojected ASCII failure without failing the SVG result", a
     compare: fakeCompare([]),
     debounceMs: 0,
   });
+  coordinator.setFeatures({
+    asciiEnabled: true,
+    compareEnabled: false,
+    diagnosticsEnabled: false,
+  });
   coordinator.setInput(
     input("ascii", {
       ...facade(),
@@ -908,6 +1034,7 @@ test("normalizes an unprojected ASCII failure without failing the SVG result", a
   const state = coordinator.store.getState();
   assert.equal(state.status, "success");
   if (state.status !== "success") return;
+  assert.ok(state.ascii);
   assert.equal(state.ascii.status, "failure");
   if (state.ascii.status !== "failure") return;
   assert.equal(
@@ -923,6 +1050,11 @@ test("publishes invalid configuration as an ASCII failure before detection", asy
   const coordinator = createRenderCoordinator({
     compare: fakeCompare([]),
     debounceMs: 0,
+  });
+  coordinator.setFeatures({
+    asciiEnabled: true,
+    compareEnabled: false,
+    diagnosticsEnabled: false,
   });
   coordinator.setInput(
     input(
@@ -950,6 +1082,7 @@ test("publishes invalid configuration as an ASCII failure before detection", asy
   if (state.status === "empty" || state.status === "pending" || state.status === "updating") {
     assert.fail(`Expected a completed render, received ${state.status}.`);
   }
+  assert.ok(state.ascii);
   assert.equal(state.ascii.status, "failure");
   if (state.ascii.status !== "failure") return;
   assert.match(state.ascii.error.summary, /JSON|configuration/i);

--- a/playground/src/runtime/render-coordinator.test.ts
+++ b/playground/src/runtime/render-coordinator.test.ts
@@ -3,9 +3,11 @@ import test from "node:test";
 import { projectNavigableInlineSvg } from "./render-artifact.ts";
 
 import type { MermanDomainFacade } from "./merman-core.ts";
-import type {
-  ConfiguredMermanOperationInput,
-  FrozenRenderOperation,
+import {
+  freezeRenderOperation,
+  type FreezeRenderOperationInput,
+  type ConfiguredMermanOperationInput,
+  type FrozenRenderOperation,
 } from "./merman-operation-input.ts";
 import {
   DEFAULT_WORKSPACE_SNAPSHOT,
@@ -216,6 +218,32 @@ test("deduplicates only when both the operation and facade authority are unchang
   coordinator.setInput(input("stable", replacementFacade));
   await waitFor(() => replacementRenderCalls === 1);
   assert.equal(firstRenderCalls, 1);
+});
+
+test("freezes only the latest input after the debounce window", async () => {
+  const frozenSources: string[] = [];
+  const coordinator = createRenderCoordinator({
+    compare: fakeCompare([]),
+    debounceMs: 10,
+    freezeOperation(input: FreezeRenderOperationInput) {
+      frozenSources.push(input.workspace.code);
+      return freezeRenderOperation(input);
+    },
+  });
+
+  coordinator.setInput(input("first"));
+  coordinator.setInput(input("second"));
+  coordinator.setInput(input("third"));
+
+  assert.deepEqual(frozenSources, []);
+  const pending = coordinator.store.getState();
+  assert.equal(pending.status, "pending");
+  await waitFor(() => coordinator.store.getState().status === "success");
+  assert.deepEqual(frozenSources, ["third"]);
+  const completed = coordinator.store.getState();
+  assert.equal(completed.status, "success");
+  if (completed.status !== "success") return;
+  assert.equal(completed.snapshot.operation.source, "third");
 });
 
 test("passes one frozen operation to every Merman projection", async () => {

--- a/playground/src/runtime/render-coordinator.test.ts
+++ b/playground/src/runtime/render-coordinator.test.ts
@@ -246,6 +246,41 @@ test("freezes only the latest input after the debounce window", async () => {
   assert.equal(completed.snapshot.operation.source, "third");
 });
 
+test("retains only the latest input while rendering is disabled", async () => {
+  const renderedSources: string[] = [];
+  const domainFacade: MermanDomainFacade = {
+    ...facade(),
+    render(operation) {
+      renderedSources.push(operation.source);
+      return facade().render(operation);
+    },
+  };
+  const coordinator = createRenderCoordinator({
+    compare: fakeCompare([]),
+    debounceMs: 0,
+  });
+
+  coordinator.setEnabled(false);
+  coordinator.setInput(input("hidden-first", domainFacade));
+  coordinator.setInput(input("hidden-latest", domainFacade));
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  assert.deepEqual(renderedSources, []);
+  assert.equal(coordinator.store.getState().status, "empty");
+
+  coordinator.setEnabled(true);
+  await waitFor(() => renderedSources.length === 1);
+  assert.deepEqual(renderedSources, ["hidden-latest"]);
+  const completed = coordinator.store.getState();
+  assert.equal(completed.status, "success");
+  if (completed.status !== "success") return;
+  assert.equal(completed.snapshot.operation.source, "hidden-latest");
+
+  coordinator.setEnabled(false);
+  coordinator.setInput(input("hidden-again", domainFacade));
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  assert.deepEqual(renderedSources, ["hidden-latest"]);
+});
+
 test("passes one frozen operation to every Merman projection", async () => {
   const operations: FrozenRenderOperation[] = [];
   const capture = (input: ConfiguredMermanOperationInput) => {

--- a/playground/src/runtime/render-coordinator.test.ts
+++ b/playground/src/runtime/render-coordinator.test.ts
@@ -952,6 +952,30 @@ test("synchronous compare exceptions become protocol failures and later work sti
   assert.equal(renderCalls, 2);
 });
 
+test("leaving a completed Compare publication resets its retained realm", async () => {
+  const compare = fakeCompare([Promise.resolve(mermaidSuccess("complete"))]);
+  const coordinator = createRenderCoordinator({
+    compare,
+    debounceMs: 0,
+  });
+  coordinator.setFeatures({
+    asciiEnabled: false,
+    compareEnabled: true,
+    diagnosticsEnabled: false,
+  });
+  coordinator.setInput(input("complete"));
+  await waitFor(() => coordinator.store.getState().status === "success");
+  assert.equal(compare.resetCalls, 0);
+
+  coordinator.setFeatures({
+    asciiEnabled: false,
+    compareEnabled: false,
+    diagnosticsEnabled: false,
+  });
+  assert.equal(compare.resetCalls, 1);
+  await waitFor(() => coordinator.store.getState().status === "success");
+});
+
 test("superseding Compare work is cancelled before publishing the latest SVG batch", async () => {
   const pending = deferred<MermaidRealmRenderResult>();
   const compare = fakeCompare([pending.promise]);

--- a/playground/src/runtime/render-coordinator.test.ts
+++ b/playground/src/runtime/render-coordinator.test.ts
@@ -286,6 +286,62 @@ test("retains only the latest input while rendering is disabled", async () => {
   assert.deepEqual(renderedSources, ["hidden-latest"]);
 });
 
+test("hidden input changes stale the visible publication without reading it", async () => {
+  const coordinator = createRenderCoordinator({
+    compare: fakeCompare([]),
+    debounceMs: 0,
+  });
+  coordinator.setInput(input("visible"));
+  await waitFor(() => coordinator.store.getState().status === "success");
+  const visible = coordinator.store.getState();
+  assert.equal(visible.status, "success");
+  if (visible.status !== "success") return;
+
+  coordinator.setEnabled(false);
+  let sourceReads = 0;
+  const hiddenWorkspace = {
+    ...DEFAULT_WORKSPACE_SNAPSHOT,
+    get code() {
+      sourceReads += 1;
+      return "hidden-latest";
+    },
+  };
+  coordinator.setInput({
+    facade: facade(),
+    renderViewport: captureRenderViewport(),
+    workspace: hiddenWorkspace,
+  });
+
+  const stale = coordinator.store.getState();
+  assert.equal(stale.status, "updating");
+  if (stale.status !== "updating") return;
+  assert.equal(stale.previous, visible);
+  assert.notEqual(stale.snapshot.publicationId, visible.snapshot.publicationId);
+  assert.equal(sourceReads, 0);
+
+  const newestWorkspace = {
+    ...DEFAULT_WORKSPACE_SNAPSHOT,
+    get code() {
+      sourceReads += 1;
+      return "hidden-newest";
+    },
+  };
+  coordinator.setInput({
+    facade: facade(),
+    renderViewport: captureRenderViewport(),
+    workspace: newestWorkspace,
+  });
+  assert.equal(coordinator.store.getState(), stale);
+  assert.equal(sourceReads, 0);
+
+  coordinator.setEnabled(true);
+  await waitFor(() => coordinator.store.getState().status === "success");
+  const latest = coordinator.store.getState();
+  assert.equal(latest.status, "success");
+  if (latest.status !== "success") return;
+  assert.equal(latest.snapshot.operation.source, "hidden-newest");
+});
+
 test("does not inspect hidden workspace source until rendering resumes", async () => {
   let sourceReads = 0;
   const workspace = {
@@ -512,8 +568,9 @@ test("preserves producer SVG validation failures", async () => {
 test("renders ASCII only after the feature is activated", async () => {
   let asciiRenderCalls = 0;
   let svgRenderCalls = 0;
+  const compare = fakeCompare([Promise.resolve(mermaidSuccess("svg-only"))]);
   const coordinator = createRenderCoordinator({
-    compare: fakeCompare([]),
+    compare,
     debounceMs: 0,
   });
   const domainFacade: MermanDomainFacade = {
@@ -530,18 +587,25 @@ test("renders ASCII only after the feature is activated", async () => {
 
   coordinator.setFeatures({
     asciiEnabled: false,
-    compareEnabled: false,
-    diagnosticsEnabled: false,
+    compareEnabled: true,
+    diagnosticsEnabled: true,
   });
-  coordinator.setInput(input("svg-only", domainFacade));
+  coordinator.setInput(
+    input("svg-only", domainFacade, {
+      presentationProfileId: "future-profile",
+    }),
+  );
   await waitFor(() => coordinator.store.getState().status === "success");
+  const initial = coordinator.store.getState();
+  assert.equal(initial.status, "success");
+  if (initial.status !== "success") return;
   assert.equal(asciiRenderCalls, 0);
   assert.equal(svgRenderCalls, 1);
 
   coordinator.setFeatures({
     asciiEnabled: true,
-    compareEnabled: false,
-    diagnosticsEnabled: false,
+    compareEnabled: true,
+    diagnosticsEnabled: true,
   });
   await waitFor(() => asciiRenderCalls === 1);
   const state = coordinator.store.getState();
@@ -551,15 +615,21 @@ test("renders ASCII only after the feature is activated", async () => {
     artifact: "svg-only",
     status: "success",
   });
-  assert.equal(svgRenderCalls, 2);
+  assert.equal(svgRenderCalls, 1);
+  assert.notEqual(state.snapshot.publicationId, initial.snapshot.publicationId);
+  assert.equal(state.merman, initial.merman);
+  assert.equal(state.mermaid, initial.mermaid);
+  assert.equal(state.diagnostics, initial.diagnostics);
+  assert.equal(state.svgPlan, initial.svgPlan);
+  assert.equal(compare.calls.length, 1);
 
   coordinator.setFeatures({
     asciiEnabled: false,
-    compareEnabled: false,
-    diagnosticsEnabled: false,
+    compareEnabled: true,
+    diagnosticsEnabled: true,
   });
   assert.equal(coordinator.store.getState(), state);
-  assert.equal(svgRenderCalls, 2);
+  assert.equal(svgRenderCalls, 1);
 });
 
 test("publishes ASCII independently when SVG validation fails", async () => {

--- a/playground/src/runtime/render-coordinator.test.ts
+++ b/playground/src/runtime/render-coordinator.test.ts
@@ -276,9 +276,41 @@ test("retains only the latest input while rendering is disabled", async () => {
   assert.equal(completed.snapshot.operation.source, "hidden-latest");
 
   coordinator.setEnabled(false);
+  coordinator.setEnabled(true);
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  assert.deepEqual(renderedSources, ["hidden-latest"]);
+
+  coordinator.setEnabled(false);
   coordinator.setInput(input("hidden-again", domainFacade));
   await new Promise((resolve) => setTimeout(resolve, 5));
   assert.deepEqual(renderedSources, ["hidden-latest"]);
+});
+
+test("does not inspect hidden workspace source until rendering resumes", async () => {
+  let sourceReads = 0;
+  const workspace = {
+    ...DEFAULT_WORKSPACE_SNAPSHOT,
+    get code() {
+      sourceReads += 1;
+      return "hidden-source";
+    },
+  };
+  const coordinator = createRenderCoordinator({
+    compare: fakeCompare([]),
+    debounceMs: 0,
+  });
+
+  coordinator.setEnabled(false);
+  coordinator.setInput({
+    facade: facade(),
+    renderViewport: captureRenderViewport(),
+    workspace,
+  });
+  assert.equal(sourceReads, 0);
+
+  coordinator.setEnabled(true);
+  await waitFor(() => coordinator.store.getState().status === "success");
+  assert.ok(sourceReads > 0);
 });
 
 test("passes one frozen operation to every Merman projection", async () => {

--- a/playground/src/runtime/render-coordinator.ts
+++ b/playground/src/runtime/render-coordinator.ts
@@ -197,6 +197,7 @@ export interface RenderCoordinator {
   pause(): Promise<() => void>;
   refresh(): void;
   resume(): void;
+  setEnabled(enabled: boolean): void;
   setFeatures(features: RenderFeatures): void;
   setInput(input: RenderCoordinatorInput): void;
   suspend(): void;
@@ -240,6 +241,7 @@ export function createRenderCoordinator({
 }: RenderCoordinatorOptions): RenderCoordinator {
   const store = createStore<RenderCoordinatorState>(() => EMPTY_STATE);
   let disposed = false;
+  let enabled = true;
   let suspended = false;
   let pauseCount = 0;
   let asciiEnabled = false;
@@ -285,6 +287,7 @@ export function createRenderCoordinator({
       replaceState(EMPTY_STATE);
       return;
     }
+    if (!enabled) return;
 
     const operationInput = freezeScheduledOperationInput({
       asciiEnabled,
@@ -334,7 +337,14 @@ export function createRenderCoordinator({
 
   const scheduleLatest = (immediate: boolean) => {
     clearTimer();
-    if (disposed || suspended || pauseCount > 0 || active || !latest) {
+    if (
+      disposed ||
+      !enabled ||
+      suspended ||
+      pauseCount > 0 ||
+      active ||
+      !latest
+    ) {
       return;
     }
     const remaining = immediate
@@ -343,7 +353,9 @@ export function createRenderCoordinator({
     timer = setTimeout(() => {
       timer = null;
       const request = latest;
-      if (!request || disposed || suspended || pauseCount > 0) return;
+      if (!request || disposed || !enabled || suspended || pauseCount > 0) {
+        return;
+      }
       const activeRequestForExecution: ActiveRequest = Object.freeze({
         facade: request.facade,
         snapshot: Object.freeze({
@@ -356,6 +368,7 @@ export function createRenderCoordinator({
         .then((completed) => {
           if (
             !disposed &&
+            enabled &&
             !suspended &&
             pauseCount === 0 &&
             latest?.publicationId === request.publicationId
@@ -418,6 +431,21 @@ export function createRenderCoordinator({
   const setInput = (input: RenderCoordinatorInput) => {
     currentInput = input;
     scheduleCurrent(false);
+  };
+  const setEnabled = (nextEnabled: boolean) => {
+    if (disposed || enabled === nextEnabled) return;
+    enabled = nextEnabled;
+    if (enabled) {
+      scheduleCurrent(true, true);
+      return;
+    }
+
+    clearTimer();
+    latest = null;
+    if (!cancelActiveCompare()) compare.reset();
+    const state = store.getState();
+    if (state.status === "pending") replaceState(EMPTY_STATE);
+    if (state.status === "updating") replaceState(state.previous);
   };
   const setFeatures = (features: RenderFeatures) => {
     const leavingCompare = compareEnabled && !features.compareEnabled;
@@ -543,6 +571,7 @@ export function createRenderCoordinator({
     pause,
     refresh,
     resume,
+    setEnabled,
     setFeatures,
     setInput,
     suspend,

--- a/playground/src/runtime/render-coordinator.ts
+++ b/playground/src/runtime/render-coordinator.ts
@@ -249,6 +249,7 @@ export function createRenderCoordinator({
   let diagnosticsEnabled = false;
   let requestSequence = 0;
   let currentInput: RenderCoordinatorInput | null = null;
+  let renderRequiredWhenEnabled = false;
   let latest: ScheduledRequest | null = null;
   let timer: ReturnType<typeof setTimeout> | null = null;
   let active: Promise<void> | null = null;
@@ -277,7 +278,7 @@ export function createRenderCoordinator({
   };
 
   const scheduleCurrent = (force: boolean, immediate = false) => {
-    if (disposed || !currentInput) return;
+    if (disposed || !enabled || !currentInput) return;
     const { facade, renderViewport, workspace } = currentInput;
     if (!facade || !workspace.code.trim()) {
       cancelActiveCompare();
@@ -287,8 +288,6 @@ export function createRenderCoordinator({
       replaceState(EMPTY_STATE);
       return;
     }
-    if (!enabled) return;
-
     const operationInput = freezeScheduledOperationInput({
       asciiEnabled,
       compareEnabled,
@@ -430,13 +429,18 @@ export function createRenderCoordinator({
 
   const setInput = (input: RenderCoordinatorInput) => {
     currentInput = input;
+    if (!enabled) {
+      renderRequiredWhenEnabled = true;
+      return;
+    }
     scheduleCurrent(false);
   };
   const setEnabled = (nextEnabled: boolean) => {
     if (disposed || enabled === nextEnabled) return;
     enabled = nextEnabled;
     if (enabled) {
-      scheduleCurrent(true, true);
+      if (renderRequiredWhenEnabled) scheduleCurrent(true, true);
+      renderRequiredWhenEnabled = false;
       return;
     }
 
@@ -444,6 +448,8 @@ export function createRenderCoordinator({
     latest = null;
     if (!cancelActiveCompare()) compare.reset();
     const state = store.getState();
+    renderRequiredWhenEnabled =
+      state.status === "pending" || state.status === "updating";
     if (state.status === "pending") replaceState(EMPTY_STATE);
     if (state.status === "updating") replaceState(state.previous);
   };
@@ -465,9 +471,17 @@ export function createRenderCoordinator({
     compareEnabled = features.compareEnabled;
     diagnosticsEnabled = features.diagnosticsEnabled;
     if (!shouldSchedule) return;
+    if (!enabled) {
+      renderRequiredWhenEnabled = true;
+      return;
+    }
     scheduleCurrent(true, true);
   };
   const refresh = () => {
+    if (!enabled) {
+      renderRequiredWhenEnabled = true;
+      return;
+    }
     scheduleCurrent(true, true);
   };
   const pause = async (): Promise<() => void> => {
@@ -506,6 +520,7 @@ export function createRenderCoordinator({
     clearTimer();
     latest = null;
     currentInput = null;
+    renderRequiredWhenEnabled = false;
     compare.dispose();
     replaceState(EMPTY_STATE);
   };

--- a/playground/src/runtime/render-coordinator.ts
+++ b/playground/src/runtime/render-coordinator.ts
@@ -113,7 +113,7 @@ export type MermanAsciiBatchResult =
     };
 
 interface CompletedBatchBase {
-  readonly ascii: MermanAsciiBatchResult;
+  readonly ascii: MermanAsciiBatchResult | null;
   readonly detection: DiagramDetectionFacts;
   readonly diagnostics: RenderDiagnostics | null;
   readonly publishedAt: number;
@@ -199,6 +199,7 @@ export interface RenderCoordinator {
 }
 
 export interface RenderFeatures {
+  readonly asciiEnabled: boolean;
   readonly compareEnabled: boolean;
   readonly diagnosticsEnabled: boolean;
 }
@@ -227,6 +228,7 @@ export function createRenderCoordinator({
   let disposed = false;
   let suspended = false;
   let pauseCount = 0;
+  let asciiEnabled = false;
   let compareEnabled = false;
   let diagnosticsEnabled = false;
   let requestSequence = 0;
@@ -271,6 +273,7 @@ export function createRenderCoordinator({
     }
 
     const operation = freezeRenderOperation({
+      asciiEnabled,
       compareEnabled,
       diagnosticsEnabled,
       layoutEnvironment: renderViewport.layoutEnvironment,
@@ -368,7 +371,9 @@ export function createRenderCoordinator({
       externalRequirements,
     );
     const merman = renderMerman(facade, operation);
-    const ascii = renderMermanAscii(facade, operation, detection);
+    const ascii = operation.asciiEnabled
+      ? renderMermanAscii(facade, operation, detection)
+      : null;
     const diagnostics = operation.diagnosticsEnabled
       ? collectDiagnostics(facade, operation, now)
       : null;
@@ -393,14 +398,21 @@ export function createRenderCoordinator({
     scheduleCurrent(false);
   };
   const setFeatures = (features: RenderFeatures) => {
+    const shouldSchedule =
+      compareEnabled !== features.compareEnabled ||
+      diagnosticsEnabled !== features.diagnosticsEnabled ||
+      (!asciiEnabled && features.asciiEnabled);
     if (
+      asciiEnabled === features.asciiEnabled &&
       compareEnabled === features.compareEnabled &&
       diagnosticsEnabled === features.diagnosticsEnabled
     ) {
       return;
     }
+    asciiEnabled = features.asciiEnabled;
     compareEnabled = features.compareEnabled;
     diagnosticsEnabled = features.diagnosticsEnabled;
+    if (!shouldSchedule) return;
     scheduleCurrent(true, true);
   };
   const refresh = () => {
@@ -732,7 +744,7 @@ function classifyBatch(
   diagnostics: RenderDiagnostics | null,
   svgPlan: SvgPlanResult | null,
   merman: MermanBatchResult,
-  ascii: MermanAsciiBatchResult,
+  ascii: MermanAsciiBatchResult | null,
   mermaid: MermaidBatchResult | null,
   publishedAt: number,
 ): CompletedRenderBatch {

--- a/playground/src/runtime/render-coordinator.ts
+++ b/playground/src/runtime/render-coordinator.ts
@@ -12,7 +12,7 @@ import type {
 } from "./merman-core.ts";
 import {
   freezeRenderOperation,
-  sameRenderOperation,
+  type FreezeRenderOperationInput,
   type FrozenRenderOperation,
 } from "./merman-operation-input.ts";
 import type { WorkspaceSnapshot } from "../lib/workspace-snapshot.ts";
@@ -40,6 +40,10 @@ export interface RenderCoordinatorInput {
 
 export interface FrozenRenderSnapshot {
   readonly operation: FrozenRenderOperation;
+  readonly publicationId: RenderPublicationId;
+}
+
+export interface ScheduledRenderSnapshot {
   readonly publicationId: RenderPublicationId;
 }
 
@@ -170,12 +174,12 @@ export type RenderCoordinatorState =
   | { readonly status: "empty" }
   | {
       readonly status: "pending";
-      readonly snapshot: FrozenRenderSnapshot;
+      readonly snapshot: ScheduledRenderSnapshot;
     }
   | {
       readonly status: "updating";
       readonly previous: CompletedRenderBatch;
-      readonly snapshot: FrozenRenderSnapshot;
+      readonly snapshot: ScheduledRenderSnapshot;
     }
   | CompletedRenderBatch;
 
@@ -207,12 +211,21 @@ export interface RenderFeatures {
 export interface RenderCoordinatorOptions {
   readonly compare: MermaidRealmController;
   readonly debounceMs?: number;
+  readonly freezeOperation?: (
+    input: FreezeRenderOperationInput,
+  ) => FrozenRenderOperation;
   readonly now?: () => number;
 }
 
 interface ScheduledRequest {
   readonly facade: MermanDomainFacade;
+  readonly operationInput: FreezeRenderOperationInput;
+  readonly publicationId: RenderPublicationId;
   readonly scheduledAt: number;
+}
+
+interface ActiveRequest {
+  readonly facade: MermanDomainFacade;
   readonly snapshot: FrozenRenderSnapshot;
 }
 
@@ -222,6 +235,7 @@ const EMPTY_STATE: RenderCoordinatorState = Object.freeze({
 export function createRenderCoordinator({
   compare,
   debounceMs = 300,
+  freezeOperation = freezeRenderOperation,
   now = () => performance.now(),
 }: RenderCoordinatorOptions): RenderCoordinator {
   const store = createStore<RenderCoordinatorState>(() => EMPTY_STATE);
@@ -236,7 +250,7 @@ export function createRenderCoordinator({
   let latest: ScheduledRequest | null = null;
   let timer: ReturnType<typeof setTimeout> | null = null;
   let active: Promise<void> | null = null;
-  let activeRequest: ScheduledRequest | null = null;
+  let activeRequest: ActiveRequest | null = null;
 
   const replaceState = (state: RenderCoordinatorState) => {
     store.setState(state, true);
@@ -272,7 +286,7 @@ export function createRenderCoordinator({
       return;
     }
 
-    const operation = freezeRenderOperation({
+    const operationInput = freezeScheduledOperationInput({
       asciiEnabled,
       compareEnabled,
       diagnosticsEnabled,
@@ -287,7 +301,7 @@ export function createRenderCoordinator({
     if (
       !force &&
       latest !== null &&
-      sameRenderOperation(latest.snapshot.operation, operation) &&
+      sameScheduledOperationInput(latest.operationInput, operationInput) &&
       latest.facade === facade
     ) {
       return;
@@ -295,14 +309,15 @@ export function createRenderCoordinator({
 
     cancelActiveCompare();
     requestSequence += 1;
-    const snapshot: FrozenRenderSnapshot = Object.freeze({
-      operation,
-      publicationId: requestSequence as RenderPublicationId,
+    const publicationId = requestSequence as RenderPublicationId;
+    const snapshot: ScheduledRenderSnapshot = Object.freeze({
+      publicationId,
     });
     latest = {
       facade,
+      operationInput,
+      publicationId,
       scheduledAt: now(),
-      snapshot,
     };
     const previous = previousCompleted();
     replaceState(
@@ -329,14 +344,21 @@ export function createRenderCoordinator({
       timer = null;
       const request = latest;
       if (!request || disposed || suspended || pauseCount > 0) return;
-      activeRequest = request;
-      const execution = execute(request)
+      const activeRequestForExecution: ActiveRequest = Object.freeze({
+        facade: request.facade,
+        snapshot: Object.freeze({
+          operation: freezeOperation(request.operationInput),
+          publicationId: request.publicationId,
+        }),
+      });
+      activeRequest = activeRequestForExecution;
+      const execution = execute(activeRequestForExecution)
         .then((completed) => {
           if (
             !disposed &&
             !suspended &&
             pauseCount === 0 &&
-            latest?.snapshot.publicationId === request.snapshot.publicationId
+            latest?.publicationId === request.publicationId
           ) {
             replaceState(completed);
           }
@@ -348,7 +370,7 @@ export function createRenderCoordinator({
           }
           if (
             latest &&
-            latest.snapshot.publicationId !== request.snapshot.publicationId
+            latest.publicationId !== request.publicationId
           ) {
             scheduleLatest(false);
           }
@@ -358,7 +380,7 @@ export function createRenderCoordinator({
   };
 
   const execute = async (
-    request: ScheduledRequest,
+    request: ActiveRequest,
   ): Promise<CompletedRenderBatch> => {
     const { facade, snapshot } = request;
     const operation = snapshot.operation;
@@ -523,6 +545,58 @@ export function createRenderCoordinator({
     setInput,
     suspend,
   };
+}
+
+function freezeScheduledOperationInput({
+  asciiEnabled,
+  compareEnabled,
+  diagnosticsEnabled,
+  layoutEnvironment,
+  versions,
+  viewport,
+  workspace,
+}: FreezeRenderOperationInput): FreezeRenderOperationInput {
+  return Object.freeze({
+    asciiEnabled,
+    compareEnabled,
+    diagnosticsEnabled,
+    layoutEnvironment: Object.freeze({ ...layoutEnvironment }),
+    versions: Object.freeze({ ...versions }),
+    viewport: viewport ? Object.freeze({ ...viewport }) : null,
+    workspace: Object.freeze({ ...workspace }),
+  });
+}
+
+function sameScheduledOperationInput(
+  left: FreezeRenderOperationInput,
+  right: FreezeRenderOperationInput,
+): boolean {
+  return (
+    left.asciiEnabled === right.asciiEnabled &&
+    left.compareEnabled === right.compareEnabled &&
+    left.diagnosticsEnabled === right.diagnosticsEnabled &&
+    left.layoutEnvironment.containerWidth ===
+      right.layoutEnvironment.containerWidth &&
+    left.layoutEnvironment.containerHeight ===
+      right.layoutEnvironment.containerHeight &&
+    (left.layoutEnvironment.screenAvailableWidth ?? null) ===
+      (right.layoutEnvironment.screenAvailableWidth ?? null) &&
+    left.versions.merman === right.versions.merman &&
+    left.versions.mermaid === right.versions.mermaid &&
+    (left.viewport?.width ?? null) === (right.viewport?.width ?? null) &&
+    (left.viewport?.height ?? null) === (right.viewport?.height ?? null) &&
+    left.workspace.code === right.workspace.code &&
+    left.workspace.mermaidConfig === right.workspace.mermaidConfig &&
+    left.workspace.diagramTheme === right.workspace.diagramTheme &&
+    left.workspace.presentationThemePresetId ===
+      right.workspace.presentationThemePresetId &&
+    left.workspace.presentationProfileId ===
+      right.workspace.presentationProfileId &&
+    left.workspace.svgPipeline === right.workspace.svgPipeline &&
+    left.workspace.textMeasurementMode ===
+      right.workspace.textMeasurementMode &&
+    left.workspace.diagramFont === right.workspace.diagramFont
+  );
 }
 
 function collectSvgPlan(

--- a/playground/src/runtime/render-coordinator.ts
+++ b/playground/src/runtime/render-coordinator.ts
@@ -430,11 +430,24 @@ export function createRenderCoordinator({
   const setInput = (input: RenderCoordinatorInput) => {
     currentInput = input;
     if (!enabled) {
+      markCompletedInputStale();
       renderRequiredWhenEnabled = true;
       return;
     }
     scheduleCurrent(false);
   };
+
+  const markCompletedInputStale = () => {
+    const state = store.getState();
+    if (!isCompletedRenderState(state)) return;
+
+    requestSequence += 1;
+    const snapshot: ScheduledRenderSnapshot = Object.freeze({
+      publicationId: requestSequence as RenderPublicationId,
+    });
+    replaceState({ status: "updating", previous: state, snapshot });
+  };
+
   const setEnabled = (nextEnabled: boolean) => {
     if (disposed || enabled === nextEnabled) return;
     enabled = nextEnabled;
@@ -451,10 +464,68 @@ export function createRenderCoordinator({
     renderRequiredWhenEnabled =
       state.status === "pending" || state.status === "updating";
     if (state.status === "pending") replaceState(EMPTY_STATE);
-    if (state.status === "updating") replaceState(state.previous);
   };
+
+  const activateAsciiFromCompleted = (): boolean => {
+    const state = store.getState();
+    if (
+      !enabled ||
+      !isCompletedRenderState(state) ||
+      !latest ||
+      latest.publicationId !== state.snapshot.publicationId ||
+      active ||
+      suspended ||
+      pauseCount > 0 ||
+      state.snapshot.operation.asciiEnabled
+    ) {
+      return false;
+    }
+
+    const publicationId = ++requestSequence as RenderPublicationId;
+    const operation: FrozenRenderOperation = Object.freeze({
+      ...state.snapshot.operation,
+      asciiEnabled: true,
+    });
+    const snapshot: FrozenRenderSnapshot = Object.freeze({
+      operation,
+      publicationId,
+    });
+    latest = {
+      ...latest,
+      operationInput: Object.freeze({
+        ...latest.operationInput,
+        asciiEnabled: true,
+      }),
+      publicationId,
+    };
+    replaceState({
+      status: "updating",
+      previous: state,
+      snapshot: Object.freeze({ publicationId }),
+    });
+    const ascii = renderMermanAscii(latest.facade, operation, state.detection);
+    replaceState(
+      classifyBatch(
+        snapshot,
+        state.detection,
+        state.diagnostics,
+        state.svgPlan,
+        state.merman,
+        ascii,
+        state.mermaid,
+        now(),
+      ),
+    );
+    return true;
+  };
+
   const setFeatures = (features: RenderFeatures) => {
     const leavingCompare = compareEnabled && !features.compareEnabled;
+    const activatingAsciiOnly =
+      !asciiEnabled &&
+      features.asciiEnabled &&
+      compareEnabled === features.compareEnabled &&
+      diagnosticsEnabled === features.diagnosticsEnabled;
     const shouldSchedule =
       compareEnabled !== features.compareEnabled ||
       diagnosticsEnabled !== features.diagnosticsEnabled ||
@@ -471,6 +542,9 @@ export function createRenderCoordinator({
     compareEnabled = features.compareEnabled;
     diagnosticsEnabled = features.diagnosticsEnabled;
     if (!shouldSchedule) return;
+    if (activatingAsciiOnly && activateAsciiFromCompleted()) {
+      return;
+    }
     if (!enabled) {
       renderRequiredWhenEnabled = true;
       return;

--- a/playground/src/runtime/render-coordinator.ts
+++ b/playground/src/runtime/render-coordinator.ts
@@ -420,6 +420,7 @@ export function createRenderCoordinator({
     scheduleCurrent(false);
   };
   const setFeatures = (features: RenderFeatures) => {
+    const leavingCompare = compareEnabled && !features.compareEnabled;
     const shouldSchedule =
       compareEnabled !== features.compareEnabled ||
       diagnosticsEnabled !== features.diagnosticsEnabled ||
@@ -431,6 +432,7 @@ export function createRenderCoordinator({
     ) {
       return;
     }
+    if (leavingCompare && !cancelActiveCompare()) compare.reset();
     asciiEnabled = features.asciiEnabled;
     compareEnabled = features.compareEnabled;
     diagnosticsEnabled = features.diagnosticsEnabled;

--- a/playground/src/runtime/startup-boundary.test.ts
+++ b/playground/src/runtime/startup-boundary.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createStartupBoundary } from "./startup-boundary.ts";
+
+test("startup work waits for the first activation owner", async () => {
+  const boundary = createStartupBoundary();
+  let observed: string | null = null;
+  const waiting = boundary.wait().then((reason) => {
+    observed = reason;
+    return reason;
+  });
+
+  await Promise.resolve();
+  assert.equal(observed, null);
+
+  boundary.activate("preview-presented");
+  assert.equal(await waiting, "preview-presented");
+  assert.equal(boundary.reason(), "preview-presented");
+});
+
+test("startup activation is one-shot and late waiters observe the owner", async () => {
+  const boundary = createStartupBoundary();
+
+  boundary.activate("editor-intent");
+  boundary.activate("preview-presented");
+
+  assert.equal(boundary.reason(), "editor-intent");
+  assert.equal(await boundary.wait(), "editor-intent");
+});

--- a/playground/src/runtime/startup-boundary.ts
+++ b/playground/src/runtime/startup-boundary.ts
@@ -1,5 +1,6 @@
 export type StartupActivationReason =
   | "preview-presented"
+  | "editor-visible"
   | "editor-intent";
 
 export interface StartupBoundary {

--- a/playground/src/runtime/startup-boundary.ts
+++ b/playground/src/runtime/startup-boundary.ts
@@ -1,0 +1,38 @@
+export type StartupActivationReason =
+  | "preview-presented"
+  | "editor-intent";
+
+export interface StartupBoundary {
+  activate(reason: StartupActivationReason): boolean;
+  reason(): StartupActivationReason | null;
+  wait(): Promise<StartupActivationReason>;
+}
+
+export function createStartupBoundary(): StartupBoundary {
+  let activationReason: StartupActivationReason | null = null;
+  let resolveActivation: (
+    reason: StartupActivationReason,
+  ) => void = () => undefined;
+  const activation = new Promise<StartupActivationReason>((resolve) => {
+    resolveActivation = resolve;
+  });
+
+  return Object.freeze({
+    activate(reason: StartupActivationReason) {
+      if (activationReason !== null) return false;
+      activationReason = reason;
+      resolveActivation(reason);
+      return true;
+    },
+    reason() {
+      return activationReason;
+    },
+    wait() {
+      return activationReason === null
+        ? activation
+        : Promise.resolve(activationReason);
+    },
+  });
+}
+
+export const playgroundStartupBoundary = createStartupBoundary();

--- a/playground/tests/mobile.interactions.spec.ts
+++ b/playground/tests/mobile.interactions.spec.ts
@@ -7,6 +7,7 @@ import {
   expectNoDocumentOverflow,
   monitorBrowserErrors,
   openPlayground,
+  previewSvgText,
   replaceEditorSource,
   waitForPreviewSvg,
 } from "./helpers/playground";
@@ -23,13 +24,6 @@ test("320px portrait keeps toolbar, workspace tabs, and preview controls reachab
   await exerciseCompactToolbarMenus(page);
 
   const host = page.locator(".preview-container > div").first();
-  await expect
-    .poll(() =>
-      host.evaluate((element) =>
-        Boolean(element.shadowRoot?.querySelector("svg")),
-      ),
-    )
-    .toBe(true);
   const editorTab = page.getByRole("tab", { name: "Editor", exact: true });
   const previewTab = page.getByRole("tab", { name: "Preview", exact: true });
   await editorTab.focus();
@@ -97,6 +91,58 @@ test("320px portrait keeps toolbar, workspace tabs, and preview controls reachab
     page.getByRole("textbox", { name: "Mermaid source" }),
   ).toBeVisible();
   await expectNoDocumentOverflow(page);
+  errors.assertNone();
+});
+
+test("hidden editor workspace defers Preview rendering and resumes the latest source", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 320, height: 568 });
+  const errors = monitorBrowserErrors(page);
+  await openPlayground(page);
+
+  const host = page.locator(".preview-container > div").first();
+  const editorTab = page.getByRole("tab", { name: "Editor", exact: true });
+  const previewTab = page.getByRole("tab", { name: "Preview", exact: true });
+  await expect(page.getByRole("textbox", { name: "Mermaid source" })).toBeVisible();
+  await expect(page.locator("footer")).toContainText("WASM: Ready");
+  await page.waitForTimeout(450);
+  await expect(host).toHaveCount(0);
+  expect(
+    await page.evaluate(
+      () =>
+        performance.getEntriesByName("merman:initial-preview-presented").length,
+    ),
+  ).toBe(0);
+
+  await replaceEditorSource(
+    page,
+    "flowchart LR\n  hidden[Hidden] --> latest[Latest source]",
+  );
+  await page.waitForTimeout(450);
+  await expect(host).toHaveCount(0);
+
+  await previewTab.tap();
+  await waitForPreviewSvg(page);
+  await expect.poll(() => previewSvgText(page)).toContain("Latest source");
+  expect(
+    await page.evaluate(
+      () =>
+        performance.getEntriesByName("merman:initial-preview-presented").length,
+    ),
+  ).toBe(1);
+
+  await editorTab.tap();
+  await replaceEditorSource(
+    page,
+    "flowchart LR\n  hidden[Hidden] --> newest[Newest source]",
+  );
+  await page.waitForTimeout(450);
+  expect(await previewSvgText(page)).toContain("Latest source");
+  expect(await previewSvgText(page)).not.toContain("Newest source");
+
+  await previewTab.tap();
+  await expect.poll(() => previewSvgText(page)).toContain("Newest source");
   errors.assertNone();
 });
 

--- a/playground/tests/mobile.interactions.spec.ts
+++ b/playground/tests/mobile.interactions.spec.ts
@@ -652,6 +652,20 @@ async function viewportZoom(viewport: Locator): Promise<number> {
 
 async function expectInsideViewport(page: Page, locator: Locator): Promise<void> {
   await expect(locator).toBeVisible();
+  await expect
+    .poll(async () => {
+      const box = await locator.boundingBox();
+      const viewport = page.viewportSize();
+      return Boolean(
+        box &&
+          viewport &&
+          box.x >= 0 &&
+          box.y >= 0 &&
+          box.x + box.width <= viewport.width + 1 &&
+          box.y + box.height <= viewport.height + 1,
+      );
+    })
+    .toBe(true);
   const box = await locator.boundingBox();
   const viewport = page.viewportSize();
   expect(box).not.toBeNull();

--- a/playground/tests/mobile.interactions.spec.ts
+++ b/playground/tests/mobile.interactions.spec.ts
@@ -138,8 +138,19 @@ test("hidden editor workspace defers Preview rendering and resumes the latest so
     "flowchart LR\n  hidden[Hidden] --> newest[Newest source]",
   );
   await page.waitForTimeout(450);
-  expect(await previewSvgText(page)).toContain("Latest source");
-  expect(await previewSvgText(page)).not.toContain("Newest source");
+  await expect(host).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Export", exact: true }).tap();
+  await expect(
+    page.getByRole("menuitem", { name: "Export image…" }),
+  ).toBeDisabled();
+  await expect(
+    page.getByRole("menuitem", { name: /^Export ASCII/u }),
+  ).toBeDisabled();
+  await expect(
+    page.getByRole("menuitem", { name: "Copy SVG", exact: true }),
+  ).toBeDisabled();
+  await page.keyboard.press("Escape");
 
   await previewTab.tap();
   await expect.poll(() => previewSvgText(page)).toContain("Newest source");

--- a/playground/tests/monaco.worker.spec.ts
+++ b/playground/tests/monaco.worker.spec.ts
@@ -9,6 +9,42 @@ import {
 test("Monaco starts local semantic and Tree-sitter workers with staged WASM", async ({
   page,
 }) => {
+  await page.addInitScript(() => {
+    const timeline: {
+      workers: Array<{ readonly at: number; readonly name: string }>;
+    } = {
+      workers: [],
+    };
+    Object.defineProperty(window, "__mermanStartupTimeline", {
+      configurable: true,
+      value: timeline,
+    });
+
+    const NativeWorker = window.Worker;
+    class ObservableWorker extends NativeWorker {
+      constructor(
+        scriptURL: string | URL,
+        options?: { readonly name?: string; readonly type?: "classic" | "module" },
+      ) {
+        super(scriptURL, options);
+        if (
+          options?.name === "merman-editor-language" ||
+          options?.name === "mermaid-tree-sitter"
+        ) {
+          timeline.workers.push({
+            at: performance.now(),
+            name: options.name,
+          });
+        }
+      }
+    }
+    Object.defineProperty(window, "Worker", {
+      configurable: true,
+      value: ObservableWorker,
+      writable: true,
+    });
+  });
+
   const errors = monitorBrowserErrors(page);
   const requests: string[] = [];
   const workers: string[] = [];
@@ -19,6 +55,22 @@ test("Monaco starts local semantic and Tree-sitter workers with staged WASM", as
   await expect(page.getByRole("textbox", { name: "Mermaid source" })).toBeVisible();
   await expect.poll(() => workers.some((url) => /merman-language\.worker/i.test(url))).toBe(true);
   await expect.poll(() => workers.some((url) => /mermaid-syntax\.worker/i.test(url))).toBe(true);
+  const startupTimeline = await page.evaluate(() => ({
+    previewPresentedAt:
+      performance.getEntriesByName("merman:initial-preview-presented")[0]
+        ?.startTime ?? null,
+    workers: (window as unknown as Window & {
+      __mermanStartupTimeline: {
+        workers: Array<{ readonly at: number; readonly name: string }>;
+      };
+    }).__mermanStartupTimeline.workers,
+  }));
+  expect(startupTimeline.previewPresentedAt).not.toBeNull();
+  for (const worker of startupTimeline.workers) {
+    expect(worker.at, `${worker.name} started before the first preview SVG`).toBeGreaterThanOrEqual(
+      startupTimeline.previewPresentedAt ?? Number.POSITIVE_INFINITY,
+    );
+  }
   await expect
     .poll(() => requests.some((url) => /merman_wasm_bg-[\w-]+\.wasm(?:\?|$)/.test(url)))
     .toBe(true);
@@ -68,6 +120,61 @@ test("Monaco starts local semantic and Tree-sitter workers with staged WASM", as
   expect(external).toEqual([]);
   for (const workerUrl of workers) expect(new URL(workerUrl).origin).toBe(pageOrigin);
   errors.assertNone();
+});
+
+test("editor intent can activate language workers before a blocked preview", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("merman-language", "en");
+  });
+  let releaseWasm: () => void = () => undefined;
+  const wasmBlocked = new Promise<void>((resolve) => {
+    releaseWasm = resolve;
+  });
+  const workers: string[] = [];
+  page.on("worker", (worker) => workers.push(worker.url()));
+  await page.route(/merman_wasm_bg-[\w-]+\.wasm(?:\?|$)/i, async (route) => {
+    await wasmBlocked;
+    await route.continue();
+  });
+
+  try {
+    await page.goto("./", { waitUntil: "domcontentloaded" });
+    const editor = page.getByRole("textbox", { name: "Mermaid source" });
+    await expect(editor).toBeVisible();
+    expect(workers.filter((url) => /merman-language|mermaid-syntax/i.test(url))).toEqual([]);
+
+    await editor.focus();
+    await expect
+      .poll(() => workers.some((url) => /merman-language\.worker/i.test(url)))
+      .toBe(true);
+    await expect
+      .poll(() => workers.some((url) => /mermaid-syntax\.worker/i.test(url)))
+      .toBe(true);
+    expect(
+      await page.evaluate(
+        () =>
+          performance.getEntriesByName("merman:initial-preview-presented")
+            .length,
+      ),
+    ).toBe(0);
+  } finally {
+    releaseWasm();
+  }
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          performance.getEntriesByName("merman:initial-preview-presented")
+            .length,
+      ),
+    )
+    .toBe(1);
+  await expect(
+    page.getByText("Language tools initializing", { exact: true }),
+  ).toBeHidden();
 });
 
 test("Tree-sitter worker returns version-bound tokens for incomplete emoji input", async ({

--- a/playground/tests/monaco.worker.spec.ts
+++ b/playground/tests/monaco.worker.spec.ts
@@ -132,7 +132,9 @@ test("editor intent can activate language workers before a blocked preview", asy
   const wasmBlocked = new Promise<void>((resolve) => {
     releaseWasm = resolve;
   });
+  const requests: string[] = [];
   const workers: string[] = [];
+  page.on("request", (request) => requests.push(request.url()));
   page.on("worker", (worker) => workers.push(worker.url()));
   await page.route(/merman_wasm_bg-[\w-]+\.wasm(?:\?|$)/i, async (route) => {
     await wasmBlocked;
@@ -141,11 +143,20 @@ test("editor intent can activate language workers before a blocked preview", asy
 
   try {
     await page.goto("./", { waitUntil: "domcontentloaded" });
+    const activation = page.getByTestId("editor-activation");
+    await expect(activation).toBeVisible();
+    expect(workers.filter((url) => /merman-language|mermaid-syntax/i.test(url))).toEqual([]);
+    expect(
+      requests.filter((url) =>
+        /monaco|floatingMenu|contribution-[\w-]+\.js|codicon|editor\.worker/i.test(
+          url,
+        ),
+      ),
+    ).toEqual([]);
+
+    await activation.focus();
     const editor = page.getByRole("textbox", { name: "Mermaid source" });
     await expect(editor).toBeVisible();
-    expect(workers.filter((url) => /merman-language|mermaid-syntax/i.test(url))).toEqual([]);
-
-    await editor.focus();
     await expect
       .poll(() => workers.some((url) => /merman-language\.worker/i.test(url)))
       .toBe(true);

--- a/playground/tests/playground.smoke.spec.ts
+++ b/playground/tests/playground.smoke.spec.ts
@@ -134,6 +134,22 @@ test("Compare owns one local Mermaid realm and publishes one coherent batch", as
     1,
   );
 
+  await page.getByRole("tab", { name: "SVG", exact: true }).click();
+  await expect(page.locator('iframe[data-merman-realm="compare"]')).toHaveCount(
+    0,
+  );
+  await page.getByRole("tab", { name: "Compare", exact: true }).click();
+  await expect(page.locator('iframe[data-merman-realm="compare"]')).toHaveCount(
+    1,
+  );
+  await expect
+    .poll(() => compareSvgTexts(page))
+    .toEqual([
+      expect.stringContaining("Latest batch"),
+      expect.stringContaining("Latest batch"),
+    ]);
+  expect(opaqueArtifactRequests).toHaveLength(1);
+
   await page.evaluate(() => {
     window.dispatchEvent(
       new PageTransitionEvent("pagehide", { persisted: true }),

--- a/playground/tests/playground.ui.spec.ts
+++ b/playground/tests/playground.ui.spec.ts
@@ -352,7 +352,11 @@ test("toolbar ASCII export renders on explicit intent from SVG mode", async ({
 
 test("preview tabs use manual keyboard activation", async ({ page }) => {
   const errors = monitorBrowserErrors(page);
+  const viewerOutput = optionalFeatureOutput("viewer");
+  const requests: string[] = [];
+  page.on("request", (request) => requests.push(request.url()));
   await openPlayground(page);
+  expect(wasRequested(requests, viewerOutput)).toBe(false);
   const diagnosticsTab = page.getByRole("tab", {
     name: "Diagnostics",
     exact: true,
@@ -366,6 +370,10 @@ test("preview tabs use manual keyboard activation", async ({ page }) => {
   await page.keyboard.press("Enter");
   await expect(diagnosticsTab).toHaveAttribute("aria-selected", "true");
   await expect(page.getByRole("tab", { name: "Parse JSON" })).toBeVisible();
+  await expect.poll(() => requestCount(requests, viewerOutput)).toBe(1);
+  expect(
+    requests.some((url) => url.startsWith("https://cdn.jsdelivr.net/")),
+  ).toBe(false);
   errors.assertNone();
 });
 

--- a/playground/tests/playground.ui.spec.ts
+++ b/playground/tests/playground.ui.spec.ts
@@ -39,12 +39,14 @@ test("manual tabs preserve the editor model, selection, and undo history", async
     .poll(() => page.locator(".monaco-editor:visible .squiggly-error").count())
     .toBeGreaterThan(0);
   await codeTab.click();
+  await expect(page.locator(".monaco-editor")).toHaveCount(1);
   await configTab.click();
   await expect(page.getByText(/Invalid JSON/)).toBeVisible();
   await configEditor.focus();
   await page.keyboard.press("Control+Z");
   await expect(page.getByText("Config OK", { exact: true })).toBeVisible();
   await codeTab.click();
+  await expect(page.locator(".monaco-editor")).toHaveCount(1);
 
   await editor.focus();
   await page.keyboard.insertText("C");

--- a/playground/tests/playground.ui.spec.ts
+++ b/playground/tests/playground.ui.spec.ts
@@ -321,6 +321,33 @@ test("export workbench targets toolbar and Compare artifacts through one dialog"
   errors.assertNone();
 });
 
+test("toolbar ASCII export renders on explicit intent from SVG mode", async ({
+  page,
+}) => {
+  const errors = monitorBrowserErrors(page);
+  await openPlayground(page);
+  await replaceEditorSource(page, "flowchart LR\n  Alpha --> Beta");
+  await waitForPreviewSvg(page);
+  await expect(
+    page.getByRole("tab", { name: "SVG", exact: true }),
+  ).toHaveAttribute("aria-selected", "true");
+
+  await page.getByRole("button", { name: "Export", exact: true }).click();
+  const exportAscii = page.getByRole("menuitem", {
+    name: /^Export ASCII/u,
+  });
+  await expect(exportAscii).toBeEnabled();
+  const download = page.waitForEvent("download");
+  await exportAscii.click();
+  const artifact = await download;
+
+  expect(artifact.suggestedFilename()).toBe("merman-diagram.txt");
+  const ascii = (await downloadBytes(artifact)).toString("utf8");
+  expect(ascii).toContain("Alpha");
+  expect(ascii).toContain("Beta");
+  errors.assertNone();
+});
+
 test("preview tabs use manual keyboard activation", async ({ page }) => {
   const errors = monitorBrowserErrors(page);
   await openPlayground(page);

--- a/playground/tests/playground.ui.spec.ts
+++ b/playground/tests/playground.ui.spec.ts
@@ -353,10 +353,17 @@ test("toolbar ASCII export renders on explicit intent from SVG mode", async ({
 test("preview tabs use manual keyboard activation", async ({ page }) => {
   const errors = monitorBrowserErrors(page);
   const viewerOutput = optionalFeatureOutput("viewer");
+  const viewerJsonOutput = optionalFeatureOutput("viewerJson");
   const requests: string[] = [];
+  const workers: string[] = [];
   page.on("request", (request) => requests.push(request.url()));
+  page.on("worker", (worker) => workers.push(worker.url()));
   await openPlayground(page);
   expect(wasRequested(requests, viewerOutput)).toBe(false);
+  await page.getByRole("button", { name: "View SVG source", exact: true }).click();
+  await expect.poll(() => requestCount(requests, viewerOutput)).toBe(1);
+  expect(wasRequested(requests, viewerJsonOutput)).toBe(false);
+  expect(workers.some((url) => /json\.worker/i.test(url))).toBe(false);
   const diagnosticsTab = page.getByRole("tab", {
     name: "Diagnostics",
     exact: true,
@@ -370,6 +377,8 @@ test("preview tabs use manual keyboard activation", async ({ page }) => {
   await page.keyboard.press("Enter");
   await expect(diagnosticsTab).toHaveAttribute("aria-selected", "true");
   await expect(page.getByRole("tab", { name: "Parse JSON" })).toBeVisible();
+  await expect.poll(() => requestCount(requests, viewerJsonOutput)).toBe(1);
+  await expect.poll(() => workers.some((url) => /json\.worker/i.test(url))).toBe(true);
   await expect.poll(() => requestCount(requests, viewerOutput)).toBe(1);
   expect(
     requests.some((url) => url.startsWith("https://cdn.jsdelivr.net/")),


### PR DESCRIPTION
## Summary

The Playground now presents the first SVG before loading optional editor and language work, and releases or suspends inactive work instead of retaining it across hidden panes. This reduces startup competition and retained browser work while preserving editor, Compare, export, mobile, and cross-browser behavior.

## Performance

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Cold first SVG | 650.25 ms | 503.85 ms | -22.51% |
| Warm first SVG | 449.95 ms | 382.10 ms | -15.08% |
| Cold transfer before first SVG | 14,450,285 bytes | 13,247,472 bytes | -8.32% |
| Workers before first SVG | 24 | 0 | -100% |
| Initial static JS closure, raw | 4,436,131 bytes | 791,247 bytes | -82.16% |
| Initial static JS closure, gzip | 1,169,826 bytes | 251,871 bytes | -78.47% |
| Initial static JS closure, Brotli q11 | 930,554 bytes | 218,374 bytes | -76.53% |

Measurements use eight fixed AB/BA pairs of production Vite builds in Chromium, with service workers blocked and the same host, viewport, source, and runtime artifacts.

The connected-bounds 10,000-node reverse-chain stress case also improved from 136.497 ms to 1.186 ms (about 115x).

## Design decisions

- Keep Monaco, language workers, configuration workbenches, and read-only viewers behind explicit activation boundaries.
- Render ASCII only when requested and reuse the completed SVG and diagnostic publication instead of rerunning the full render path.
- Suspend hidden mobile previews and invalidate stale export artifacts until the latest source has rendered.
- Release inactive Compare realms and editor models while preserving document state, undo history, and errors.
- Replace quadratic connected-bound fitting with sorted monotone frontiers while retaining semantic-equivalence tests.

## Validation

- `npm run verify:dependencies --prefix playground`
- `npm run prepare:browser-runtime --prefix playground`
- `npm run test:prepared --prefix playground`
- `npm run lint --prefix playground`
- `npm run build:prepared --prefix playground`
- `npm run test:browser:smoke:non-chromium:built --prefix playground` (3 passed)
- `npm run test:browser:chromium:desktop:built --prefix playground` (76 passed)
- `npm run test:browser:mobile:built --prefix playground` (12 passed)
