### PR TITLE
perf(playground): initialize editor alongside preview

### DIFF
--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -106,10 +106,13 @@ export default function App() {
                   onPointerDownCapture={() => setWorkspacePane("editor")}
                 >
                   <EditorPanel
-                    activateCodeEditorImmediately={
+                    activateEditorLanguageImmediately={
                       isNarrowLayout && workspacePane === "editor"
                     }
                     editorMode={editorMode}
+                    mountCodeEditorImmediately={
+                      !isNarrowLayout || workspacePane === "editor"
+                    }
                     setEditorMode={setEditorMode}
                     t={t}
                   />
@@ -147,13 +150,15 @@ export default function App() {
 }
 
 function EditorPanel({
-  activateCodeEditorImmediately,
+  activateEditorLanguageImmediately,
   editorMode,
+  mountCodeEditorImmediately,
   setEditorMode,
   t,
 }: {
-  activateCodeEditorImmediately: boolean;
+  activateEditorLanguageImmediately: boolean;
   editorMode: "code" | "config";
+  mountCodeEditorImmediately: boolean;
   setEditorMode(mode: "code" | "config"): void;
   t(key: string): string;
 }) {
@@ -188,9 +193,10 @@ function EditorPanel({
         forceMount
         className="mt-0 min-h-0 data-[state=inactive]:hidden"
       >
-        <DeferredCodeEditor
-          activateImmediately={activateCodeEditorImmediately}
+        <StartupCodeEditor
+          activateLanguageImmediately={activateEditorLanguageImmediately}
           className="h-full min-h-0"
+          mountImmediately={mountCodeEditorImmediately}
         />
       </TabsContent>
       <TabsContent
@@ -208,22 +214,24 @@ function EditorPanel({
   );
 }
 
-function DeferredCodeEditor({
-  activateImmediately,
+function StartupCodeEditor({
+  activateLanguageImmediately,
   className,
+  mountImmediately,
 }: {
-  readonly activateImmediately: boolean;
+  readonly activateLanguageImmediately: boolean;
   readonly className?: string;
+  readonly mountImmediately: boolean;
 }) {
   const { t } = useTranslation();
-  const [activated, setActivated] = useState(
-    () => playgroundStartupBoundary.reason() !== null,
+  const [mounted, setMounted] = useState(
+    () => mountImmediately || playgroundStartupBoundary.reason() !== null,
   );
 
   useEffect(() => {
     let active = true;
     void playgroundStartupBoundary.wait().then(() => {
-      if (active) setActivated(true);
+      if (active) setMounted(true);
     });
     return () => {
       active = false;
@@ -231,26 +239,34 @@ function DeferredCodeEditor({
   }, []);
 
   useEffect(() => {
-    if (!activateImmediately) return;
-    playgroundStartupBoundary.activate("editor-visible");
-    setActivated(true);
-  }, [activateImmediately]);
+    if (!mountImmediately) return;
+    setMounted(true);
+  }, [mountImmediately]);
 
-  const activateFromEditorIntent = () => {
+  useEffect(() => {
+    if (!activateLanguageImmediately) return;
+    playgroundStartupBoundary.activate("editor-visible");
+  }, [activateLanguageImmediately]);
+
+  const activateLanguageFromEditorIntent = () => {
     playgroundStartupBoundary.activate("editor-intent");
-    setActivated(true);
   };
 
-  if (!activated) {
+  const mountFromEditorIntent = () => {
+    activateLanguageFromEditorIntent();
+    setMounted(true);
+  };
+
+  if (!mounted) {
     return (
       <button
         type="button"
         data-testid="editor-activation"
         aria-label={t("editor.loading")}
         className={`${className ?? ""} flex w-full items-center justify-center bg-card text-sm text-muted-foreground`}
-        onClick={activateFromEditorIntent}
-        onFocus={activateFromEditorIntent}
-        onPointerDown={activateFromEditorIntent}
+        onClick={mountFromEditorIntent}
+        onFocus={mountFromEditorIntent}
+        onPointerDown={mountFromEditorIntent}
       >
         {t("editor.loading")}
       </button>
@@ -258,12 +274,22 @@ function DeferredCodeEditor({
   }
 
   return (
-    <LazyFeatureBoundary
-      feature={t("layout.editor")}
-      presentation={{ kind: "panel" }}
+    <div
+      className={`${className ?? ""} flex flex-col`}
+      data-testid="editor-startup-surface"
+      onFocusCapture={activateLanguageFromEditorIntent}
+      onPointerDownCapture={activateLanguageFromEditorIntent}
     >
-      <CodeEditor className={className} />
-    </LazyFeatureBoundary>
+      <LazyFeatureBoundary
+        feature={t("layout.editor")}
+        presentation={{ kind: "panel" }}
+      >
+        <CodeEditor
+          className="h-full min-h-0"
+          waitForLanguageActivation={playgroundStartupBoundary.wait}
+        />
+      </LazyFeatureBoundary>
+    </div>
   );
 }
 

--- a/playground/src/components/Editor.tsx
+++ b/playground/src/components/Editor.tsx
@@ -17,8 +17,11 @@ import { registerBrowserMermaidLanguage } from "@/src/lib/mermaid-language-brows
 import { useAppStore } from "@/src/store";
 
 interface CodeEditorProps {
-  className?: string;
+  readonly className?: string;
+  readonly waitForLanguageActivation?: () => Promise<unknown>;
 }
+
+const waitForImmediateLanguageActivation = () => Promise.resolve();
 
 type LanguageState =
   | { readonly status: "initializing" }
@@ -27,7 +30,10 @@ type LanguageState =
   | { readonly status: "reconnecting" }
   | { readonly status: "unavailable"; readonly error: Error };
 
-export function CodeEditor({ className }: CodeEditorProps) {
+export function CodeEditor({
+  className,
+  waitForLanguageActivation = waitForImmediateLanguageActivation,
+}: CodeEditorProps) {
   const { t } = useTranslation();
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const layoutBindingRef = useRef<IDisposable | null>(null);
@@ -112,30 +118,37 @@ export function CodeEditor({ className }: CodeEditorProps) {
     let active = true;
     let registration: MermaidLanguageRegistration | null = null;
     languageFailureRef.current = null;
-    void registerBrowserMermaidLanguage(localMonaco, {
-      onRequestRejected: (rejection) => {
-        if (languageGenerationRef.current !== generation) return;
-        setRequestRejection(rejection);
-      },
-      onSemanticUnavailable: (error) =>
-        markLanguageDegraded(error, generation),
-      onSyntaxUnavailable: (error) =>
-        markLanguageDegraded(error, generation),
-    })
-      .then((nextRegistration) => {
-        if (!active || languageGenerationRef.current !== generation) {
-          nextRegistration.dispose();
-          return;
-        }
-        registration = nextRegistration;
-        registrationRef.current = registration;
-        const model = editorRef.current?.getModel();
-        if (model) void bindLanguageService(registration, model, generation);
-      })
-      .catch((error: unknown) => {
-        if (!active || languageGenerationRef.current !== generation) return;
-        markLanguageUnavailable(error, generation);
-      });
+    void (async () => {
+      await waitForLanguageActivation();
+      if (!active || languageGenerationRef.current !== generation) return;
+
+      const nextRegistration = await registerBrowserMermaidLanguage(
+        localMonaco,
+        {
+          onRequestRejected: (rejection) => {
+            if (languageGenerationRef.current !== generation) return;
+            setRequestRejection(rejection);
+          },
+          onSemanticUnavailable: (error) =>
+            markLanguageDegraded(error, generation),
+          onSyntaxUnavailable: (error) =>
+            markLanguageDegraded(error, generation),
+        },
+      );
+
+      if (!active || languageGenerationRef.current !== generation) {
+        nextRegistration.dispose();
+        return;
+      }
+
+      registration = nextRegistration;
+      registrationRef.current = registration;
+      const model = editorRef.current?.getModel();
+      if (model) void bindLanguageService(registration, model, generation);
+    })().catch((error: unknown) => {
+      if (!active || languageGenerationRef.current !== generation) return;
+      markLanguageUnavailable(error, generation);
+    });
 
     return () => {
       active = false;
@@ -154,6 +167,7 @@ export function CodeEditor({ className }: CodeEditorProps) {
     languageAttempt,
     markLanguageDegraded,
     markLanguageUnavailable,
+    waitForLanguageActivation,
   ]);
 
   useEffect(

--- a/playground/tests/monaco.worker.spec.ts
+++ b/playground/tests/monaco.worker.spec.ts
@@ -3,7 +3,9 @@ import { MERMAID_SYNTAX_WORKER_PROTOCOL } from "../src/editor/syntax-protocol";
 import {
   monitorBrowserErrors,
   openPlayground,
+  previewSvgText,
   replaceEditorSource,
+  waitForPreviewSvg,
 } from "./helpers/playground";
 
 test("Monaco starts local semantic and Tree-sitter workers with staged WASM", async ({
@@ -29,7 +31,7 @@ test("Monaco starts local semantic and Tree-sitter workers with staged WASM", as
         super(scriptURL, options);
         if (
           options?.name === "merman-editor-language" ||
-          options?.name === "mermaid-tree-sitter"
+          options?.name === "mermaid-tree-sitter-syntax"
         ) {
           timeline.workers.push({
             at: performance.now(),
@@ -122,12 +124,13 @@ test("Monaco starts local semantic and Tree-sitter workers with staged WASM", as
   errors.assertNone();
 });
 
-test("editor intent can activate language workers before a blocked preview", async ({
+test("editor shell is usable before a blocked preview and intent starts language workers", async ({
   page,
 }) => {
   await page.addInitScript(() => {
     window.localStorage.setItem("merman-language", "en");
   });
+  const errors = monitorBrowserErrors(page);
   let releaseWasm: () => void = () => undefined;
   const wasmBlocked = new Promise<void>((resolve) => {
     releaseWasm = resolve;
@@ -143,20 +146,30 @@ test("editor intent can activate language workers before a blocked preview", asy
 
   try {
     await page.goto("./", { waitUntil: "domcontentloaded" });
-    const activation = page.getByTestId("editor-activation");
-    await expect(activation).toBeVisible();
-    expect(workers.filter((url) => /merman-language|mermaid-syntax/i.test(url))).toEqual([]);
-    expect(
-      requests.filter((url) =>
-        /monaco|floatingMenu|contribution-[\w-]+\.js|codicon|editor\.worker/i.test(
-          url,
-        ),
-      ),
-    ).toEqual([]);
-
-    await activation.focus();
     const editor = page.getByRole("textbox", { name: "Mermaid source" });
     await expect(editor).toBeVisible();
+    expect(workers.filter((url) => /merman-language|mermaid-syntax/i.test(url))).toEqual([]);
+    await expect
+      .poll(() =>
+        requests.some((url) =>
+          /monaco|floatingMenu|contribution-[\w-]+\.js|codicon|editor\.worker/i.test(
+            url,
+          ),
+        ),
+      )
+      .toBe(true);
+    expect(
+      await page.evaluate(
+        () =>
+          performance.getEntriesByName("merman:initial-preview-presented")
+            .length,
+      ),
+    ).toBe(0);
+
+    await replaceEditorSource(
+      page,
+      "flowchart LR\n  early[Early editor] --> latest[Latest source]",
+    );
     await expect
       .poll(() => workers.some((url) => /merman-language\.worker/i.test(url)))
       .toBe(true);
@@ -183,9 +196,12 @@ test("editor intent can activate language workers before a blocked preview", asy
       ),
     )
     .toBe(1);
+  await waitForPreviewSvg(page);
+  await expect.poll(() => previewSvgText(page)).toContain("Latest source");
   await expect(
     page.getByText("Language tools initializing", { exact: true }),
   ).toBeHidden();
+  errors.assertNone();
 });
 
 test("Tree-sitter worker returns version-bound tokens for incomplete emoji input", async ({


### PR DESCRIPTION
## Summary

The desktop Playground now becomes editable while Merman is still loading instead of waiting for the first preview render. This cuts editor-visible readiness roughly in half while keeping custom language workers behind the existing startup boundary.

## What changed

- Start the dynamically split Monaco editor shell alongside the initial preview render on desktop.
- Keep the Merman semantic worker and Tree-sitter syntax worker deferred until the first SVG or explicit editor intent.
- Preserve mobile pane deferral and cover the blocked-WASM startup path with a browser regression test.

## Verification

- [x] `cargo fmt --all --check` — not applicable; no Rust files changed
- [x] Relevant tests ran — prepared source suites, lint, production build, 76 desktop Chromium tests, 12 mobile Chromium tests, and Firefox/WebKit smoke tests
- [x] Benchmark or report updated if this affects performance — adjacent 8-pair AB/BA results are recorded below

## Performance / parity notes

Adjacent 8-pair AB/BA measurements on Apple M4 Pro with Chromium:

| Readiness metric | `main` | This PR | Change |
| --- | ---: | ---: | ---: |
| Cold first SVG | 499.25 ms | 494.75 ms | -0.90% |
| Cold editor visible | 856.85 ms | 401.05 ms | -53.19% |
| Cold language ready | 876.80 ms | 507.10 ms | -42.16% |
| Warm first SVG | 385.25 ms | 387.35 ms | +0.55% |
| Warm editor visible | 705.85 ms | 352.70 ms | -50.03% |
| Warm language ready | 722.15 ms | 400.00 ms | -44.61% |

- Benchmark or report: the initial static closure remains 22 files and 246.04 KiB gzip. Neither custom language worker starts before the first SVG without editor intent.
- Parity impact: none expected. Rendering, editor semantics, and mobile pane behavior are unchanged; only startup scheduling changes.
- Rollback risk: low. Under a 20 Mbps / 40 ms / 4x CPU diagnostic profile, cold first SVG increased by 7.13% while editor visibility improved by 76.21%; the preview result stayed below the pre-set joint rejection threshold of more than 10% and more than 50 ms.

## Follow-ups

None required.
