### PR TITLE
refactor(ascii): centralize integration test render helpers

### DIFF
--- a/crates/merman-ascii/tests/new_family_models.rs
+++ b/crates/merman-ascii/tests/new_family_models.rs
@@ -20,7 +20,7 @@ use merman_core::diagrams::timeline::{
 };
 use merman_core::diagrams::tree_view::{TreeViewDiagramRenderModel, TreeViewNodeRenderModel};
 use merman_core::{DiagramWarningFact, GIT_GRAPH_DUPLICATE_COMMIT_WARNING_RULE_ID};
-use support::{render_controlled_model, render_model};
+use support::{render_controlled_model, render_model, render_source};
 
 fn render(model: RenderSemanticModel) -> String {
     render_model(&model, &AsciiRenderOptions::ascii()).unwrap()
@@ -30,13 +30,8 @@ fn render_with_options(model: RenderSemanticModel, options: &AsciiRenderOptions)
     render_model(&model, options).unwrap()
 }
 
-fn render_parsed(input: &str) -> String {
-    let engine = merman_core::Engine::new();
-    let parsed = engine
-        .parse_diagram_for_render_model_sync(input, merman_core::ParseOptions::strict())
-        .unwrap()
-        .unwrap();
-    render_model(parsed.model(), &AsciiRenderOptions::ascii()).unwrap()
+fn render_parsed(source: &str) -> String {
+    render_source(source)
 }
 
 fn render_with_scheduled_cancellation(

--- a/crates/merman-ascii/tests/operation_cancellation.rs
+++ b/crates/merman-ascii/tests/operation_cancellation.rs
@@ -9,17 +9,8 @@ use merman_core::diagrams::mindmap::{MindmapDiagramRenderModel, MindmapDiagramRe
 use merman_core::diagrams::packet::{PacketDiagramRenderModel, PacketRenderBlock};
 use merman_core::diagrams::timeline::TimelineDiagramRenderModel;
 use merman_core::diagrams::tree_view::TreeViewDiagramRenderModel;
-use merman_core::{Engine, OperationControl, OperationPhase, ParseOptions, RenderSemanticModel};
-use support::{render_controlled_model, render_model};
-
-fn parse_model(source: &str) -> RenderSemanticModel {
-    Engine::new()
-        .parse_diagram_for_render_model_sync(source, ParseOptions::strict())
-        .expect("diagram should parse")
-        .expect("diagram should be detected")
-        .into_parts()
-        .1
-}
+use merman_core::{Engine, OperationControl, OperationPhase, RenderSemanticModel};
+use support::{parse_model, render_controlled_model, render_model};
 
 fn operation_context() -> merman_core::runtime::OperationContext {
     Engine::new()

--- a/crates/merman-ascii/tests/sectioned_structured_text.rs
+++ b/crates/merman-ascii/tests/sectioned_structured_text.rs
@@ -4,17 +4,7 @@ use merman_ascii::{AsciiError, AsciiRenderOptions};
 use merman_core::diagram::RenderSemanticModel;
 use merman_core::diagrams::journey::{JourneyDiagramRenderModel, JourneyRenderTask};
 use merman_core::diagrams::timeline::{TimelineDiagramRenderModel, TimelineRenderTask};
-use merman_core::{Engine, ParseOptions};
-use support::render_model;
-
-fn render_parsed(source: &str) -> String {
-    let parsed = Engine::new()
-        .parse_diagram_for_render_model_sync(source, ParseOptions::strict())
-        .expect("diagram should parse")
-        .expect("diagram should be detected");
-    render_model(parsed.model(), &AsciiRenderOptions::ascii())
-        .expect("parsed structured-text diagram should render")
-}
+use support::{render_model, render_source};
 
 fn timeline_task(section: &str, section_index: Option<usize>, task: &str) -> TimelineRenderTask {
     TimelineRenderTask {
@@ -42,7 +32,7 @@ fn journey_task(section: &str, section_index: Option<usize>, task: &str) -> Jour
 
 #[test]
 fn timeline_duplicate_section_fixture_preserves_occurrence_ownership() {
-    let rendered = render_parsed(include_str!(
+    let rendered = render_source(include_str!(
         "../../../fixtures/timeline/timeline_stress_section_name_repeated.mmd"
     ));
 
@@ -65,7 +55,7 @@ fn timeline_duplicate_section_fixture_preserves_occurrence_ownership() {
 
 #[test]
 fn journey_duplicate_sections_preserve_parser_occurrence_ownership() {
-    let rendered = render_parsed(concat!(
+    let rendered = render_source(concat!(
         "journey\n",
         "title Repeated journey\n",
         "section Repeated\n",

--- a/crates/merman-ascii/tests/support/mod.rs
+++ b/crates/merman-ascii/tests/support/mod.rs
@@ -1,6 +1,15 @@
 use merman_ascii::{AsciiRenderOptions, AsciiRenderer, AsciiResourcePolicy};
 use merman_core::diagram::{ParsedDiagramRender, RenderSemanticModel};
-use merman_core::{OperationControl, runtime::OperationContext};
+use merman_core::{Engine, OperationControl, ParseOptions, runtime::OperationContext};
+
+pub(crate) fn parse_model(source: &str) -> RenderSemanticModel {
+    Engine::new()
+        .parse_diagram_for_render_model_sync(source, ParseOptions::strict())
+        .expect("diagram should parse")
+        .expect("diagram should be detected")
+        .into_parts()
+        .1
+}
 
 #[allow(dead_code)]
 pub(crate) fn render_model(
@@ -41,6 +50,11 @@ pub(crate) fn render_parsed(
         &context,
         AsciiResourcePolicy::default(),
     )
+}
+
+#[allow(dead_code)]
+pub(crate) fn render_source(source: &str) -> String {
+    render_model(&parse_model(source), &AsciiRenderOptions::ascii()).expect("diagram should render")
 }
 
 pub(crate) fn render_controlled_model(

--- a/crates/merman-ascii/tests/terminal_text_safety.rs
+++ b/crates/merman-ascii/tests/terminal_text_safety.rs
@@ -3,17 +3,8 @@ mod support;
 use merman_ascii::{AsciiColorMode, AsciiRenderOptions, TerminalWidthProfile};
 use merman_core::diagram::RenderSemanticModel;
 use merman_core::diagrams::git_graph::{GitGraphBranchRenderModel, GitGraphRenderModel};
-use merman_core::{Engine, ParseOptions};
-use support::render_model;
+use support::{parse_model, render_model};
 use unicode_width::UnicodeWidthStr;
-
-fn parse_model(source: &str) -> RenderSemanticModel {
-    let parsed = Engine::new()
-        .parse_diagram_for_render_model_sync(source, ParseOptions::strict())
-        .expect("diagram should parse")
-        .expect("diagram should be detected");
-    parsed.into_parts().1
-}
 
 fn render(source: &str, options: &AsciiRenderOptions) -> String {
     render_model(&parse_model(source), options).expect("diagram should render")


### PR DESCRIPTION
## Summary

- centralize repeated parser-to-model test setup in tests/support
- reuse one source-render helper for structured-text fixtures
- keep all parser-backed, direct-model, and cancellation assertions unchanged

## Validation

- cargo fmt -p merman-ascii -- --check
- git diff --check
- CARGO_BUILD_JOBS=1 cargo nextest run -p merman-ascii --test new_family_models --test operation_cancellation --test sectioned_structured_text --test terminal_text_safety -j 1 (70 passed)

## Scope

Test-only cleanup; no production code, public API, evidence, or CI behavior changes.
