### PR TITLE
fix(sequence): preserve nested frame horizontal margins

### DIFF
--- a/crates/merman-render/src/model.rs
+++ b/crates/merman-render/src/model.rs
@@ -750,6 +750,10 @@ pub struct ErDiagramLayout {
 pub struct SequenceBlockLayout {
     pub start_y: f64,
     pub stop_y: f64,
+    /// Mermaid expands every active sequence frame by its nesting depth.
+    /// These coordinates are captured during layout replay rather than inferred from SVG nodes.
+    pub start_x: Option<f64>,
+    pub stop_x: Option<f64>,
     pub section_ys_by_id: FxHashMap<String, f64>,
 }
 

--- a/crates/merman-render/src/sequence/orchestration.rs
+++ b/crates/merman-render/src/sequence/orchestration.rs
@@ -61,6 +61,10 @@ pub(super) struct SequenceLayoutGraph {
 struct OpenSequenceBlockLayout {
     id: String,
     start_y: f64,
+    /// Position of this control block in Mermaid's active `sequenceItems` stack.
+    sequence_item_index: usize,
+    start_x: Option<f64>,
+    stop_x: Option<f64>,
     section_ys_by_id: rustc_hash::FxHashMap<String, f64>,
 }
 
@@ -113,10 +117,14 @@ impl<'a> SequenceLayoutLoopState<'a> {
     }
 
     fn open_sequence_block(&mut self, id: &str, start_y: f64) {
+        let sequence_item_index = self.block_stopy_stack.len();
         self.open_content_block();
         self.open_sequence_blocks.push(OpenSequenceBlockLayout {
             id: id.to_string(),
             start_y,
+            sequence_item_index,
+            start_x: None,
+            stop_x: None,
             section_ys_by_id: rustc_hash::FxHashMap::default(),
         });
     }
@@ -135,6 +143,27 @@ impl<'a> SequenceLayoutLoopState<'a> {
         let nested_margin = self.block_stopy_stack.len() as f64 * box_margin;
         self.bounds_start_x = self.bounds_start_x.min(min_x - nested_margin);
         self.bounds_stop_x = self.bounds_stop_x.max(max_x + nested_margin);
+
+        // Mermaid updates every active sequence item for each insertion. The outermost item gets
+        // the largest margin, while the innermost item gets one box margin. `block_stopy_stack`
+        // mirrors that stack and also includes `rect` items, which do not have a control frame.
+        let sequence_item_depth = self.block_stopy_stack.len();
+        for block in &mut self.open_sequence_blocks {
+            let depth_margin =
+                sequence_item_depth.saturating_sub(block.sequence_item_index) as f64 * box_margin;
+            let frame_start_x = min_x - depth_margin;
+            let frame_stop_x = max_x + depth_margin;
+            block.start_x = Some(
+                block
+                    .start_x
+                    .map_or(frame_start_x, |current| current.min(frame_start_x)),
+            );
+            block.stop_x = Some(
+                block
+                    .stop_x
+                    .map_or(frame_stop_x, |current| current.max(frame_stop_x)),
+            );
+        }
     }
 
     fn close_content_block(&mut self, box_margin: f64) {
@@ -149,6 +178,8 @@ impl<'a> SequenceLayoutLoopState<'a> {
                 SequenceBlockLayout {
                     start_y: open.start_y,
                     stop_y: self.cursor_y,
+                    start_x: open.start_x,
+                    stop_x: open.stop_x,
                     section_ys_by_id: open.section_ys_by_id,
                 },
             );

--- a/crates/merman-render/src/svg/parity/sequence/blocks.rs
+++ b/crates/merman-render/src/svg/parity/sequence/blocks.rs
@@ -140,10 +140,13 @@ pub(super) fn render_simple_sequence_block(
         return;
     };
 
-    let (frame_x1, frame_x2, _min_left) = block
-        .geometry
-        .frame_x(ctx.actor_nodes_by_id)
-        .unwrap_or((ctx.default_frame_x1, ctx.default_frame_x2, f64::INFINITY));
+    let (frame_x1, frame_x2) = layout.start_x.zip(layout.stop_x).unwrap_or_else(|| {
+        block
+            .geometry
+            .frame_x(ctx.actor_nodes_by_id)
+            .map(|(x1, x2, _)| (x1, x2))
+            .unwrap_or((ctx.default_frame_x1, ctx.default_frame_x2))
+    });
 
     let frame_y1 = layout.start_y;
     let frame_y2 = layout.stop_y;
@@ -218,11 +221,12 @@ pub(super) fn render_sectioned_sequence_block(
         return;
     };
 
-    let (frame_x1, frame_x2, _min_left) = geometry.frame_x(ctx.actor_nodes_by_id).unwrap_or((
-        ctx.default_frame_x1,
-        ctx.default_frame_x2,
-        f64::INFINITY,
-    ));
+    let (frame_x1, frame_x2) = layout.start_x.zip(layout.stop_x).unwrap_or_else(|| {
+        geometry
+            .frame_x(ctx.actor_nodes_by_id)
+            .map(|(x1, x2, _)| (x1, x2))
+            .unwrap_or((ctx.default_frame_x1, ctx.default_frame_x2))
+    });
 
     let frame_y1 = layout.start_y;
     let frame_y2 = layout.stop_y;
@@ -315,11 +319,13 @@ pub(super) fn render_critical_sequence_block(
         return;
     };
 
-    let (mut frame_x1, frame_x2, min_left) = geometry.frame_x(ctx.actor_nodes_by_id).unwrap_or((
-        ctx.default_frame_x1,
-        ctx.default_frame_x2,
-        f64::INFINITY,
-    ));
+    let (mut frame_x1, mut frame_x2, min_left) = geometry
+        .frame_x(ctx.actor_nodes_by_id)
+        .unwrap_or((ctx.default_frame_x1, ctx.default_frame_x2, f64::INFINITY));
+    if let Some((layout_x1, layout_x2)) = layout.start_x.zip(layout.stop_x) {
+        frame_x1 = layout_x1;
+        frame_x2 = layout_x2;
+    }
     if sections.len() > 1 && min_left.is_finite() {
         // Mermaid's `critical` w/ `option` sections widens the frame to the left.
         frame_x1 = frame_x1.min(min_left - 9.0);

--- a/crates/merman-render/tests/sequence_svg_test.rs
+++ b/crates/merman-render/tests/sequence_svg_test.rs
@@ -610,6 +610,48 @@ fn render_sequence_svg_from_text_with_engine(engine: Engine, text: &str) -> Stri
         .to_string()
 }
 
+fn sequence_control_frame_x(svg: &str, label: &str) -> (f64, f64) {
+    let document = roxmltree::Document::parse(svg).expect("valid Sequence SVG");
+    let group = document
+        .descendants()
+        .find(|node| {
+            node.is_element()
+                && node.tag_name().name() == "g"
+                && node.attribute("data-et") == Some("control-structure")
+                && node
+                    .descendants()
+                    .filter(|descendant| descendant.is_text())
+                    .filter_map(|descendant| descendant.text())
+                    .any(|text| text.contains(label))
+        })
+        .unwrap_or_else(|| panic!("missing control structure {label:?}: {svg}"));
+
+    let mut min_x = f64::INFINITY;
+    let mut max_x = f64::NEG_INFINITY;
+    for line in group.children().filter(|node| {
+        node.is_element()
+            && node.tag_name().name() == "line"
+            && node.attribute("class") == Some("loopLine")
+            && node.attribute("style").is_none()
+    }) {
+        let x1 = line
+            .attribute("x1")
+            .and_then(|value| value.parse::<f64>().ok())
+            .expect("numeric frame x1");
+        let x2 = line
+            .attribute("x2")
+            .and_then(|value| value.parse::<f64>().ok())
+            .expect("numeric frame x2");
+        min_x = min_x.min(x1).min(x2);
+        max_x = max_x.max(x1).max(x2);
+    }
+    assert!(
+        min_x.is_finite() && max_x.is_finite(),
+        "control structure {label:?} has no frame lines: {svg}"
+    );
+    (min_x, max_x)
+}
+
 #[test]
 fn sequence_actor_links_follow_mermaid_security_level() {
     let strict = render_sequence_svg_from_text(
@@ -1997,7 +2039,7 @@ fn sequence_zed_59651_nested_frame_headers_follow_the_preceding_note() {
 }
 
 #[test]
-fn sequence_issue_86_nested_loop_and_alt_labels_keep_separate_vertical_positions() {
+fn sequence_issue_86_nested_loop_and_alt_frames_follow_nested_depth() {
     let svg = render_sequence_svg_from_text(
         r#"sequenceDiagram
     participant A
@@ -2034,6 +2076,44 @@ fn sequence_issue_86_nested_loop_and_alt_labels_keep_separate_vertical_positions
     assert!(
         inner_y - outer_y >= 20.0,
         "nested loop and alt labels must occupy separate vertical bands, got outer y={outer_y}, inner y={inner_y}: {svg}"
+    );
+
+    let (outer_x1, outer_x2) = sequence_control_frame_x(&svg, "[Outer loop]");
+    let (inner_x1, inner_x2) = sequence_control_frame_x(&svg, "[Inner branch]");
+    assert!(
+        outer_x1 < inner_x1 && outer_x2 > inner_x2,
+        "nested frame sides must expand with depth, got outer x={outer_x1}..{outer_x2}, inner x={inner_x1}..{inner_x2}: {svg}"
+    );
+    assert!(
+        (inner_x1 - outer_x1 - 10.0).abs() < 0.0001 && (outer_x2 - inner_x2 - 10.0).abs() < 0.0001,
+        "nested frame sides must use Mermaid's box margin, got outer x={outer_x1}..{outer_x2}, inner x={inner_x1}..{inner_x2}: {svg}"
+    );
+}
+
+#[test]
+fn sequence_nested_rect_contributes_to_parent_frame_depth() {
+    let svg = render_sequence_svg_from_text(
+        r#"sequenceDiagram
+    participant A
+    participant B
+    loop Outer loop
+        rect rgb(240,240,240)
+            alt Inner branch
+                A->>B: Message
+            end
+        end
+    end
+"#,
+    );
+    let (outer_x1, outer_x2) = sequence_control_frame_x(&svg, "[Outer loop]");
+    let (inner_x1, inner_x2) = sequence_control_frame_x(&svg, "[Inner branch]");
+    assert!(
+        outer_x1 < inner_x1 && outer_x2 > inner_x2,
+        "the parent frame must remain wider than the nested control frame: {svg}"
+    );
+    assert!(
+        (inner_x1 - outer_x1 - 20.0).abs() < 0.0001 && (outer_x2 - inner_x2 - 20.0).abs() < 0.0001,
+        "a nested rect must consume one additional Mermaid sequence-item margin, got outer x={outer_x1}..{outer_x2}, inner x={inner_x1}..{inner_x2}: {svg}"
     );
 }
 

--- a/crates/merman-render/tests/sequence_svg_test.rs
+++ b/crates/merman-render/tests/sequence_svg_test.rs
@@ -1997,6 +1997,47 @@ fn sequence_zed_59651_nested_frame_headers_follow_the_preceding_note() {
 }
 
 #[test]
+fn sequence_issue_86_nested_loop_and_alt_labels_keep_separate_vertical_positions() {
+    let svg = render_sequence_svg_from_text(
+        r#"sequenceDiagram
+    participant A
+    participant B
+    loop Outer loop
+        alt Inner branch
+            A->>B: Message
+        end
+    end
+"#,
+    );
+    let document = roxmltree::Document::parse(&svg).expect("valid Sequence SVG");
+
+    let title_y = |label: &str| {
+        document
+            .descendants()
+            .find(|node| {
+                node.is_element()
+                    && node.tag_name().name() == "text"
+                    && node.attribute("class") == Some("loopText")
+                    && node
+                        .descendants()
+                        .filter(|descendant| descendant.is_text())
+                        .filter_map(|descendant| descendant.text())
+                        .any(|text| text.contains(label))
+            })
+            .and_then(|node| node.attribute("y"))
+            .and_then(|value| value.parse::<f64>().ok())
+            .unwrap_or_else(|| panic!("missing numeric loop title {label:?}: {svg}"))
+    };
+
+    let outer_y = title_y("[Outer loop]");
+    let inner_y = title_y("[Inner branch]");
+    assert!(
+        inner_y - outer_y >= 20.0,
+        "nested loop and alt labels must occupy separate vertical bands, got outer y={outer_y}, inner y={inner_y}: {svg}"
+    );
+}
+
+#[test]
 fn sequence_rect_block_is_root_level_before_actors() {
     let svg = render_sequence_svg_from_fixture("upstream_rect_block_spec.mmd");
 


### PR DESCRIPTION
## Summary

Nested sequence control frames now expand by Mermaid's active `sequenceItems` depth, so a parent frame no longer shares both vertical sides with its child frame.

Fixes #86.

## What changed

- Capture each active control frame's horizontal bounds during sequence layout replay.
- Count nested `rect` entries in the same depth stack, matching upstream Mermaid behavior.
- Render simple, sectioned, and critical control frames from the captured bounds while retaining the geometry fallback.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo nextest run --locked -p merman-render --test sequence_svg_test --no-fail-fast` (42 passed)
- [x] `cargo nextest run -p merman-render --lib --no-fail-fast` (1087 passed)
- [x] `cargo clippy -p merman-render --all-targets -- -D warnings`
- [x] `cargo run --locked --release -p xtask -- compare-all-svgs --check-dom --dom-mode structure --dom-decimals 3`
- [x] CLI SVG and PNG check of the issue input: inner frame `x=64..286`, outer frame `x=54..296`
- [x] Benchmark or report updated if this affects performance (not applicable; no performance contract changed)

## Performance / parity notes

- Benchmark or report: Not applicable.
- Parity impact: Aligns Sequence frame bounds with Mermaid's nesting-margin semantics.
- Rollback risk: Low; the change is limited to Sequence control-frame coordinates and preserves the existing geometry fallback.

## Follow-ups

None.
