### PR TITLE
refactor(ascii): unify relation materialization observer seam

### DIFF
--- a/crates/merman-ascii/src/canvas.rs
+++ b/crates/merman-ascii/src/canvas.rs
@@ -1055,30 +1055,41 @@ pub(crate) fn finish_styled_line_iter_with_deferred_resources_with_execution<'a,
 where
     I: Clone + Iterator<Item = &'a crate::text::StyledLine>,
 {
-    debug_assert_eq!(resources.policy(), *execution.resources());
-    finish_styled_line_iter(lines, options, trim, resources, Some(deferred), execution)
+    finish_styled_line_iter_with_deferred_resources_with_execution_and_observer(
+        lines,
+        options,
+        trim,
+        resources,
+        deferred,
+        execution,
+        || {},
+    )
 }
 
-#[cfg(test)]
-pub(crate) fn finish_styled_line_iter_with_deferred_probe<'a, 'text, I>(
+pub(crate) fn finish_styled_line_iter_with_deferred_resources_with_execution_and_observer<
+    'a,
+    'text,
+    I,
+>(
     lines: I,
     options: &AsciiRenderOptions,
     trim: bool,
     resources: &mut ResourceContext,
     deferred: &DeferredTextRegistry<'text>,
+    execution: AsciiExecution<'_>,
     before_materialize: impl FnOnce(),
 ) -> crate::Result<String>
 where
     I: Clone + Iterator<Item = &'a crate::text::StyledLine>,
 {
-    let policy = resources.policy();
+    debug_assert_eq!(resources.policy(), *execution.resources());
     finish_styled_line_iter_with_observer(
         lines,
         options,
         trim,
         resources,
         Some(deferred),
-        AsciiExecution::for_test(&policy),
+        execution,
         before_materialize,
     )
 }

--- a/crates/merman-ascii/src/relation_graph/encode.rs
+++ b/crates/merman-ascii/src/relation_graph/encode.rs
@@ -1,10 +1,8 @@
 use super::RelationGraphLine;
 use crate::Result;
 #[cfg(test)]
-use crate::canvas::finish_styled_line_iter_with_deferred_probe;
-#[cfg(test)]
 use crate::canvas::finish_styled_line_iter_with_deferred_resources;
-use crate::canvas::finish_styled_line_iter_with_deferred_resources_with_execution;
+use crate::canvas::finish_styled_line_iter_with_deferred_resources_with_execution_and_observer;
 use crate::operation::AsciiExecution;
 use crate::options::AsciiRenderOptions;
 use crate::resource::ResourceContext;
@@ -57,19 +55,37 @@ pub(crate) fn render_lines_with_deferred_options_with_execution(
     deferred: &DeferredTextRegistry<'_>,
     execution: AsciiExecution<'_>,
 ) -> Result<String> {
+    render_lines_with_deferred_options_with_execution_and_observer(
+        lines,
+        options,
+        resources,
+        deferred,
+        execution,
+        || {},
+    )
+}
+
+pub(crate) fn render_lines_with_deferred_options_with_execution_and_observer(
+    lines: &[RelationGraphLine],
+    options: &AsciiRenderOptions,
+    resources: &mut ResourceContext,
+    deferred: &DeferredTextRegistry<'_>,
+    execution: AsciiExecution<'_>,
+    before_materialize: impl FnOnce(),
+) -> Result<String> {
     if lines.is_empty() {
         return Ok(String::new());
     }
 
     assert_width_profile(lines, options);
-    let mut resources = execution.resource_context(resources, merman_core::OperationPhase::Emit);
-    finish_styled_line_iter_with_deferred_resources_with_execution(
+    finish_styled_line_iter_with_deferred_resources_with_execution_and_observer(
         lines.iter().map(RelationGraphLine::styled),
         options,
         true,
-        &mut resources,
+        resources,
         deferred,
         execution,
+        before_materialize,
     )
 }
 
@@ -81,17 +97,13 @@ pub(crate) fn render_lines_with_deferred_probe(
     deferred: &DeferredTextRegistry<'_>,
     before_materialize: impl FnOnce(),
 ) -> Result<String> {
-    if lines.is_empty() {
-        return Ok(String::new());
-    }
-
-    assert_width_profile(lines, options);
-    finish_styled_line_iter_with_deferred_probe(
-        lines.iter().map(RelationGraphLine::styled),
+    let policy = resources.policy();
+    render_lines_with_deferred_options_with_execution_and_observer(
+        lines,
         options,
-        true,
         resources,
         deferred,
+        AsciiExecution::for_test(&policy),
         before_materialize,
     )
 }


### PR DESCRIPTION
## Summary

- Route relation-graph test observation through the same production materialization seam.
- Remove the canvas-specific deferred probe finalizer.
- Avoid the extra relation-graph ResourceContext rebinding.

## Validation

- cargo fmt -p merman-ascii -- --check
- git diff --check
- CARGO_BUILD_JOBS=1 cargo nextest run -p merman-ascii --lib -j 1 (672 passed)

## Scope

This PR intentionally does not change AsciiExecution::for_test, the core test-support feature, or public error naming. Those remain separate cleanup candidates.
