### PR TITLE
docs: reconcile stale workstream and ZenUML status

### DIFF
--- a/docs/alignment/FIXTURE_EXPANSION_TODO.md
+++ b/docs/alignment/FIXTURE_EXPANSION_TODO.md
@@ -191,9 +191,15 @@ Upstream source:
 
 Current status:
 
-- Snapshot-gated only (no upstream SVG baselines).
-- Translation-based compatibility mode implemented in:
-  - `crates/merman-core/src/diagrams/zenuml.rs`
+- Full grammar-derived lexer, recovering parser, semantic/editor model, typed layout, and headless
+  SVG are implemented against the admitted ZenUML Core 3.50.1 behavior source.
+- ZenUML remains outside the built-in upstream-SVG matrix; its exact external plugin graph is tested
+  in a separate opaque-browser comparison lane.
+- Family-owned implementation:
+  - Syntax and model: `crates/merman-core/src/diagrams/zenuml/`
+  - Typed layout: `crates/merman-render/src/zenuml.rs`
+  - Headless SVG: `crates/merman-render/src/svg/parity/zenuml.rs`
+- ZenUML is parsed directly and is never translated through Mermaid Sequence JSON or actions.
 
 Imported from docs (snapshot-gated):
 

--- a/docs/workstreams/python-uniffi-package/DESIGN.md
+++ b/docs/workstreams/python-uniffi-package/DESIGN.md
@@ -1,6 +1,6 @@
 # Python UniFFI Package
 
-Status: Active
+Status: Closed
 Last updated: 2026-05-31
 
 ## Why This Lane Exists

--- a/docs/workstreams/python-uniffi-package/EVIDENCE_AND_GATES.md
+++ b/docs/workstreams/python-uniffi-package/EVIDENCE_AND_GATES.md
@@ -1,6 +1,6 @@
 # Python UniFFI Package - Evidence And Gates
 
-Status: Active
+Status: Closed
 Last updated: 2026-05-31
 
 ## Smallest Current Repro

--- a/docs/workstreams/python-uniffi-package/MILESTONES.md
+++ b/docs/workstreams/python-uniffi-package/MILESTONES.md
@@ -1,6 +1,6 @@
 # Python UniFFI Package - Milestones
 
-Status: Active
+Status: Closed
 Last updated: 2026-05-31
 
 ## M0 - Scope And Evidence Freeze

--- a/docs/workstreams/python-uniffi-package/TODO.md
+++ b/docs/workstreams/python-uniffi-package/TODO.md
@@ -1,6 +1,6 @@
 # Python UniFFI Package - TODO
 
-Status: Active
+Status: Closed
 Last updated: 2026-05-31
 
 ## M0 - Scope And Evidence Freeze

--- a/docs/workstreams/resvg-safe-svg-output/DESIGN.md
+++ b/docs/workstreams/resvg-safe-svg-output/DESIGN.md
@@ -1,6 +1,6 @@
 # Resvg-Safe SVG Output Pipeline
 
-Status: Active
+Status: Complete
 Last updated: 2026-05-28
 
 ## Why This Lane Exists


### PR DESCRIPTION
## Summary

- align the five stale workstream status headers with their completed/closed manifests
- replace the retired ZenUML translation-mode description with the current family-owned syntax, layout, and SVG paths
- retain the separate external comparison boundary instead of claiming built-in upstream-SVG admission

## Verification

- `git diff --check`
- replayed the path and status reproduction commands from both issues
- confirmed the three documented ZenUML implementation paths exist and the retired single-file path does not

No runtime tests were run because this PR changes documentation only.

Closes #78
Closes #79