### PR TITLE
fix(rustdoc): avoid duplicate browser labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ The next workspace release remains in development. This section records only com
 
 ### Fixed
 
+- `merman-rustdoc` now defaults to browser-parity SVG instead of adding a second visible text
+  fallback beside each native HTML label. Explicit `readable` and `resvg-safe` pipelines remain
+  available for consumers that need SVG text fallbacks. #81
 - Restored `roughr-merman` 0.12 source compatibility for stable Merman 0.7 without removing the operation-owned randomness contract used by current releases, and raised the workspace dependency floor to the repaired patch.
 - Playground Mermaid.js comparison realms now preserve SVG label colors without letting page CSS override Mermaid output, and ZenUML's injected `MS Sans Serif` font remains isolated to the affected comparison instead of changing other examples.
 - Native Assets eliminates Flutter's legacy Linux Windows-wrapper linkage and SwiftPM symlink packaging paths, while Apple dylibs use normalized install names and refreshed signatures before Flutter's final assembly. #55 #56 #57

--- a/crates/merman-rustdoc/README.md
+++ b/crates/merman-rustdoc/README.md
@@ -150,7 +150,7 @@ All attribute options use string literals:
     all(doc, feature = "doc-diagrams"),
     merman_rustdoc::merman(
         scope = "item",
-        pipeline = "readable",
+        pipeline = "parity",
         fail = "error",
         source = "hide",
         sanitize = "strict",
@@ -167,13 +167,19 @@ pub fn configured() {}
 | Option | Values | Default | Meaning |
 | --- | --- | --- | --- |
 | `scope` | `item`, `tree` | `item` | Rewrite only the annotated item or recurse through an inline item tree. |
-| `pipeline` | `readable`, `parity`, `resvg-safe` | `readable` | Select the SVG output pipeline. |
+| `pipeline` | `parity`, `readable`, `resvg-safe` | `parity` | Select the SVG output pipeline. |
 | `fail` | `error`, `keep-source` | `error` | Fail documentation or preserve the Mermaid source after an error. |
 | `source` | `hide`, `details` | `hide` | Optionally add the source in a collapsed details block. |
 | `sanitize` | `strict`, `off` | `strict` | Reject scripts, event attributes, unsafe URLs, and remote resources before insertion. |
 | `theme` | `rustdoc`, `mermaid`, or a supported Mermaid theme | `rustdoc` | Follow rustdoc, source-level Mermaid config, or one fixed theme. |
 
 `theme = "rustdoc"` renders light and dark SVG variants and switches between them with rustdoc's existing page theme state. No Mermaid runtime is loaded in the browser. `theme = "mermaid"` emits one SVG controlled by Mermaid source config, while a value such as `theme = "dark"` selects one fixed Merman theme. Source-level Mermaid config still takes precedence.
+
+`parity` is the default because rustdoc pages target browsers, which render Mermaid's native
+`<foreignObject>` labels directly. `readable` deliberately adds SVG `<text>` fallbacks alongside
+those labels and can display both representations in consumers that support each one. Use it only
+when the host selects one representation. `resvg-safe` removes `<foreignObject>` labels and keeps
+the SVG text fallback for rasterizers and other compatible consumers.
 
 Use `scope = "tree"` when one attribute should process children inside an inline module, trait, impl block, struct, or enum:
 

--- a/crates/merman-rustdoc/src/lib.rs
+++ b/crates/merman-rustdoc/src/lib.rs
@@ -82,7 +82,7 @@
 //!     doc,
 //!     merman_rustdoc::merman(
 //!         scope = "item",
-//!         pipeline = "readable",
+//!         pipeline = "parity",
 //!         fail = "error",
 //!         source = "hide",
 //!         sanitize = "strict",
@@ -99,11 +99,17 @@
 //! | Option | Values | Default | Meaning |
 //! | --- | --- | --- | --- |
 //! | `scope` | `item`, `tree` | `item` | Controls whether only the annotated item or the inline item tree is rewritten. |
-//! | `pipeline` | `readable`, `parity`, `resvg-safe` | `readable` | Selects the SVG output pipeline. |
+//! | `pipeline` | `parity`, `readable`, `resvg-safe` | `parity` | Selects the SVG output pipeline. |
 //! | `fail` | `error`, `keep-source` | `error` | Controls what happens when rendering or file includes fail. |
 //! | `source` | `hide`, `details` | `hide` | Adds a collapsed Mermaid source block under the SVG when set to `details`. |
 //! | `sanitize` | `strict`, `off` | `strict` | Checks rendered SVG for script elements, event attributes, and unsafe resource references. |
 //! | `theme` | `rustdoc`, `mermaid`, or a supported Mermaid theme name | `rustdoc` | Controls whether diagrams follow rustdoc light/dark themes, use Mermaid source config, or use a fixed Mermaid theme. |
+//!
+//! `parity` is the default because rustdoc pages target browsers, which render Mermaid's native
+//! `<foreignObject>` labels directly. `readable` deliberately adds SVG `<text>` fallbacks alongside
+//! those labels and can display both representations in consumers that support each one.
+//! `resvg-safe` removes the native labels and retains the SVG text fallback for compatible
+//! rasterizers.
 //!
 //! Use `scope = "tree"` to process docs on children inside an inline module, trait, impl block,
 //! struct fields, and enum variants:

--- a/crates/merman-rustdoc/src/options.rs
+++ b/crates/merman-rustdoc/src/options.rs
@@ -5,8 +5,14 @@ use crate::error::{Error, Result};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum PipelineMode {
+    /// Keep the Mermaid-compatible SVG unchanged for browser presentation.
     Parity,
+    /// Retain native HTML labels and add SVG text fallbacks alongside them.
+    ///
+    /// Hosts that can render both representations must select or hide one to
+    /// avoid displaying duplicate labels.
     Readable,
+    /// Replace browser-only labels with fallbacks and finalize for resvg.
     ResvgSafe,
 }
 
@@ -55,7 +61,9 @@ impl Default for Options {
     fn default() -> Self {
         Self {
             scope: ScopeMode::Item,
-            pipeline: PipelineMode::Readable,
+            // Rustdoc is presented in a browser, where the native Mermaid
+            // labels are supported and a second fallback can become visible.
+            pipeline: PipelineMode::Parity,
             fail: FailMode::Error,
             source: SourceMode::Hide,
             sanitize: SanitizeMode::Strict,
@@ -206,10 +214,10 @@ mod tests {
 
     #[test]
     fn parses_default_options() {
-        assert_eq!(
-            Options::parse(TokenStream::new()).unwrap(),
-            Options::default()
-        );
+        let options = Options::parse(TokenStream::new()).unwrap();
+
+        assert_eq!(options, Options::default());
+        assert_eq!(options.pipeline, PipelineMode::Parity);
     }
 
     #[test]

--- a/crates/merman-rustdoc/src/render.rs
+++ b/crates/merman-rustdoc/src/render.rs
@@ -154,6 +154,7 @@ fn render_mermaid_svg(
     let request = SvgRequest {
         environment: SvgEnvironment::deterministic(),
         pipeline: match pipeline {
+            // No post-processing is the parity pipeline for an SVG request.
             PipelineMode::Parity => None,
             PipelineMode::Readable => Some(SvgPipeline::readable()),
             PipelineMode::ResvgSafe => Some(SvgPipeline::resvg_safe()),
@@ -258,6 +259,62 @@ mod tests {
         .unwrap();
 
         assert!(matches!(rendered, RenderedDiagram::Single(_)));
+    }
+
+    #[test]
+    fn default_pipeline_keeps_one_browser_label_representation() {
+        let source = r#"classDiagram
+    EventConsumer <|.. OnClickConsumer
+    OnClick <.. OnClickConsumer : uses
+"#;
+        let rendered = render_mermaid_diagram(
+            source,
+            0,
+            Options {
+                theme: ThemeMode::Fixed("default"),
+                ..Options::default()
+            },
+        )
+        .unwrap();
+
+        let RenderedDiagram::Single(svg) = rendered else {
+            panic!("expected fixed theme to render one SVG");
+        };
+        assert!(svg.contains("<foreignObject"), "{svg}");
+        assert!(
+            !svg.contains(r#"data-merman-foreignobject="fallback""#),
+            "default rustdoc output must not add a second visible label representation: {svg}"
+        );
+        assert!(
+            svg.contains(r#"class="edge-thickness-normal edge-pattern-dashed relation""#),
+            "expected dotted Class relations to keep Mermaid's dashed edge pattern: {svg}"
+        );
+        assert!(
+            svg.contains(".edge-pattern-dashed{stroke-dasharray:3;}"),
+            "expected Class SVG to include Mermaid's shared dashed-edge CSS: {svg}"
+        );
+    }
+
+    #[test]
+    fn readable_pipeline_remains_an_explicit_fallback_overlay_option() {
+        let rendered = render_mermaid_diagram(
+            "flowchart TD\nA[Start] --> B[Done]",
+            0,
+            Options {
+                pipeline: PipelineMode::Readable,
+                theme: ThemeMode::Fixed("default"),
+                ..Options::default()
+            },
+        )
+        .unwrap();
+
+        let RenderedDiagram::Single(svg) = rendered else {
+            panic!("expected fixed theme to render one SVG");
+        };
+        assert!(
+            svg.contains(r#"data-merman-foreignobject="fallback""#),
+            "explicit readable output should retain SVG text fallbacks: {svg}"
+        );
     }
 
     #[test]

--- a/docs/rendering/SVG_OUTPUT_PIPELINE.md
+++ b/docs/rendering/SVG_OUTPUT_PIPELINE.md
@@ -30,8 +30,9 @@ evidence, but they are not browser-visible evidence. Browser-visible claims requ
 Typical choices:
 
 - Use a default `SvgRequest` when the caller wants the closest Mermaid-compatible SVG string.
-- Set `SvgRequest.pipeline = Some(SvgPipeline::readable())` for browser previews that can keep
-  `<foreignObject>` but should also expose SVG text fallbacks.
+- Set `SvgRequest.pipeline = Some(SvgPipeline::readable())` only when the output deliberately needs
+  both native `<foreignObject>` labels and SVG text fallbacks. A browser host must select or hide
+  one representation or both may be visible.
 - Set `SvgRequest.pipeline = Some(SvgPipeline::resvg_safe())`, select a typed PNG/JPEG/PDF target,
   or use `SvgPipeline::process_resvg_compatible()` before calling low-level encoders.
 - Use `merman-cli render --svg-pipeline resvg-safe` when you want the CLI to write export-safe SVG
@@ -47,7 +48,7 @@ Typical choices:
 | Preset | Behavior |
 | --- | --- |
 | `SvgPipeline::parity()` | No post-processing. This preserves the exact SVG string produced by the parity renderer. |
-| `SvgPipeline::readable()` | Adds best-effort SVG `<text>` overlays for labels emitted via `<foreignObject>`. |
+| `SvgPipeline::readable()` | Adds best-effort SVG `<text>` overlays while retaining `<foreignObject>` labels. Consumers that render both representations may display duplicate text. |
 | `SvgPipeline::resvg_safe()` | Adds readable fallbacks, strips the original `<foreignObject>` elements, and removes common `usvg` / `resvg` hazards. Structural references are limited to same-document fragments; ordinary image resources require an approved inline PNG/JPEG/GIF/WebP data URL whose encoding is syntactically decodable; `feImage` accepts either form. `<a>` navigation links remain metadata outside the raster-resource contract. |
 
 For Mermaid 11.16 Quadrant, parity output intentionally retains upstream's invalid


### PR DESCRIPTION
## Summary

- default `merman-rustdoc` to browser-parity SVG so rustdoc pages render one native label representation
- keep `readable` as an explicit dual-label compatibility pipeline and document that hosts must select or hide one representation
- cover the reported Class diagram, including its dashed relationship styling, with a regression test

`resvg-safe` behavior is unchanged: it removes browser-only `<foreignObject>` labels and keeps SVG text fallbacks for compatible rasterizers.

Fixes #81.

## Validation

- `cargo nextest run --locked -p merman-rustdoc --no-default-features --features svg --no-fail-fast -j 1` — 39/39 passed
- `cargo fmt --all -- --check`
- generated the issue's rustdoc page and verified it in Playwright Firefox: one visible representation per label, no fallback overlay groups, and `3px` dashed relationship styling
