### PR TITLE
feat(node): add explicit Node WASM npm package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -657,6 +657,27 @@ jobs:
         if: github.event_name != 'push'
         run: node platforms/node/scripts/build-candidate.mjs --candidate node-wasm
 
+      - name: Assemble and install-smoke the Node-WASM npm package on PRs
+        if: github.event_name != 'push'
+        run: |
+          set -euo pipefail
+          package_root="$RUNNER_TEMP/node-wasm-package"
+          artifact_dir="$RUNNER_TEMP/node-wasm-smoke-artifact"
+          smoke_root="$RUNNER_TEMP/node-wasm-install-smoke"
+          version="$(node -p "JSON.parse(require('fs').readFileSync('platforms/node/package-surfaces.json', 'utf8')).version")"
+          node platforms/node/scripts/assemble-packages.mjs --wasm --output-root "$package_root"
+          node platforms/node/scripts/verify-packages.mjs --packed-root "$package_root"
+          mkdir -p "$artifact_dir" "$smoke_root"
+          npm pack "$package_root/node-wasm" --json --pack-destination "$artifact_dir" > "$RUNNER_TEMP/node-wasm-pack.json"
+          test "$(find "$artifact_dir" -maxdepth 1 -name '*.tgz' -type f | wc -l | tr -d ' ')" = 1
+          cd "$smoke_root"
+          npm init -y >/dev/null
+          npm install --ignore-scripts --no-audit --no-fund "$artifact_dir"/*.tgz >/dev/null
+          node "$GITHUB_WORKSPACE/platforms/node/scripts/smoke-installed-package.mjs" \
+            --project "$smoke_root" \
+            --version "$version" \
+            --target node-wasm
+
       - name: Build and probe the real Node N-API candidate on PRs
         if: github.event_name != 'push'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -508,11 +508,31 @@ jobs:
 
       - name: Build and probe the Node-WASM candidate
         if: matrix.parity && github.event_name == 'push'
-        run: npm run --prefix platforms/node build:candidate -- --candidate node-wasm
+        run: node platforms/node/scripts/build-candidate.mjs --candidate node-wasm
 
       - name: Build and probe the Node N-API candidate
         if: matrix.parity && github.event_name == 'push'
-        run: npm run --prefix platforms/node build:candidate -- --candidate napi --target linux-x64-gnu
+        run: |
+          set -euo pipefail
+          docker build \
+            --platform linux/amd64 \
+            --file platforms/node/Dockerfile.gnu \
+            --build-arg NODE_IMAGE=node:24-bullseye \
+            --build-arg RUST_IMAGE=rust:1.95-bullseye \
+            --tag merman-node-gnu:ci \
+            platforms/node
+          docker run --rm \
+            --platform linux/amd64 \
+            -e CARGO_INCREMENTAL=0 \
+            -v "$GITHUB_WORKSPACE:/work" \
+            -w /work \
+            merman-node-gnu:ci \
+            sh -c '
+              set -eu
+              git config --global --add safe.directory /work
+              npm ci --prefix platforms/node
+              node platforms/node/scripts/build-candidate.mjs --candidate napi --target linux-x64-gnu
+            '
 
       - name: Verify committed upstream alignment manifests
         if: matrix.parity
@@ -635,11 +655,31 @@ jobs:
 
       - name: Build and probe the real Node-WASM candidate on PRs
         if: github.event_name != 'push'
-        run: npm run --prefix platforms/node build:candidate -- --candidate node-wasm
+        run: node platforms/node/scripts/build-candidate.mjs --candidate node-wasm
 
       - name: Build and probe the real Node N-API candidate on PRs
         if: github.event_name != 'push'
-        run: npm run --prefix platforms/node build:candidate -- --candidate napi --target linux-x64-gnu
+        run: |
+          set -euo pipefail
+          docker build \
+            --platform linux/amd64 \
+            --file platforms/node/Dockerfile.gnu \
+            --build-arg NODE_IMAGE=node:24-bullseye \
+            --build-arg RUST_IMAGE=rust:1.95-bullseye \
+            --tag merman-node-gnu:ci \
+            platforms/node
+          docker run --rm \
+            --platform linux/amd64 \
+            -e CARGO_INCREMENTAL=0 \
+            -v "$GITHUB_WORKSPACE:/work" \
+            -w /work \
+            merman-node-gnu:ci \
+            sh -c '
+              set -eu
+              git config --global --add safe.directory /work
+              npm ci --prefix platforms/node
+              node platforms/node/scripts/build-candidate.mjs --candidate napi --target linux-x64-gnu
+            '
 
   typst-package:
     name: typst-package

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -12,6 +12,11 @@ on:
         required: true
         default: "main"
         type: string
+      recovery_run_id:
+        description: "Prior non-publishing release-node run containing the verified package group"
+        required: false
+        default: ""
+        type: string
       publish_to_npm:
         description: "Publish the verified @mermanjs/node package group"
         required: true
@@ -35,6 +40,7 @@ jobs:
       release_tag: ${{ steps.release.outputs.release_tag }}
       version: ${{ steps.release.outputs.version }}
       npm_dist_tag: ${{ steps.release.outputs.npm_dist_tag }}
+      recovery_run_id: ${{ steps.release.outputs.recovery_run_id }}
     steps:
       - uses: actions/checkout@v7.0.1
         with:
@@ -47,6 +53,7 @@ jobs:
         env:
           DISPATCH_RELEASE_TAG: ${{ inputs.release_tag }}
           DISPATCH_SOURCE_REF: ${{ inputs.source_ref }}
+          DISPATCH_RECOVERY_RUN_ID: ${{ inputs.recovery_run_id }}
           DISPATCH_PUBLISH_TO_NPM: ${{ inputs.publish_to_npm }}
         run: |
           set -euo pipefail
@@ -61,6 +68,17 @@ jobs:
             echo "::error::source_ref must be a single line" >&2
             exit 1
           }
+          RECOVERY_RUN_ID="$DISPATCH_RECOVERY_RUN_ID"
+          if [ -n "$RECOVERY_RUN_ID" ]; then
+            [[ "$RECOVERY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || {
+              echo "::error::recovery_run_id must be a positive GitHub Actions run id" >&2
+              exit 1
+            }
+            [[ "$DISPATCH_PUBLISH_TO_NPM" == "true" ]] || {
+              echo "::error::recovery_run_id requires publish_to_npm=true" >&2
+              exit 1
+            }
+          fi
           if [[ "$SOURCE_REF" =~ ^[0-9a-f]{40}$ ]]; then
             validated_source_ref="$SOURCE_REF"
           elif [[ "$SOURCE_REF" == "main" || "$SOURCE_REF" == "refs/heads/main" ]]; then
@@ -80,6 +98,7 @@ jobs:
             printf 'release_tag=%s\n' "$RELEASE_TAG"
             printf 'version=%s\n' "$version"
             printf 'npm_dist_tag=%s\n' "$npm_dist_tag"
+            printf 'recovery_run_id=%s\n' "$RECOVERY_RUN_ID"
           } >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v7.0.1
@@ -501,11 +520,12 @@ jobs:
     needs:
       - validate-inputs
       - package-group
-    if: ${{ inputs.publish_to_npm }}
+    if: ${{ always() && needs.validate-inputs.result == 'success' && inputs.publish_to_npm && (needs.package-group.result == 'success' || needs.validate-inputs.outputs.recovery_run_id != '') }}
     name: publish npm package group
     runs-on: ubuntu-24.04
     environment: npm
     permissions:
+      actions: read
       contents: read
       id-token: write
     steps:
@@ -535,6 +555,8 @@ jobs:
         with:
           name: merman-node-npm-package-group
           path: target/node-npm-package-group
+          github-token: ${{ github.token }}
+          run-id: ${{ needs.validate-inputs.outputs.recovery_run_id != '' && needs.validate-inputs.outputs.recovery_run_id || github.run_id }}
 
       - name: Verify downloaded Node package group
         env:

--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -139,7 +139,7 @@ jobs:
         run: |
           npm ci --prefix platforms/node
           npm test --prefix platforms/node
-          npm run --prefix platforms/node check:packages
+          node platforms/node/scripts/verify-packages.mjs
 
       - name: Pack loader package
         shell: bash
@@ -161,6 +161,85 @@ jobs:
         with:
           name: merman-node-npm-loader
           path: ${{ runner.temp }}/node-loader-artifact/*.tgz
+          if-no-files-found: error
+
+  node-wasm-package:
+    needs: validate-inputs
+    name: Node WASM package
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ needs.validate-inputs.outputs.source_sha }}
+          persist-credentials: false
+
+      - name: Verify pinned release source and versions
+        env:
+          SOURCE_SHA: ${{ needs.validate-inputs.outputs.source_sha }}
+          SOURCE_TREE: ${{ needs.validate-inputs.outputs.source_tree }}
+          VERSION: ${{ needs.validate-inputs.outputs.version }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse 'HEAD^{commit}')" = "$SOURCE_SHA"
+          test "$(git rev-parse 'HEAD^{tree}')" = "$SOURCE_TREE"
+          python3 scripts/release-version.py check --version "$VERSION"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.95.0
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2.9.2
+        with:
+          workspaces: crates/merman-node
+
+      - name: Setup Node
+        uses: actions/setup-node@v7.0.0
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: platforms/node/package-lock.json
+
+      - name: Install pinned Node build dependencies
+        run: npm ci --prefix platforms/node
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --version 0.15.0 --locked
+
+      - name: Build and probe Node WASM candidate
+        run: node platforms/node/scripts/build-candidate.mjs --candidate node-wasm
+
+      - name: Assemble and verify Node WASM package
+        env:
+          VERSION: ${{ needs.validate-inputs.outputs.version }}
+        run: |
+          set -euo pipefail
+          package_root="$RUNNER_TEMP/node-wasm-package"
+          artifact_dir="$RUNNER_TEMP/node-wasm-artifact"
+          node platforms/node/scripts/assemble-packages.mjs --wasm --output-root "$package_root"
+          node platforms/node/scripts/verify-packages.mjs --packed-root "$package_root"
+          mkdir -p "$artifact_dir"
+          npm pack "$package_root/node-wasm" --json --pack-destination "$artifact_dir" > "$RUNNER_TEMP/node-wasm-pack.json"
+
+          smoke_root="$RUNNER_TEMP/node-wasm-install-smoke"
+          mkdir -p "$smoke_root"
+          cd "$smoke_root"
+          npm init -y >/dev/null
+          npm install --ignore-scripts --no-audit --no-fund "$artifact_dir"/*.tgz >/dev/null
+          node "$GITHUB_WORKSPACE/platforms/node/scripts/smoke-installed-package.mjs" \
+            --project "$smoke_root" \
+            --version "$VERSION" \
+            --target node-wasm
+
+      - name: Upload Node WASM package
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: merman-node-npm-wasm
+          path: ${{ runner.temp }}/node-wasm-artifact/*.tgz
           if-no-files-found: error
 
   platform:
@@ -207,13 +286,13 @@ jobs:
           python3 scripts/release-version.py check --version "$VERSION"
 
       - name: Install Rust toolchain
-        if: matrix.target != 'linux-x64-musl'
+        if: matrix.target != 'linux-x64-musl' && matrix.target != 'linux-x64-gnu'
         uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: ${{ matrix.rust_target }}
 
       - name: Rust cache
-        if: matrix.target != 'linux-x64-musl'
+        if: matrix.target != 'linux-x64-musl' && matrix.target != 'linux-x64-gnu'
         uses: Swatinem/rust-cache@v2.9.2
         with:
           workspaces: crates/merman-node
@@ -245,13 +324,13 @@ jobs:
               set -eu
               git config --global --add safe.directory /work
               npm ci --prefix platforms/node
-              npm run --prefix platforms/node build:candidate -- --candidate napi --target "$TARGET"
+              node platforms/node/scripts/build-candidate.mjs --candidate napi --target "$TARGET"
               package_root=/runner-temp/node-packages
               artifact_dir=/runner-temp/node-platform-artifact
               smoke_tarballs=/runner-temp/node-smoke-tarballs
               smoke_root=/runner-temp/node-install-smoke
               node platforms/node/scripts/assemble-packages.mjs --target "$TARGET" --output-root "$package_root"
-              npm run --prefix platforms/node check:packages -- --packed-root "$package_root"
+              node platforms/node/scripts/verify-packages.mjs --packed-root "$package_root"
               mkdir -p "$artifact_dir" "$smoke_tarballs" "$smoke_root"
               npm pack "$package_root/node" --json --pack-destination "$smoke_tarballs" >/runner-temp/node-root-pack.json
               npm pack "$package_root/$TARGET" --json --pack-destination "$artifact_dir" >/runner-temp/node-target-pack.json
@@ -263,8 +342,53 @@ jobs:
               node /work/platforms/node/scripts/smoke-installed-package.mjs --project "$smoke_root" --version "$VERSION" --target "$TARGET"
             '
 
+      - name: Build, package, and smoke GNU target
+        if: matrix.target == 'linux-x64-gnu'
+        env:
+          TARGET: ${{ matrix.target }}
+          VERSION: ${{ needs.validate-inputs.outputs.version }}
+        run: |
+          set -euo pipefail
+          docker build \
+            --platform linux/amd64 \
+            --file platforms/node/Dockerfile.gnu \
+            --build-arg NODE_IMAGE=node:24-bullseye \
+            --build-arg RUST_IMAGE=rust:1.95-bullseye \
+            --tag merman-node-gnu:ci \
+            platforms/node
+          docker run --rm \
+            --platform linux/amd64 \
+            -e CARGO_INCREMENTAL=0 \
+            -e TARGET="$TARGET" \
+            -e VERSION="$VERSION" \
+            -v "$GITHUB_WORKSPACE:/work" \
+            -v "$RUNNER_TEMP:/runner-temp" \
+            -w /work \
+            merman-node-gnu:ci \
+            sh -c '
+              set -eu
+              git config --global --add safe.directory /work
+              test "$(node -p "process.report.getReport().header.glibcVersionRuntime")" = "2.31"
+              npm ci --prefix platforms/node
+              node platforms/node/scripts/build-candidate.mjs --candidate napi --target "$TARGET"
+              package_root=/runner-temp/node-packages
+              artifact_dir=/runner-temp/node-platform-artifact
+              smoke_tarballs=/runner-temp/node-smoke-tarballs
+              smoke_root=/runner-temp/node-install-smoke
+              node platforms/node/scripts/assemble-packages.mjs --target "$TARGET" --output-root "$package_root"
+              node platforms/node/scripts/verify-packages.mjs --packed-root "$package_root"
+              mkdir -p "$artifact_dir" "$smoke_tarballs" "$smoke_root"
+              npm pack "$package_root/node" --json --pack-destination "$smoke_tarballs" >/runner-temp/node-root-pack.json
+              npm pack "$package_root/$TARGET" --json --pack-destination "$artifact_dir" >/runner-temp/node-target-pack.json
+              cp "$artifact_dir"/*.tgz "$smoke_tarballs"/
+              cd "$smoke_root"
+              npm init -y >/dev/null
+              npm install --ignore-scripts --no-audit --no-fund "$smoke_tarballs"/*.tgz >/dev/null
+              node /work/platforms/node/scripts/smoke-installed-package.mjs --project "$smoke_root" --version "$VERSION" --target "$TARGET"
+            '
+
       - name: Setup Node
-        if: matrix.target != 'linux-x64-musl'
+        if: matrix.target != 'linux-x64-musl' && matrix.target != 'linux-x64-gnu'
         uses: actions/setup-node@v7.0.0
         with:
           node-version: "24"
@@ -272,15 +396,15 @@ jobs:
           cache-dependency-path: platforms/node/package-lock.json
 
       - name: Install pinned Node build dependencies
-        if: matrix.target != 'linux-x64-musl'
+        if: matrix.target != 'linux-x64-musl' && matrix.target != 'linux-x64-gnu'
         run: npm ci --prefix platforms/node
 
       - name: Build and probe native package
-        if: matrix.target != 'linux-x64-musl'
-        run: npm run --prefix platforms/node build:candidate -- --candidate napi --target "${{ matrix.target }}"
+        if: matrix.target != 'linux-x64-musl' && matrix.target != 'linux-x64-gnu'
+        run: node platforms/node/scripts/build-candidate.mjs --candidate napi --target "${{ matrix.target }}"
 
       - name: Assemble and verify target package
-        if: matrix.target != 'linux-x64-musl'
+        if: matrix.target != 'linux-x64-musl' && matrix.target != 'linux-x64-gnu'
         env:
           TARGET: ${{ matrix.target }}
         run: |
@@ -289,10 +413,10 @@ jobs:
           node platforms/node/scripts/assemble-packages.mjs \
             --target "$TARGET" \
             --output-root "$package_root"
-          npm run --prefix platforms/node check:packages -- --packed-root "$package_root"
+          node platforms/node/scripts/verify-packages.mjs --packed-root "$package_root"
 
       - name: Pack and install-smoke target package
-        if: matrix.target != 'linux-x64-musl'
+        if: matrix.target != 'linux-x64-musl' && matrix.target != 'linux-x64-gnu'
         env:
           TARGET: ${{ matrix.target }}
           VERSION: ${{ needs.validate-inputs.outputs.version }}
@@ -328,6 +452,7 @@ jobs:
     needs:
       - validate-inputs
       - loader
+      - node-wasm-package
       - platform
     name: verified package group
     runs-on: ubuntu-24.04

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -499,7 +499,7 @@ jobs:
         run: |
           npm ci --prefix platforms/node
           npm test --prefix platforms/node
-          npm run --prefix platforms/node check:packages
+          node platforms/node/scripts/verify-packages.mjs
 
       - name: Pack Node loader package
         run: |
@@ -515,6 +515,75 @@ jobs:
         with:
           name: preflight-node-npm-loader
           path: ${{ runner.temp }}/node-loader-artifact/*.tgz
+          if-no-files-found: error
+
+  node-wasm-package:
+    needs: validate-inputs
+    name: node-wasm-package
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ needs.validate-inputs.outputs.source_sha }}
+          persist-credentials: false
+
+      - name: Verify release versions
+        env:
+          VERSION: ${{ needs.validate-inputs.outputs.version }}
+        run: python3 scripts/release-version.py check --version "$VERSION"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.95.0
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2.9.2
+        with:
+          workspaces: crates/merman-node
+
+      - name: Setup Node
+        uses: actions/setup-node@v7.0.0
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: platforms/node/package-lock.json
+
+      - name: Install Node build dependencies
+        run: npm ci --prefix platforms/node
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --version 0.15.0 --locked
+
+      - name: Build and probe Node WASM candidate
+        run: node platforms/node/scripts/build-candidate.mjs --candidate node-wasm
+
+      - name: Pack and install-smoke Node WASM package
+        env:
+          VERSION: ${{ needs.validate-inputs.outputs.version }}
+        run: |
+          set -euo pipefail
+          package_root="$RUNNER_TEMP/node-wasm-package"
+          artifact_dir="$RUNNER_TEMP/node-wasm-artifact"
+          node platforms/node/scripts/assemble-packages.mjs --wasm --output-root "$package_root"
+          node platforms/node/scripts/verify-packages.mjs --packed-root "$package_root"
+          mkdir -p "$artifact_dir"
+          npm pack "$package_root/node-wasm" --json --pack-destination "$artifact_dir" > "$RUNNER_TEMP/node-wasm-pack.json"
+          smoke_root="$RUNNER_TEMP/node-wasm-install-smoke"
+          mkdir -p "$smoke_root"
+          cd "$smoke_root"
+          npm init -y >/dev/null
+          npm install --ignore-scripts --no-audit --no-fund "$artifact_dir"/*.tgz >/dev/null
+          node "$GITHUB_WORKSPACE/platforms/node/scripts/smoke-installed-package.mjs" --project "$smoke_root" --version "$VERSION" --target node-wasm
+
+      - name: Upload Node WASM package
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: preflight-node-npm-wasm
+          path: ${{ runner.temp }}/node-wasm-artifact/*.tgz
           if-no-files-found: error
 
   node-platform-package:
@@ -555,13 +624,13 @@ jobs:
         run: python3 scripts/release-version.py check --version "$VERSION"
 
       - name: Install Rust toolchain
-        if: matrix.target != 'linux-x64-musl'
+        if: matrix.target != 'linux-x64-musl' && matrix.target != 'linux-x64-gnu'
         uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: ${{ matrix.rust_target }}
 
       - name: Rust cache
-        if: matrix.target != 'linux-x64-musl'
+        if: matrix.target != 'linux-x64-musl' && matrix.target != 'linux-x64-gnu'
         uses: Swatinem/rust-cache@v2.9.2
         with:
           workspaces: crates/merman-node
@@ -593,13 +662,13 @@ jobs:
               set -eu
               git config --global --add safe.directory /work
               npm ci --prefix platforms/node
-              npm run --prefix platforms/node build:candidate -- --candidate napi --target "$TARGET"
+              node platforms/node/scripts/build-candidate.mjs --candidate napi --target "$TARGET"
               package_root=/runner-temp/node-packages
               artifact_dir=/runner-temp/node-platform-artifact
               smoke_tarballs=/runner-temp/node-smoke-tarballs
               smoke_root=/runner-temp/node-install-smoke
               node platforms/node/scripts/assemble-packages.mjs --target "$TARGET" --output-root "$package_root"
-              npm run --prefix platforms/node check:packages -- --packed-root "$package_root"
+              node platforms/node/scripts/verify-packages.mjs --packed-root "$package_root"
               mkdir -p "$artifact_dir" "$smoke_tarballs" "$smoke_root"
               npm pack "$package_root/node" --json --pack-destination "$smoke_tarballs" >/runner-temp/node-root-pack.json
               npm pack "$package_root/$TARGET" --json --pack-destination "$artifact_dir" >/runner-temp/node-target-pack.json
@@ -611,8 +680,53 @@ jobs:
               node /work/platforms/node/scripts/smoke-installed-package.mjs --project "$smoke_root" --version "$VERSION" --target "$TARGET"
             '
 
+      - name: Build, package, and smoke GNU target
+        if: matrix.target == 'linux-x64-gnu'
+        env:
+          TARGET: ${{ matrix.target }}
+          VERSION: ${{ needs.validate-inputs.outputs.version }}
+        run: |
+          set -euo pipefail
+          docker build \
+            --platform linux/amd64 \
+            --file platforms/node/Dockerfile.gnu \
+            --build-arg NODE_IMAGE=node:24-bullseye \
+            --build-arg RUST_IMAGE=rust:1.95-bullseye \
+            --tag merman-node-gnu:ci \
+            platforms/node
+          docker run --rm \
+            --platform linux/amd64 \
+            -e CARGO_INCREMENTAL=0 \
+            -e TARGET="$TARGET" \
+            -e VERSION="$VERSION" \
+            -v "$GITHUB_WORKSPACE:/work" \
+            -v "$RUNNER_TEMP:/runner-temp" \
+            -w /work \
+            merman-node-gnu:ci \
+            sh -c '
+              set -eu
+              git config --global --add safe.directory /work
+              test "$(node -p "process.report.getReport().header.glibcVersionRuntime")" = "2.31"
+              npm ci --prefix platforms/node
+              node platforms/node/scripts/build-candidate.mjs --candidate napi --target "$TARGET"
+              package_root=/runner-temp/node-packages
+              artifact_dir=/runner-temp/node-platform-artifact
+              smoke_tarballs=/runner-temp/node-smoke-tarballs
+              smoke_root=/runner-temp/node-install-smoke
+              node platforms/node/scripts/assemble-packages.mjs --target "$TARGET" --output-root "$package_root"
+              node platforms/node/scripts/verify-packages.mjs --packed-root "$package_root"
+              mkdir -p "$artifact_dir" "$smoke_tarballs" "$smoke_root"
+              npm pack "$package_root/node" --json --pack-destination "$smoke_tarballs" >/runner-temp/node-root-pack.json
+              npm pack "$package_root/$TARGET" --json --pack-destination "$artifact_dir" >/runner-temp/node-target-pack.json
+              cp "$artifact_dir"/*.tgz "$smoke_tarballs"/
+              cd "$smoke_root"
+              npm init -y >/dev/null
+              npm install --ignore-scripts --no-audit --no-fund "$smoke_tarballs"/*.tgz >/dev/null
+              node /work/platforms/node/scripts/smoke-installed-package.mjs --project "$smoke_root" --version "$VERSION" --target "$TARGET"
+            '
+
       - name: Setup Node
-        if: matrix.target != 'linux-x64-musl'
+        if: matrix.target != 'linux-x64-musl' && matrix.target != 'linux-x64-gnu'
         uses: actions/setup-node@v7.0.0
         with:
           node-version: "24"
@@ -620,15 +734,15 @@ jobs:
           cache-dependency-path: platforms/node/package-lock.json
 
       - name: Install Node build dependencies
-        if: matrix.target != 'linux-x64-musl'
+        if: matrix.target != 'linux-x64-musl' && matrix.target != 'linux-x64-gnu'
         run: npm ci --prefix platforms/node
 
       - name: Build and probe Node native package
-        if: matrix.target != 'linux-x64-musl'
-        run: npm run --prefix platforms/node build:candidate -- --candidate napi --target "${{ matrix.target }}"
+        if: matrix.target != 'linux-x64-musl' && matrix.target != 'linux-x64-gnu'
+        run: node platforms/node/scripts/build-candidate.mjs --candidate napi --target "${{ matrix.target }}"
 
       - name: Pack and install-smoke Node native package
-        if: matrix.target != 'linux-x64-musl'
+        if: matrix.target != 'linux-x64-musl' && matrix.target != 'linux-x64-gnu'
         env:
           TARGET: ${{ matrix.target }}
           VERSION: ${{ needs.validate-inputs.outputs.version }}
@@ -638,7 +752,7 @@ jobs:
           artifact_dir="$RUNNER_TEMP/node-platform-artifact"
           smoke_tarballs="$RUNNER_TEMP/node-smoke-tarballs"
           node platforms/node/scripts/assemble-packages.mjs --target "$TARGET" --output-root "$package_root"
-          npm run --prefix platforms/node check:packages -- --packed-root "$package_root"
+          node platforms/node/scripts/verify-packages.mjs --packed-root "$package_root"
           mkdir -p "$artifact_dir" "$smoke_tarballs"
           npm pack "$package_root/node" --json --pack-destination "$smoke_tarballs" > "$RUNNER_TEMP/node-root-pack.json"
           npm pack "$package_root/$TARGET" --json --pack-destination "$artifact_dir" > "$RUNNER_TEMP/node-target-pack.json"
@@ -662,6 +776,7 @@ jobs:
     needs:
       - validate-inputs
       - node-loader-package
+      - node-wasm-package
       - node-platform-package
     name: node-npm-dry-run
     runs-on: ubuntu-24.04

--- a/docs/performance/NODE_TRANSPORT_ADMISSION.md
+++ b/docs/performance/NODE_TRANSPORT_ADMISSION.md
@@ -133,13 +133,13 @@ candidate artifacts serially, then produce and validate a new raw report:
 ```bash
 cd platforms/node
 npm ci
-CARGO_BUILD_JOBS=1 npm run build:candidate -- --candidate napi --target darwin-arm64
-CARGO_BUILD_JOBS=1 npm run build:candidate -- --candidate node-wasm
-npm run benchmark -- --native artifacts/napi/darwin-arm64/merman.node \
+CARGO_BUILD_JOBS=1 node scripts/build-candidate.mjs --candidate napi --target darwin-arm64
+CARGO_BUILD_JOBS=1 node scripts/build-candidate.mjs --candidate node-wasm
+node scripts/benchmark/run.mjs --native artifacts/napi/darwin-arm64/merman.node \
   --wasm artifacts/node-wasm/merman_node.js \
   --output reports/node-transport-comparison-local.json
 npm test
-npm run check:packages
+node scripts/verify-packages.mjs
 ```
 
 The raw report must validate through `scripts/benchmark/report-contract.mjs` against the checked-in

--- a/docs/release/FFI_CONTRACT_READINESS.md
+++ b/docs/release/FFI_CONTRACT_READINESS.md
@@ -11,7 +11,7 @@ sets and release evidence differ.
 | --- | --- | --- | --- |
 | `public-native` | green | C ABI 3, Android JNI transport API 2, UniFFI API 5, and the shared default native prebuilt SKU | current artifact-profile dependency claims and the platform verification script |
 | `public-typst` | green | Typst plugin ABI 2 with SVG, canonical analysis, and both layout backends | exact `typst-wasm` recipe, import/export validation, package smoke, and size matrix |
-| `public-node-alpha` | green, experimental | deterministic static SVG plus metadata/layout operations with both layout backends and no specialist math/export closure | public six-package contract, generated wire contract, target install/render smokes, and verified npm package-group workflow |
+| `public-node-alpha` | green, experimental | deterministic static SVG plus metadata/layout operations with both layout backends and no specialist math/export closure | public seven-package contract, generated wire contract, glibc-baseline native builds, target install/render smokes, and verified npm package-group workflow |
 
 The public-native lane does not claim that Android uses C ABI 3: Android consumes its direct JNI
 transport API 2. C ABI 3 retains size-tagged discovery and its current wire layout, but historical

--- a/docs/release/PACKAGE_SURFACES.md
+++ b/docs/release/PACKAGE_SURFACES.md
@@ -97,9 +97,9 @@ Merman CI keeps publication separate from validation:
 - `web-npm-dry-run` builds each admitted TypeScript/WASM package, verifies its package projection,
   then packs and verifies the complete lockstep npm group without publishing it.
 - `release-node.yml` builds, packs, installs, and renders the public Node loader through its real
-  macOS arm64/x64, Linux x64 glibc/musl, and Windows x64 native package. Its publisher receives
-  verified tarballs only and publishes platform packages before the root loader under the requested
-  final dist-tag.
+  macOS arm64/x64, Linux x64 glibc/musl, and Windows x64 native packages, plus the explicit
+  Node-targeted WASM package. Its publisher receives a verified seven-package group only and
+  publishes platform packages, WASM, and then the root loader under the requested final dist-tag.
 - `vscode-extension.yml` and the VS Code preflight job build platform runtime binaries, package a
   VSIX, and verify package contents, target platform, stable manifest version, and pre-release
   marker.

--- a/docs/release/PACKAGE_SURFACES.md
+++ b/docs/release/PACKAGE_SURFACES.md
@@ -69,9 +69,9 @@ The repository-owned delivery routes are:
 6. GitHub Release AAR for Android.
 7. lockstep npm publishing for the admitted `@mermanjs/web` browser package group through
    `release-web.yml` after Trusted Publishing setup.
-8. lockstep npm publishing for `@mermanjs/node` and its five native platform packages through
-   `release-node.yml`. Node is an experimental alpha surface; it requires first-publish bootstrap
-   before npm Trusted Publishing can take over.
+8. lockstep npm publishing for `@mermanjs/node`, its five native platform packages, and the
+   explicit `@mermanjs/node-wasm` package through `release-node.yml`. Node is an experimental alpha
+   surface; it requires first-publish bootstrap before npm Trusted Publishing can take over.
 9. Platform VSIX artifacts for the independently versioned VS Code extension through
    `vscode-extension.yml`; Marketplace publishing needs an explicit release decision and credentials
    before it is enabled.
@@ -203,7 +203,7 @@ library-size evidence.
 | Browser artifact evidence | The selected Web artifact profiles have current raw, stripped, gzip, and Brotli measurements; do not substitute a legacy feature-profile name. |
 | Browser/Typst size evidence | The owner-specific Web and Typst size commands share one budget catalog and together cover every admitted artifact exactly once. |
 | Typst transport | The sole `publish` package profile consumes the canonical `typst-wasm` artifact recipe and proves plugin ABI 2, dependency closure, size, provenance, package contents, and examples. Its admitted `json5`, `lol_html`, and `url` dependencies remain measured pure-Rust parts of invariant Mermaid semantics. |
-| Node npm alpha package group | The selected N-API recipe, generated wire contract, runtime catalog, package contracts, exact-version optional dependencies, build receipts, packed tarballs, and five real-target install/render smokes agree. |
+| Node npm alpha package group | The selected N-API recipe, explicit Node-targeted WASM recipe, generated wire contract, runtime catalog, package contracts, exact-version optional dependencies, glibc-baseline build receipts, packed tarballs, five native install/render smokes, and one WASM install/render smoke agree. |
 
 ## WASM Size Matrix
 

--- a/docs/release/PUBLISH_ORDER.md
+++ b/docs/release/PUBLISH_ORDER.md
@@ -117,20 +117,23 @@ publish only the missing exact tarballs directly under the requested final tag w
 2FA-protected npm credential, configure Trusted Publishing for those package names, then rerun the
 workflow with publication enabled. Do not keep the bootstrap credential in GitHub Actions.
 
-## Node Native Package Group
+## Node npm Package Group
 
-The experimental Node package is also a lockstep npm group, but it is native rather than browser
-WASM: `@mermanjs/node`, `@mermanjs/node-darwin-arm64`, `@mermanjs/node-darwin-x64`,
+The experimental Node packages are one lockstep npm group: the native loader and five platform
+packages (`@mermanjs/node`, `@mermanjs/node-darwin-arm64`, `@mermanjs/node-darwin-x64`,
 `@mermanjs/node-linux-x64-gnu`, `@mermanjs/node-linux-x64-musl`, and
-`@mermanjs/node-win32-x64-msvc`. Run `release-node.yml` against a reviewed immutable source commit
-after the matching preflight succeeds. It builds and installs every native target, preflights
-existing registry integrity and tags, then publishes missing exact versions directly under the
-requested final tag in platform-first order, with the root loader last.
+`@mermanjs/node-win32-x64-msvc`) plus the explicit Node-targeted WASM package
+`@mermanjs/node-wasm`. Run `release-node.yml` against a reviewed immutable source commit after
+the matching preflight succeeds. It builds and installs every native target and the WASM target,
+preflights existing registry integrity and tags, then publishes missing exact versions directly
+under the requested final tag in platform-first order, with the WASM package before the root
+loader.
 
 The first version of each npm package cannot use npm Trusted Publishing before the package exists.
 For that one bootstrap, download the verified group artifact from a non-publishing run, publish the
-five platform tarballs and then the loader directly under the requested final tag with a
-maintainer's 2FA-protected npm credential, configure Trusted Publishing for all six package names,
+five platform tarballs, the WASM tarball, and then the loader directly under the requested final
+tag with a maintainer's 2FA-protected npm credential, configure Trusted Publishing for all seven
+package names,
 and rerun `release-node.yml` with publishing enabled. Thereafter the workflow owns idempotent
 publishing and provenance; do not keep an npm token in GitHub Actions.
 

--- a/docs/release/PUBLISH_ORDER.md
+++ b/docs/release/PUBLISH_ORDER.md
@@ -130,12 +130,15 @@ under the requested final tag in platform-first order, with the WASM package bef
 loader.
 
 The first version of each npm package cannot use npm Trusted Publishing before the package exists.
-For that one bootstrap, download the verified group artifact from a non-publishing run, publish the
-five platform tarballs, the WASM tarball, and then the loader directly under the requested final
-tag with a maintainer's 2FA-protected npm credential, configure Trusted Publishing for all seven
-package names,
-and rerun `release-node.yml` with publishing enabled. Thereafter the workflow owns idempotent
-publishing and provenance; do not keep an npm token in GitHub Actions.
+For that one bootstrap, dispatch `release-node.yml` with `publish_to_npm=false` against the reviewed
+immutable source and record its workflow run id. Download the verified
+`merman-node-npm-package-group` artifact from that exact run, publish the five platform tarballs, the
+WASM tarball, and then the loader directly under the requested final tag with a maintainer's
+2FA-protected npm credential, and configure Trusted Publishing for all seven package names. Then
+dispatch `release-node.yml` with the same `release_tag` and `source_ref`,
+`publish_to_npm=true`, and `recovery_run_id=<bootstrap-run-id>`. The recovery run reuses and verifies
+the original tarballs; it must not accept a separately rebuilt candidate. Thereafter the workflow
+owns idempotent publishing and provenance; do not keep an npm token in GitHub Actions.
 
 The immutable `@mermanjs/node@0.8.0-alpha.5` loader tarball was packed before its package-local
 changelog heading was dated, so the registry copy contains an `Unreleased` heading. This is a

--- a/docs/release/RELEASING.md
+++ b/docs/release/RELEASING.md
@@ -27,7 +27,7 @@ is zero.
 | `release-flutter.yml` | `merman` with Native Assets for Android, iOS, macOS, Windows, and Linux | pub.dev |
 | `release-android.yml` | `merman-android-<tag>.aar` | GitHub Release |
 | `release-web.yml` | admitted `@mermanjs/web` browser package group | npm |
-| `release-node.yml` | experimental `@mermanjs/node` loader and five native platform packages | npm |
+| `release-node.yml` | experimental `@mermanjs/node` loader, five native platform packages, and explicit `@mermanjs/node-wasm` | npm |
 | `release-tree-sitter-mermaid.yml` | `tree-sitter-mermaid` crate, `@mermanjs/tree-sitter-mermaid`, language WASM, and source archive | crates.io, npm, and GitHub Release |
 | `vscode-extension.yml` | Platform-specific `merman-vscode` VSIX artifacts | GitHub Actions artifacts |
 | `homebrew.yml` | Nothing; Homebrew/core formula health check only | Homebrew |
@@ -117,15 +117,14 @@ or recovery operator must publish and reconcile the exact candidate from one wor
 rerun only that run's failed jobs. Do not manually publish a candidate from one run and ask a later
 run to accept a separately rebuilt npm tarball as byte-identical.
 
-The experimental native Node group is `@mermanjs/node`, `@mermanjs/node-darwin-arm64`,
-`@mermanjs/node-darwin-x64`, `@mermanjs/node-linux-x64-gnu`,
-`@mermanjs/node-linux-x64-musl`, and `@mermanjs/node-win32-x64-msvc`. Its workflow builds and
-install-smokes each actual target, packages platform binaries before the root loader, and uses the
-same direct-publish plus integrity-preflight boundary as the browser group. npm only allows a
-trusted publisher to be configured for an existing package, so the first release of each new Node
-package requires the documented one-time, 2FA-protected bootstrap from the verified workflow
-artifact; configure OIDC for all six names immediately afterward. Do not add a persistent npm token
-to the repository workflow.
+The experimental Node group is `@mermanjs/node`, its five native platform packages, and the
+explicit `@mermanjs/node-wasm` package. Its workflow builds and install-smokes each actual native
+target plus the Node WASM artifact, packages platform binaries and the WASM package before the root
+loader, and uses the same direct-publish plus integrity-preflight boundary as the browser group.
+npm only allows a trusted publisher to be configured for an existing package, so the first release
+of each new Node package requires the documented one-time, 2FA-protected bootstrap from the
+verified workflow artifact; configure OIDC for all seven names immediately afterward. Do not add a
+persistent npm token to the repository workflow.
 
 For an npm-only alpha test, `release-node.yml` treats `release_tag` as the package version label and
 `source_ref` as the build source. The source may be a reviewed full commit SHA newer than the
@@ -188,7 +187,7 @@ Treat the root `CHANGELOG.md` as the canonical project-wide release narrative an
 
 | Surface | Registry or audience behavior | Changelog source |
 | --- | --- | --- |
-| Node | The root loader tarball includes the user-facing changelog for the six-package group | `platforms/node/CHANGELOG.md` |
+| Node | The root loader tarball includes the user-facing changelog for the seven-package group | `platforms/node/CHANGELOG.md` |
 | Flutter/Dart | pub.dev renders the package-root changelog as its Changelog tab | `platforms/flutter/CHANGELOG.md` |
 | Python | PyPI project metadata links Python users to the package changelog | `platforms/python/merman/CHANGELOG.md` |
 | Android | The Android package README links consumers to its JNI/AAR-specific history | `platforms/android/CHANGELOG.md` |
@@ -332,10 +331,10 @@ npm pack "$package_root/node" --dry-run
 ```
 
 The release preflight and `release-node.yml` remain responsible for building, installing, and
-render-smoke-testing all five native targets. A local host build does not substitute for that
-matrix. Normal Node releases publish the five platform packages before the root loader and verify
-the exact package-group integrity and target tags before publishing any missing package directly
-under the public prerelease tag.
+render-smoke-testing all five native targets plus the explicit Node WASM package. A local host build
+does not substitute for that matrix. Normal Node releases publish the five platform packages and
+the WASM package before the root loader and verify the exact package-group integrity and target tags
+before publishing any missing package directly under the public prerelease tag.
 
 For local VS Code VSIX validation:
 

--- a/docs/release/RELEASING.md
+++ b/docs/release/RELEASING.md
@@ -123,8 +123,10 @@ target plus the Node WASM artifact, packages platform binaries and the WASM pack
 loader, and uses the same direct-publish plus integrity-preflight boundary as the browser group.
 npm only allows a trusted publisher to be configured for an existing package, so the first release
 of each new Node package requires the documented one-time, 2FA-protected bootstrap from the
-verified workflow artifact; configure OIDC for all seven names immediately afterward. Do not add a
-persistent npm token to the repository workflow.
+verified `release-node.yml` workflow artifact; configure OIDC for all seven names immediately
+afterward. Dispatch the publishing run with that bootstrap run's `recovery_run_id` so the publisher
+reuses the exact verified tarballs instead of rebuilding them. Do not add a persistent npm token to
+the repository workflow.
 
 For an npm-only alpha test, `release-node.yml` treats `release_tag` as the package version label and
 `source_ref` as the build source. The source may be a reviewed full commit SHA newer than the

--- a/platforms/node/CHANGELOG.md
+++ b/platforms/node/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `@mermanjs/node` package group will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- Added the opt-in `@mermanjs/node-wasm` package with a Node-targeted wasm-bindgen artifact. It is
+  published separately from the native `@mermanjs/node` loader and never reuses `@mermanjs/web`.
+- Added a typed `MermanNativeLoadError` for installed native packages that fail dynamic loading,
+  including ABI and glibc diagnostics.
+- Moved Linux GNU candidate builds to a glibc 2.31 baseline container and recorded the build
+  environment in the candidate receipt.
+
 ## [0.8.0-alpha.5] - 2026-08-11
 
 ### Added

--- a/platforms/node/Dockerfile.gnu
+++ b/platforms/node/Dockerfile.gnu
@@ -1,0 +1,25 @@
+ARG RUST_IMAGE=rust:1.95-bullseye
+ARG NODE_IMAGE=node:24-bullseye
+
+FROM ${RUST_IMAGE} AS rust-toolchain
+
+FROM ${NODE_IMAGE}
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends build-essential ca-certificates git pkg-config python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=rust-toolchain /usr/local/cargo /usr/local/cargo
+COPY --from=rust-toolchain /usr/local/rustup /usr/local/rustup
+
+ENV CARGO_HOME=/usr/local/cargo
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV PATH=/usr/local/cargo/bin:${PATH}
+
+RUN node --version \
+    && npm --version \
+    && rustc --version \
+    && cargo --version \
+    && node -p "process.report.getReport().header.glibcVersionRuntime"
+
+WORKDIR /work

--- a/platforms/node/README.md
+++ b/platforms/node/README.md
@@ -25,6 +25,27 @@ try {
 }
 ```
 
+## SVG output pipelines
+
+`renderSvg()` and `renderSvgSync()` use the `parity` pipeline by default. This preserves the
+Mermaid-compatible SVG structure and is the right choice for trusted input or parity-sensitive
+consumers. `parity` is not a browser DOM-admission or sanitization check.
+
+For SVG that will be embedded directly into HTML, or when the Mermaid source is not fully trusted,
+select the sealed `resvg-safe` pipeline explicitly:
+
+```js
+const options = {
+  optionsJson: JSON.stringify({ svg: { pipeline: "resvg-safe" } }),
+};
+const svg = await engine.renderSvg(source, options);
+```
+
+The supported pipeline values are `parity`, `readable`, and `resvg-safe`. The safe pipeline can
+remove browser-only SVG features such as active content and `foreignObject` labels. It does not
+provide browser `Document` or owner-document admission APIs; use `@mermanjs/web*` for browser DOM
+mounting.
+
 The package supports macOS arm64/x64, Linux x64 glibc/musl, and Windows x64 MSVC. Its shipped
 recipe includes deterministic SVG plus Cytoscape and ELK layouts. Math, binary export, analysis,
 ASCII, text-measurement callbacks, browser fallback, and runtime downloads remain outside this
@@ -34,12 +55,13 @@ surface.
 
 - `packages/node` contains the public ESM loader, JavaScript engine, declarations, and user README.
 - Generated `@mermanjs/node-<platform>` packages contain the native binary for one supported host.
-- The Node-targeted WASM implementation is an internal comparison transport and is never selected
-  by the public loader. It supports operation deadlines, but its single-threaded execution cannot
-  observe a mid-call JavaScript `AbortSignal`.
+- `@mermanjs/node-wasm` is a separate explicit Node-targeted WASM package for deployments that
+  cannot load a native addon. It does not reuse `@mermanjs/web`, and its single-threaded execution
+  cannot observe a mid-call JavaScript `AbortSignal`.
 
-Install only `@mermanjs/node`; its exact-version optional dependencies keep the selected platform
-package aligned with the loader.
+Install `@mermanjs/node` for native execution or `@mermanjs/node-wasm` when a portable Node
+artifact is preferred. The native loader's exact-version optional dependencies keep the selected
+platform package aligned with the loader; it never silently changes transport.
 
 Native cancellation is cooperative after JavaScript queue admission. The bridge does not forcibly
 remove work already submitted to libuv; the Promise settles when that worker observes cancellation

--- a/platforms/node/candidate-builds.json
+++ b/platforms/node/candidate-builds.json
@@ -46,6 +46,7 @@
         {
           "id": "linux-x64-gnu",
           "rust_target": "x86_64-unknown-linux-gnu",
+          "glibc_floor": "2.31",
           "runtime_ci_required": true
         },
         {

--- a/platforms/node/package-surfaces.json
+++ b/platforms/node/package-surfaces.json
@@ -7,6 +7,13 @@
     "name": "@mermanjs/node",
     "directory": "packages/node"
   },
+  "wasm": {
+    "name": "@mermanjs/node-wasm",
+    "directory": "packages/node-wasm",
+    "artifact_directory": "artifact",
+    "node_artifact": "merman_node.cjs",
+    "wasm_artifact": "merman_node_bg.wasm"
+  },
   "targets": [
     {
       "target": "darwin-arm64",

--- a/platforms/node/packages/node-wasm/README.md
+++ b/platforms/node/packages/node-wasm/README.md
@@ -1,0 +1,47 @@
+# @mermanjs/node-wasm
+
+Explicit Node-targeted WebAssembly rendering for Node.js 22+ and static-site build pipelines.
+This is a separate opt-in package; `@mermanjs/node` remains the native N-API package and never
+silently falls back to browser or Node WASM.
+
+## Quick start
+
+```sh
+npm install @mermanjs/node-wasm@alpha
+```
+
+```js
+import { createNodeEngine } from "@mermanjs/node-wasm";
+
+const engine = await createNodeEngine();
+
+try {
+  const svg = await engine.renderSvg("flowchart TD\nA --> B");
+  console.log(svg);
+} finally {
+  await engine.dispose();
+}
+```
+
+The package embeds a Node-targeted wasm-bindgen artifact and does not depend on `@mermanjs/web`.
+It is intended for Node-only server-side rendering and static generation. The WASM transport is
+single-threaded, so an `AbortSignal` cannot interrupt an operation after it enters the candidate;
+operation deadlines remain available through `timeoutMs`.
+
+`renderSvg()` and `renderSvgSync()` use the `parity` pipeline by default. This preserves the
+Mermaid-compatible SVG structure for trusted input and parity-sensitive consumers. For SVG that
+will be embedded directly into HTML, or when the Mermaid source is not fully trusted, select the
+sealed `resvg-safe` pipeline through `optionsJson`:
+
+```js
+const svg = await engine.renderSvg(source, {
+  optionsJson: JSON.stringify({ svg: { pipeline: "resvg-safe" } }),
+});
+```
+
+The pipeline values are `parity`, `readable`, and `resvg-safe`. The safe pipeline does not provide
+browser `Document` or owner-document admission APIs; use `@mermanjs/web*` for browser DOM mounting.
+
+The native package is the recommended choice when a supported platform binary is available. Use
+this package when a deployment target cannot load the native package or when a single portable
+Node artifact is more useful than native startup and throughput.

--- a/platforms/node/packages/node-wasm/package.json
+++ b/platforms/node/packages/node-wasm/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@mermanjs/node-wasm",
+  "version": "0.8.0-alpha.6",
+  "description": "Explicit Node-targeted WebAssembly rendering package for Merman.",
+  "type": "module",
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Latias94/merman.git"
+  },
+  "homepage": "https://github.com/Latias94/merman/tree/main/platforms/node#readme",
+  "keywords": [
+    "mermaid",
+    "diagram",
+    "svg",
+    "node",
+    "wasm",
+    "webassembly"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "CHANGELOG.md",
+    "artifact",
+    "dist",
+    "LICENSE-APACHE",
+    "LICENSE-MIT",
+    "README.md",
+    "THIRD_PARTY_LICENSES",
+    "THIRD_PARTY_NOTICES.md"
+  ],
+  "license": "MIT OR Apache-2.0"
+}

--- a/platforms/node/packages/node/README.md
+++ b/platforms/node/packages/node/README.md
@@ -29,6 +29,27 @@ try {
 
 Create an engine once, reuse it for related work, and dispose it during teardown.
 
+## SVG output pipelines
+
+`renderSvg()` and `renderSvgSync()` use the `parity` pipeline by default. This preserves the
+Mermaid-compatible SVG structure for trusted input and parity-sensitive consumers. `parity` is
+not a browser DOM-admission or sanitization check.
+
+For SVG that will be embedded directly into HTML, or when the Mermaid source is not fully trusted,
+select the sealed `resvg-safe` pipeline explicitly:
+
+```js
+const options = {
+  optionsJson: JSON.stringify({ svg: { pipeline: "resvg-safe" } }),
+};
+const svg = await engine.renderSvg(source, options);
+```
+
+The supported pipeline values are `parity`, `readable`, and `resvg-safe`. The safe pipeline can
+remove browser-only SVG features such as active content and `foreignObject` labels. It does not
+provide browser `Document` or owner-document admission APIs; use `@mermanjs/web*` for browser DOM
+mounting.
+
 ## Supported hosts
 
 - macOS arm64 and x64
@@ -39,6 +60,11 @@ Create an engine once, reuse it for related work, and dispose it during teardown
 The root loader selects one matching exact-version `@mermanjs/node-<platform>` optional dependency.
 Do not install platform packages directly. The loader contains no native or WASM binary and never
 downloads one during installation or runtime.
+
+If the native addon is installed but the host dynamic loader rejects it (for example because the
+glibc baseline is too new), construction throws `MermanNativeLoadError` with the target package
+name and an explicit suggestion to use `@mermanjs/node-wasm`. It does not silently switch
+transports.
 
 ## Capability boundary
 

--- a/platforms/node/scripts/assemble-packages.mjs
+++ b/platforms/node/scripts/assemble-packages.mjs
@@ -23,11 +23,13 @@ if (isMainModule()) {
     const outputRoot = valueAfter(args, "--output-root") ?? path.join(nodeRoot, "dist-packages");
     if (args.includes("--loader-only")) {
       assembleLoaderOnly(outputRoot);
+    } else if (args.includes("--wasm")) {
+      assembleWasmPackage(outputRoot);
     } else {
       const target = valueAfter(args, "--target");
       if (!target) {
         throw new Error(
-          "usage: node scripts/assemble-packages.mjs (--loader-only | --target <target-id>) [--output-root <path>]",
+          "usage: node scripts/assemble-packages.mjs (--loader-only | --wasm | --target <target-id>) [--output-root <path>]",
         );
       }
       assembleNativePackages(target, outputRoot);
@@ -79,6 +81,40 @@ export function assembleLoaderOnly(outputRoot = path.join(nodeRoot, "dist-packag
   }
 }
 
+export function assembleWasmPackage(
+  outputRoot = path.join(nodeRoot, "dist-packages"),
+  wasmOverride = null,
+  { readReceipt = readBuildReceipt } = {},
+) {
+  const wasmDescriptor = descriptor.wasm;
+  if (!wasmDescriptor) throw new Error("Node package surface does not declare a WASM package.");
+  assertAssemblyPackageManifest(wasmDescriptor);
+  const candidateRoot = wasmOverride
+    ? path.dirname(wasmOverride)
+    : path.join(nodeRoot, "artifacts", "node-wasm");
+  const wasm = wasmOverride ?? path.join(candidateRoot, wasmDescriptor.wasm_artifact);
+  const loader = path.join(candidateRoot, "merman_node.js");
+  assertFile(wasm, "Node-targeted WASM binary");
+  assertFile(loader, "Node-targeted WASM loader");
+  assertWasmBuildProvenance(wasmDescriptor, readReceipt(wasm));
+
+  const stage = `${outputRoot}.stage-${process.pid}`;
+  rmSync(stage, { recursive: true, force: true });
+  mkdirSync(stage, { recursive: true });
+  try {
+    assembleWasmPackageContents(
+      wasmDescriptor,
+      loader,
+      wasm,
+      path.join(stage, path.basename(wasmDescriptor.directory)),
+    );
+    replaceDirectory(stage, outputRoot);
+  } catch (error) {
+    rmSync(stage, { recursive: true, force: true });
+    throw error;
+  }
+}
+
 function assembleLoaderPackage(output) {
   const source = path.join(nodeRoot, descriptor.root.directory);
   mkdirSync(path.join(output, "dist", "candidates"), { recursive: true });
@@ -120,6 +156,53 @@ function assembleLoaderPackage(output) {
   projectLegalMaterial(output);
 }
 
+function assembleWasmPackageContents(packageDescriptor, loader, wasm, output) {
+  const source = path.join(nodeRoot, packageDescriptor.directory);
+  mkdirSync(path.join(output, "dist", "candidates"), { recursive: true });
+  mkdirSync(path.join(output, "dist", "generated"), { recursive: true });
+  mkdirSync(path.join(output, packageDescriptor.artifact_directory), { recursive: true });
+  cpSync(path.join(source, "package.json"), path.join(output, "package.json"));
+  cpSync(path.join(source, "README.md"), path.join(output, "README.md"));
+  cpSync(path.join(nodeRoot, "CHANGELOG.md"), path.join(output, "CHANGELOG.md"));
+  for (const name of [
+    "engine.mjs",
+    "errors.mjs",
+    "bounded-executor.mjs",
+    "native-loader.mjs",
+    "transport-contract.mjs",
+  ]) {
+    cpSync(path.join(nodeRoot, "src", name), path.join(output, "dist", name));
+  }
+  cpSync(
+    path.join(nodeRoot, "src", "node-wasm-index.mjs"),
+    path.join(output, "dist", "index.mjs"),
+  );
+  cpSync(
+    path.join(nodeRoot, "src", "candidates", "wasm.mjs"),
+    path.join(output, "dist", "candidates", "wasm.mjs"),
+  );
+  cpSync(
+    path.join(nodeRoot, "src", "candidates", "wrap-engine.mjs"),
+    path.join(output, "dist", "candidates", "wrap-engine.mjs"),
+  );
+  cpSync(
+    path.join(nodeRoot, "src", "generated", "capability-surface.mjs"),
+    path.join(output, "dist", "generated", "capability-surface.mjs"),
+  );
+  cpSync(
+    path.join(nodeRoot, "src", "generated", "binding-contract.mjs"),
+    path.join(output, "dist", "generated", "binding-contract.mjs"),
+  );
+  cpSync(
+    path.join(nodeRoot, "src", "generated", "node-wire-contract.json"),
+    path.join(output, "dist", "generated", "node-wire-contract.json"),
+  );
+  cpSync(path.join(nodeRoot, "src", "index.d.ts"), path.join(output, "dist", "index.d.ts"));
+  cpSync(loader, path.join(output, packageDescriptor.artifact_directory, packageDescriptor.node_artifact));
+  cpSync(wasm, path.join(output, packageDescriptor.artifact_directory, packageDescriptor.wasm_artifact));
+  projectLegalMaterial(output);
+}
+
 function assemblePlatformPackage(targetDescriptor, binary, output) {
   const source = path.join(nodeRoot, targetDescriptor.directory);
   mkdirSync(output, { recursive: true });
@@ -142,6 +225,22 @@ function assertNativeBuildProvenance(targetDescriptor, receipt) {
     throw new Error(
       `Native candidate build receipt target ${JSON.stringify(receipt?.target)} does not match ${targetDescriptor.target}.`,
     );
+  }
+}
+
+function assertWasmBuildProvenance(packageDescriptor, receipt) {
+  if (receipt?.candidate !== "node-wasm") {
+    throw new Error(
+      `Node WASM candidate build receipt candidate ${JSON.stringify(receipt?.candidate)} must be node-wasm.`,
+    );
+  }
+  if (receipt.target !== null) {
+    throw new Error(
+      `Node WASM candidate build receipt target ${JSON.stringify(receipt.target)} must be null.`,
+    );
+  }
+  if (packageDescriptor.wasm_artifact !== "merman_node_bg.wasm") {
+    throw new Error("Node WASM package descriptor must use the canonical wasm-bindgen artifact.");
   }
 }
 

--- a/platforms/node/scripts/benchmark/footprint.mjs
+++ b/platforms/node/scripts/benchmark/footprint.mjs
@@ -117,6 +117,7 @@ export function stageWasmPackage(temporaryRoot, artifact) {
       "  MermanInvalidTransportError,",
       "  MermanLifecycleError,",
       "  MermanMissingPlatformPackageError,",
+      "  MermanNativeLoadError,",
       "  MermanOperationError,",
       "  MermanQueueSaturatedError,",
       "  MermanUnsupportedTargetError,",

--- a/platforms/node/scripts/benchmark/worker.mjs
+++ b/platforms/node/scripts/benchmark/worker.mjs
@@ -15,6 +15,7 @@ const PRODUCT_EXPORTS = [
   "MermanInvalidTransportError",
   "MermanLifecycleError",
   "MermanMissingPlatformPackageError",
+  "MermanNativeLoadError",
   "MermanOperationError",
   "MermanQueueSaturatedError",
   "MermanUnsupportedTargetError",

--- a/platforms/node/scripts/build-candidate.mjs
+++ b/platforms/node/scripts/build-candidate.mjs
@@ -81,6 +81,7 @@ export function buildCandidate({ candidate, target = null }) {
     ) {
       throw new Error("Node candidate dependency closure changed during the build; rerun it.");
     }
+    writeBuildEnvironmentEvidence(stage, recipe);
     writeBuildReceipt(stage, recipe, before, dependencyClosure, runtime);
     replaceDirectory(stage, output);
     console.log(`[merman-node] built ${candidate}${resolvedTarget ? ` for ${resolvedTarget}` : ""}`);
@@ -220,6 +221,7 @@ function writeBuildReceipt(
     target: recipe.targetId,
     rust_target: recipe.rustTarget,
     wasm_pack_target: recipe.wasmPackTarget,
+    glibc_floor: recipe.glibcFloor,
     default_features: false,
     capability_recipe: {
       descriptor: descriptor.capability_recipe.descriptor,
@@ -248,6 +250,40 @@ function writeBuildReceipt(
     artifacts: artifactEntries(stage),
   };
   writeFileSync(path.join(stage, "build-receipt.json"), `${JSON.stringify(receipt, null, 2)}\n`);
+}
+
+function writeBuildEnvironmentEvidence(stage, recipe) {
+  if (recipe.glibcFloor === null) return;
+  const runtimeVersion = process.report?.getReport?.()?.header?.glibcVersionRuntime;
+  if (typeof runtimeVersion !== "string" || runtimeVersion.length === 0) {
+    throw new Error("The Linux GNU candidate build must record its runtime glibc version.");
+  }
+  if (compareGlibcVersions(runtimeVersion, recipe.glibcFloor) > 0) {
+    throw new Error(
+      `The Linux GNU candidate build ran on glibc ${runtimeVersion}, above the ${recipe.glibcFloor} compatibility floor.`,
+    );
+  }
+  writeFileSync(
+    path.join(stage, "build-environment.json"),
+    `${JSON.stringify({
+      schema_version: 1,
+      target: recipe.targetId,
+      libc: "glibc",
+      version: runtimeVersion,
+      floor: recipe.glibcFloor,
+    }, null, 2)}\n`,
+  );
+}
+
+function compareGlibcVersions(left, right) {
+  const parse = (value) => {
+    const match = /^(\d+)\.(\d+)$/.exec(value);
+    if (!match) throw new Error(`Invalid glibc version: ${value}.`);
+    return [Number(match[1]), Number(match[2])];
+  };
+  const [leftMajor, leftMinor] = parse(left);
+  const [rightMajor, rightMinor] = parse(right);
+  return leftMajor - rightMajor || leftMinor - rightMinor;
 }
 
 export function probeCandidateRuntime(stage, recipe) {
@@ -620,6 +656,7 @@ export function resolveCandidateRecipe(candidate, target) {
         rustTarget: wasm.rust_target,
         transportFeature: wasm.transport_feature,
         wasmPackTarget: wasm.wasm_pack_target,
+        glibcFloor: null,
       },
       capabilityFeatures,
     );
@@ -634,6 +671,7 @@ export function resolveCandidateRecipe(candidate, target) {
       rustTarget: nativeTarget.rust_target,
       transportFeature: descriptor.candidates.napi.transport_feature,
       wasmPackTarget: null,
+      glibcFloor: nativeTarget.glibc_floor ?? null,
     },
     capabilityFeatures,
   );
@@ -645,6 +683,9 @@ function completeCandidateRecipe(recipe, capabilityFeatures) {
     !recipe.transportFeature.startsWith("transport-")
   ) {
     throw new Error(`Invalid transport feature for ${recipe.candidate}.`);
+  }
+  if (recipe.glibcFloor !== null && typeof recipe.glibcFloor !== "string") {
+    throw new Error(`Invalid glibc floor for ${recipe.candidate}.`);
   }
   if (capabilityFeatures.includes(recipe.transportFeature)) {
     throw new Error(

--- a/platforms/node/scripts/build-receipt.mjs
+++ b/platforms/node/scripts/build-receipt.mjs
@@ -117,6 +117,7 @@ export function readBuildReceipt(
   if (JSON.stringify(actualArtifactPaths) !== JSON.stringify(recordedArtifactPaths)) {
     throw new Error("candidate build receipt artifact file set does not match its directory.");
   }
+  validateBuildEnvironmentEvidence(receiptRoot, buildRecipe);
   const recordedArtifact = value.artifacts?.find((item) => item.path === artifactPath);
   const artifactDigest = digestFile(artifact);
   if (recordedArtifact?.sha256 !== artifactDigest) {
@@ -134,6 +135,7 @@ export function readBuildReceipt(
     target: value.config.target,
     rust_target: value.config.rust_target,
     wasm_pack_target: value.config.wasm_pack_target,
+    glibc_floor: value.config.glibc_floor,
     commit: value.commit,
     source_digest: value.source_digest,
     cargo_lock_digest: value.cargo_lock_digest,
@@ -289,6 +291,7 @@ function validateCapabilityRecipe(config) {
     "target",
     "rust_target",
     "wasm_pack_target",
+    "glibc_floor",
     "default_features",
     "capability_recipe",
     "features",
@@ -329,7 +332,8 @@ function validateCapabilityRecipe(config) {
   if (
     config.target !== expectedBuildRecipe.targetId ||
     config.rust_target !== expectedBuildRecipe.rustTarget ||
-    config.wasm_pack_target !== expectedBuildRecipe.wasmPackTarget
+    config.wasm_pack_target !== expectedBuildRecipe.wasmPackTarget ||
+    config.glibc_floor !== expectedBuildRecipe.glibcFloor
   ) {
     throw new Error("candidate build receipt target configuration is not canonical.");
   }
@@ -349,6 +353,39 @@ function validateCapabilityRecipe(config) {
       },
     },
   };
+}
+
+function validateBuildEnvironmentEvidence(receiptRoot, buildRecipe) {
+  if (buildRecipe.glibcFloor === null) return;
+  const evidencePath = path.join(receiptRoot, "build-environment.json");
+  assertFile(evidencePath, "glibc build environment evidence");
+  let evidence;
+  try {
+    evidence = JSON.parse(readFileSync(evidencePath, "utf8"));
+  } catch (cause) {
+    throw new Error("glibc build environment evidence is not valid JSON.", { cause });
+  }
+  if (
+    evidence?.schema_version !== 1 ||
+    evidence.target !== buildRecipe.targetId ||
+    evidence.libc !== "glibc" ||
+    evidence.floor !== buildRecipe.glibcFloor ||
+    typeof evidence.version !== "string" ||
+    compareGlibcVersions(evidence.version, buildRecipe.glibcFloor) > 0
+  ) {
+    throw new Error("glibc build environment evidence does not prove the canonical compatibility floor.");
+  }
+}
+
+function compareGlibcVersions(left, right) {
+  const parse = (value) => {
+    const match = /^(\d+)\.(\d+)$/.exec(value);
+    if (!match) throw new Error(`Invalid glibc version: ${value}.`);
+    return [Number(match[1]), Number(match[2])];
+  };
+  const [leftMajor, leftMinor] = parse(left);
+  const [rightMajor, rightMinor] = parse(right);
+  return leftMajor - rightMajor || leftMinor - rightMinor;
 }
 
 function validateBuildTools(tools) {

--- a/platforms/node/scripts/package-contract.mjs
+++ b/platforms/node/scripts/package-contract.mjs
@@ -8,6 +8,7 @@ export async function inspectPackageManifests(nodeRoot, descriptor) {
     throw new Error("Node package surface descriptor must define the schema-1 public alpha group.");
   }
   const root = await inspectManifest(nodeRoot, descriptor.root, "loader");
+  const wasm = await inspectManifest(nodeRoot, descriptor.wasm, "wasm");
   const targets = [];
   for (const targetDescriptor of descriptor.targets) {
     targets.push({
@@ -15,12 +16,17 @@ export async function inspectPackageManifests(nodeRoot, descriptor) {
       ...(await inspectManifest(nodeRoot, targetDescriptor, "platform")),
     });
   }
-  const versions = new Set([root.manifest.version, ...targets.map((item) => item.manifest.version)]);
+  const versions = new Set([
+    root.manifest.version,
+    wasm.manifest.version,
+    ...targets.map((item) => item.manifest.version),
+  ]);
   if (versions.size !== 1 || !versions.has(descriptor.version)) {
     throw new Error("Node candidate package versions must be exact and lockstep.");
   }
   const engineRanges = new Set([
     root.manifest.engines?.node,
+    wasm.manifest.engines?.node,
     ...targets.map((item) => item.manifest.engines?.node),
   ]);
   if (
@@ -51,13 +57,14 @@ export async function inspectPackageManifests(nodeRoot, descriptor) {
   if (JSON.stringify(optionalNames) !== JSON.stringify(targetNames)) {
     throw new Error("Node loader optional dependencies must exactly match the target package set.");
   }
-  return { root, targets };
+  return { root, wasm, targets };
 }
 
 export function verifyPackedFileOwnership({ packageName, role, files }) {
-  const paths = files.map((item) => item.path);
+  const paths = files.map((item) => item.path.replace(/^package\//, ""));
   const nodeFiles = paths.filter((item) => item.endsWith(".node"));
   const wasmFiles = paths.filter((item) => item.endsWith(".wasm"));
+  const cjsFiles = paths.filter((item) => item.endsWith(".cjs"));
   if (role === "loader" && nodeFiles.length !== 0) {
     throw new Error(`${packageName} loader package must not contain native binaries.`);
   }
@@ -69,6 +76,21 @@ export function verifyPackedFileOwnership({ packageName, role, files }) {
   }
   if (role === "platform" && wasmFiles.length !== 0) {
     throw new Error(`${packageName} platform package must not contain WASM binaries.`);
+  }
+  if (role === "wasm") {
+    if (nodeFiles.length !== 0) {
+      throw new Error(`${packageName} WASM package must not contain native binaries.`);
+    }
+    if (wasmFiles.length !== 1 || wasmFiles[0] !== "artifact/merman_node_bg.wasm") {
+      throw new Error(
+        `${packageName} WASM package must contain exactly package/artifact/merman_node_bg.wasm.`,
+      );
+    }
+    if (cjsFiles.length !== 1 || cjsFiles[0] !== "artifact/merman_node.cjs") {
+      throw new Error(
+        `${packageName} WASM package must contain exactly package/artifact/merman_node.cjs.`,
+      );
+    }
   }
 }
 
@@ -92,6 +114,22 @@ async function inspectManifest(nodeRoot, descriptor, role) {
   const wasmFiles = declaredFiles.filter((item) => item.endsWith(".wasm"));
   if (role === "platform" && (nodeFiles.length !== 1 || nodeFiles[0] !== descriptor.node_artifact)) {
     throw new Error(`${descriptor.name} must own exactly ${descriptor.node_artifact}.`);
+  }
+  if (role === "wasm") {
+    if (
+      manifest.main !== "./dist/index.mjs" ||
+      manifest.types !== "./dist/index.d.ts" ||
+      !declaredFiles.includes("artifact") ||
+      !declaredFiles.includes("dist") ||
+      Object.keys({
+        ...manifest.dependencies,
+        ...manifest.optionalDependencies,
+        ...manifest.peerDependencies,
+      }).length !== 0 ||
+      ["os", "cpu", "libc"].some((field) => field in manifest)
+    ) {
+      throw new Error(`${descriptor.name} must be an unconstrained, dependency-free Node WASM package.`);
+    }
   }
   const dependencyNames = Object.keys({
     ...manifest.dependencies,

--- a/platforms/node/scripts/smoke-installed-package.mjs
+++ b/platforms/node/scripts/smoke-installed-package.mjs
@@ -19,7 +19,8 @@ async function main() {
     );
   }
 
-  const entrypoint = resolveInstalledEntrypoint(project);
+  const packageName = expectedTarget === "node-wasm" ? "@mermanjs/node-wasm" : "@mermanjs/node";
+  const entrypoint = resolveInstalledEntrypoint(project, packageName);
   const packageManifest = JSON.parse(
     await readFile(path.resolve(path.dirname(entrypoint), "..", "package.json"), "utf8"),
   );
@@ -34,7 +35,7 @@ async function main() {
     assert.match(svg, /<\/svg>/);
     console.log(
       JSON.stringify({
-        package: "@mermanjs/node",
+        package: packageName,
         version: expectedVersion,
         target: expectedTarget,
         svg_bytes: Buffer.byteLength(svg),
@@ -45,7 +46,7 @@ async function main() {
   }
 }
 
-export function resolveInstalledEntrypoint(project) {
+export function resolveInstalledEntrypoint(project, packageName = "@mermanjs/node") {
   // Resolve from the installed project with ESM import conditions. createRequire() would select
   // CommonJS conditions and reject this intentionally ESM-only package.
   const entrypointUrl = execFileSync(
@@ -53,7 +54,7 @@ export function resolveInstalledEntrypoint(project) {
     [
       "--input-type=module",
       "--eval",
-      'process.stdout.write(import.meta.resolve("@mermanjs/node"));',
+      `process.stdout.write(import.meta.resolve(${JSON.stringify(packageName)}));`,
     ],
     {
       cwd: path.resolve(project),

--- a/platforms/node/scripts/verify-packages.mjs
+++ b/platforms/node/scripts/verify-packages.mjs
@@ -34,11 +34,22 @@ async function main() {
 }
 
 function verifyPackedRoot(root, descriptor) {
-  verifyPackage(path.join(root, "node"), descriptor.root.name, "loader");
+  let verified = false;
+  if (existsForTarget(root, "node")) {
+    verifyPackage(path.join(root, "node"), descriptor.root.name, "loader");
+    verified = true;
+  }
   for (const target of descriptor.targets) {
     if (!existsForTarget(root, target.target)) continue;
     verifyPackage(path.join(root, target.target), target.name, "platform");
+    verified = true;
   }
+  const wasmDirectory = descriptor.wasm?.directory?.split("/").at(-1);
+  if (descriptor.wasm && wasmDirectory && existsForTarget(root, wasmDirectory)) {
+    verifyPackage(path.join(root, wasmDirectory), descriptor.wasm.name, "wasm");
+    verified = true;
+  }
+  if (!verified) throw new Error("packed Node package root contains no recognized package.");
 }
 
 function verifyPackage(packageRoot, packageName, role) {

--- a/platforms/node/src/errors.mjs
+++ b/platforms/node/src/errors.mjs
@@ -150,6 +150,17 @@ export class MermanMissingPlatformPackageError extends MermanError {
   }
 }
 
+export class MermanNativeLoadError extends MermanError {
+  constructor({ packageName, target, cause }) {
+    super(
+      `The installed Merman platform package ${packageName} could not load its native addon for ${target}. This is a native ABI or shared-library loader failure, not a missing npm package. Use a compatible glibc baseline or opt into @mermanjs/node-wasm.`,
+      { code: "MERMAN_NATIVE_LOAD_ERROR", cause },
+    );
+    this.packageName = packageName;
+    this.target = target;
+  }
+}
+
 export class MermanInvalidTransportError extends MermanError {
   constructor(message, cause) {
     super(message, { code: "MERMAN_INVALID_TRANSPORT", cause });

--- a/platforms/node/src/index.d.ts
+++ b/platforms/node/src/index.d.ts
@@ -264,6 +264,10 @@ export declare class MermanMissingPlatformPackageError extends MermanError {
   readonly packageName: string;
   readonly target: string;
 }
+export declare class MermanNativeLoadError extends MermanError {
+  readonly packageName: string;
+  readonly target: string;
+}
 export declare class MermanUnsupportedTargetError extends MermanError {
   readonly platform: string;
   readonly arch: string;

--- a/platforms/node/src/index.mjs
+++ b/platforms/node/src/index.mjs
@@ -16,6 +16,7 @@ export {
   MermanInvalidTransportError,
   MermanLifecycleError,
   MermanMissingPlatformPackageError,
+  MermanNativeLoadError,
   MermanOperationError,
   MermanQueueSaturatedError,
   MermanUnsupportedTargetError,

--- a/platforms/node/src/native-loader.mjs
+++ b/platforms/node/src/native-loader.mjs
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import {
   MermanInvalidTransportError,
   MermanMissingPlatformPackageError,
+  MermanNativeLoadError,
   MermanUnsupportedTargetError,
   parseRuntimeCatalogJsonText,
 } from "./errors.mjs";
@@ -79,6 +80,9 @@ export function loadNativeBinding({
     if (isMissingModule(cause)) {
       throw new MermanMissingPlatformPackageError({ packageName, target, cause });
     }
+    if (isNativeLoadFailure(cause)) {
+      throw new MermanNativeLoadError({ packageName, target, cause });
+    }
     throw cause;
   }
 }
@@ -109,4 +113,13 @@ function isMissingModule(error) {
       typeof error === "object" &&
       (error.code === "MODULE_NOT_FOUND" || error.code === "ERR_MODULE_NOT_FOUND"),
   );
+}
+
+function isNativeLoadFailure(error) {
+  if (!error || typeof error !== "object") return false;
+  if (error.code === "ERR_DLOPEN_FAILED") return true;
+  return typeof error.message === "string" &&
+    /(?:GLIBC(?:XX)?_|CXXABI_|invalid ELF|wrong ELF|shared object file|not a valid Win32|mach-?o)/i.test(
+      error.message,
+    );
 }

--- a/platforms/node/src/node-wasm-index.mjs
+++ b/platforms/node/src/node-wasm-index.mjs
@@ -1,0 +1,37 @@
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+import {
+  MermanEngine,
+  createNodeEngine as createEngineWithTransport,
+} from "./engine.mjs";
+import { loadNodeWasmTransport } from "./candidates/wasm.mjs";
+
+const wasmBindingPath = fileURLToPath(
+  new URL("../artifact/merman_node.cjs", import.meta.url),
+);
+const requireFromPackage = createRequire(import.meta.url);
+
+export { MermanEngine };
+
+export function createNodeEngine(options) {
+  return createEngineWithTransport(options, {
+    loadTransport: (optionsJson) =>
+      loadNodeWasmTransport(optionsJson, {
+        modulePath: wasmBindingPath,
+        loadModule: () => Promise.resolve(requireFromPackage(wasmBindingPath)),
+      }),
+  });
+}
+
+export {
+  MermanDisposedError,
+  MermanError,
+  MermanInvalidTransportError,
+  MermanLifecycleError,
+  MermanMissingPlatformPackageError,
+  MermanNativeLoadError,
+  MermanOperationError,
+  MermanQueueSaturatedError,
+  MermanUnsupportedTargetError,
+} from "./errors.mjs";

--- a/platforms/node/tests/benchmark-contract.test.mjs
+++ b/platforms/node/tests/benchmark-contract.test.mjs
@@ -377,6 +377,7 @@ function productFacadeTestExports() {
     "export class MermanInvalidTransportError extends Error {}",
     "export class MermanLifecycleError extends Error {}",
     "export class MermanMissingPlatformPackageError extends Error {}",
+    "export class MermanNativeLoadError extends Error {}",
     "export class MermanOperationError extends Error {}",
     "export class MermanQueueSaturatedError extends Error {}",
     "export class MermanUnsupportedTargetError extends Error {}",
@@ -396,7 +397,11 @@ test("benchmark provenance binds every runtime and package assembly input", () =
     "src/engine.mjs",
     "src/candidates/native.mjs",
   ]) {
-    assert.equal(inputs.some((file) => file.endsWith(expected)), true, expected);
+    assert.equal(
+      inputs.some((file) => file.replaceAll(path.sep, "/").endsWith(expected)),
+      true,
+      expected,
+    );
   }
 });
 
@@ -1079,6 +1084,7 @@ test("a build receipt is bound to the exact measured artifact", (context) => {
       target: "darwin-arm64",
       rust_target: "aarch64-apple-darwin",
       wasm_pack_target: null,
+      glibc_floor: null,
       default_features: false,
       capability_recipe: CAPABILITY_RECIPE.capability_recipe,
       features: [
@@ -1161,6 +1167,7 @@ test("a build receipt is bound to the exact measured artifact", (context) => {
     target: "darwin-arm64",
     rust_target: "aarch64-apple-darwin",
     wasm_pack_target: null,
+    glibc_floor: null,
     commit: receipt.commit,
     source_digest: receipt.source_digest,
     cargo_lock_digest: receipt.cargo_lock_digest,

--- a/platforms/node/tests/build-candidate.test.mjs
+++ b/platforms/node/tests/build-candidate.test.mjs
@@ -67,6 +67,8 @@ test("candidate builds project its private capability recipe plus one transport"
     assert.equal(invocation.args.includes("-j1"), true);
     assert.equal(invocation.args.join(" ").includes("rust-static-svg"), false);
   }
+  assert.equal(resolveCandidateRecipe("napi", "linux-x64-gnu").glibcFloor, "2.31");
+  assert.equal(resolveCandidateRecipe("napi", "linux-x64-musl").glibcFloor, null);
 });
 
 test("Windows native candidates request reproducible MSVC linking", () => {

--- a/platforms/node/tests/loader-contract.test.mjs
+++ b/platforms/node/tests/loader-contract.test.mjs
@@ -20,6 +20,7 @@ import {
   MermanDisposedError,
   MermanInvalidTransportError,
   MermanMissingPlatformPackageError,
+  MermanNativeLoadError,
   MermanOperationError,
   MermanUnsupportedTargetError,
   NODE_TRANSPORT_LIMITS,
@@ -134,6 +135,34 @@ test("the loader resolves one target-specific package and no browser package", (
   assert.equal(loaded, binding);
   assert.deepEqual(requested, ["@mermanjs/node-darwin-arm64"]);
   assert.equal(nativePackageName("linux-x64-musl"), "@mermanjs/node-linux-x64-musl");
+});
+
+test("the native loader diagnoses installed packages that fail dynamic loading", () => {
+  const loaderFailure = Object.assign(
+    new Error("/lib64/libm.so.6: version `GLIBC_2.35' not found"),
+    { code: "ERR_DLOPEN_FAILED" },
+  );
+  assert.throws(
+    () =>
+      loadNativeBinding({
+        platform: "linux",
+        arch: "x64",
+        report: glibcReport,
+        loadPackage: () => {
+          throw loaderFailure;
+        },
+      }),
+    (error) => {
+      assert.ok(error instanceof MermanNativeLoadError);
+      assert.equal(error.code, "MERMAN_NATIVE_LOAD_ERROR");
+      assert.equal(error.packageName, "@mermanjs/node-linux-x64-gnu");
+      assert.equal(error.target, "linux-x64-gnu");
+      assert.equal(error.cause, loaderFailure);
+      assert.match(error.message, /ABI|shared-library/i);
+      assert.match(error.message, /node-wasm/);
+      return true;
+    },
+  );
 });
 
 test("the native loader reads its expected version from its own package manifest", () => {

--- a/platforms/node/tests/package-contract.test.mjs
+++ b/platforms/node/tests/package-contract.test.mjs
@@ -9,7 +9,10 @@ import {
   inspectPackageManifests,
   verifyPackedFileOwnership,
 } from "../scripts/package-contract.mjs";
-import { assembleNativePackages } from "../scripts/assemble-packages.mjs";
+import {
+  assembleNativePackages,
+  assembleWasmPackage,
+} from "../scripts/assemble-packages.mjs";
 import {
   assertSuccessfulNpmSpawn,
   spawnNpmSync,
@@ -32,6 +35,14 @@ test("public alpha manifests preserve the intended napi package shape", async ()
   assert.equal(inspected.root.hasLifecycleDownload, false);
   assert.equal(inspected.root.hasBrowserFallback, false);
   assert.equal(inspected.root.manifest.engines.node, descriptor.node_engine);
+  assert.equal(inspected.wasm.manifest.name, "@mermanjs/node-wasm");
+  assert.equal(inspected.wasm.manifest.publishConfig.access, "public");
+  assert.equal(inspected.wasm.manifest.main, "./dist/index.mjs");
+  assert.equal(inspected.wasm.manifest.types, "./dist/index.d.ts");
+  assert.equal(inspected.wasm.hasBrowserFallback, false);
+  assert.equal(inspected.wasm.manifest.dependencies, undefined);
+  assert.equal(inspected.wasm.manifest.optionalDependencies, undefined);
+  assert.equal(inspected.wasm.manifest.version, descriptor.version);
 
   const expectedTargets = [
     "darwin-arm64",
@@ -69,6 +80,25 @@ test("packed ownership allows no native binary in root and exactly one in a targ
         { path: "package/package.json" },
       ],
     }),
+  );
+  assert.doesNotThrow(() =>
+    verifyPackedFileOwnership({
+      packageName: "@mermanjs/node-wasm",
+      role: "wasm",
+      files: [
+        { path: "package/artifact/merman_node.cjs" },
+        { path: "package/artifact/merman_node_bg.wasm" },
+      ],
+    }),
+  );
+  assert.throws(
+    () =>
+      verifyPackedFileOwnership({
+        packageName: "@mermanjs/node-wasm",
+        role: "wasm",
+        files: [{ path: "package/artifact/merman_node_bg.wasm" }],
+      }),
+    /exactly.*merman_node\.cjs/i,
   );
   assert.doesNotThrow(() =>
     verifyPackedFileOwnership({
@@ -201,6 +231,40 @@ test("assembled native packages pass real npm pack ownership inspection", async 
       `${pathToFileURL(path.join(output, "node", "dist", "native-loader.mjs")).href}?assembled`
     );
     assert.equal(assembledLoader.nodeLoaderPackageVersion(), descriptor.version);
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true });
+  }
+});
+
+test("assembled Node WASM package owns only its explicit Node artifacts", async () => {
+  const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), "merman-node-wasm-pack-test-"));
+  try {
+    const wasm = path.join(temporaryRoot, "merman_node_bg.wasm");
+    const loader = path.join(temporaryRoot, "merman_node.js");
+    const output = path.join(temporaryRoot, "packages");
+    await writeFile(wasm, "synthetic wasm candidate");
+    await writeFile(loader, "module.exports = {};\n");
+    assembleWasmPackage(output, wasm, {
+      readReceipt(artifact) {
+        assert.equal(artifact, wasm);
+        return { candidate: "node-wasm", target: null };
+      },
+    });
+
+    const pack = npmPackDryRun(path.join(output, "node-wasm"));
+    verifyPackedFileOwnership({
+      packageName: "@mermanjs/node-wasm",
+      role: "wasm",
+      files: pack.files,
+    });
+    assert.equal(
+      pack.files.some((item) => item.path === "artifact/merman_node.cjs"),
+      true,
+    );
+    assert.equal(
+      pack.files.some((item) => item.path === "build-receipt.json"),
+      false,
+    );
   } finally {
     await rm(temporaryRoot, { recursive: true, force: true });
   }

--- a/scripts/node_package_group.py
+++ b/scripts/node_package_group.py
@@ -47,6 +47,13 @@ EXPECTED_ROOT = {
     "name": "@mermanjs/node",
     "directory": "packages/node",
 }
+EXPECTED_WASM = {
+    "name": "@mermanjs/node-wasm",
+    "directory": "packages/node-wasm",
+    "artifact_directory": "artifact",
+    "node_artifact": "merman_node.cjs",
+    "wasm_artifact": "merman_node_bg.wasm",
+}
 EXPECTED_TARGETS = [
     {
         "target": "darwin-arm64",
@@ -107,6 +114,21 @@ REQUIRED_LOADER_FILES = {
     "package/dist/generated/capability-surface.mjs",
     "package/dist/generated/node-wire-contract.json",
 }
+REQUIRED_WASM_FILES = {
+    "package/CHANGELOG.md",
+    "package/dist/index.mjs",
+    "package/dist/index.d.ts",
+    "package/dist/candidates/wasm.mjs",
+    "package/dist/candidates/wrap-engine.mjs",
+    "package/dist/engine.mjs",
+    "package/dist/errors.mjs",
+    "package/dist/native-loader.mjs",
+    "package/dist/generated/binding-contract.mjs",
+    "package/dist/generated/capability-surface.mjs",
+    "package/dist/generated/node-wire-contract.json",
+    "package/artifact/merman_node.cjs",
+    "package/artifact/merman_node_bg.wasm",
+}
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -137,6 +159,8 @@ def load_descriptor(path: Path) -> dict[str, Any]:
         raise PackageGroupError("Node descriptor must require Node.js 22 or newer")
     if descriptor.get("root") != EXPECTED_ROOT:
         raise PackageGroupError("Node descriptor loader package does not match the public contract")
+    if descriptor.get("wasm") != EXPECTED_WASM:
+        raise PackageGroupError("Node descriptor WASM package does not match the public contract")
     if descriptor.get("targets") != EXPECTED_TARGETS:
         raise PackageGroupError("Node descriptor target packages do not match the public contract")
     return descriptor
@@ -206,6 +230,7 @@ def descriptor_entries(descriptor: dict[str, Any]) -> dict[str, tuple[str, dict[
     entries: dict[str, tuple[str, dict[str, Any]]] = {}
     for target in descriptor["targets"]:
         entries[target["name"]] = ("platform", target)
+    entries[descriptor["wasm"]["name"]] = ("wasm", descriptor["wasm"])
     entries[descriptor["root"]["name"]] = ("loader", descriptor["root"])
     return entries
 
@@ -241,7 +266,7 @@ def inspect_tarball(
         )
     node_files = sorted(name for name in names if name.endswith(".node"))
     wasm_files = sorted(name for name in names if name.endswith(".wasm"))
-    if wasm_files:
+    if role != "wasm" and wasm_files:
         raise PackageGroupError(f"{package_name} must not contain WASM artifacts")
     if role == "loader":
         missing_loader = REQUIRED_LOADER_FILES - names
@@ -258,6 +283,25 @@ def inspect_tarball(
             )
         if any(key in manifest for key in ("os", "cpu", "libc")):
             raise PackageGroupError(f"{package_name} loader must not declare platform constraints")
+    elif role == "wasm":
+        missing_wasm = REQUIRED_WASM_FILES - names
+        if missing_wasm:
+            raise PackageGroupError(
+                f"{package_name} is missing required WASM files: {', '.join(sorted(missing_wasm))}"
+            )
+        if node_files:
+            raise PackageGroupError(f"{package_name} WASM package must not contain native artifacts")
+        if wasm_files != [f"package/{package_descriptor['artifact_directory']}/{package_descriptor['wasm_artifact']}"]:
+            raise PackageGroupError(f"{package_name} must contain exactly one canonical WASM artifact")
+        cjs_files = sorted(name for name in names if name.endswith(".cjs"))
+        if cjs_files != [f"package/{package_descriptor['artifact_directory']}/{package_descriptor['node_artifact']}"]:
+            raise PackageGroupError(f"{package_name} must contain exactly one Node WASM loader")
+        if manifest.get("main") != "./dist/index.mjs" or manifest.get("types") != "./dist/index.d.ts":
+            raise PackageGroupError(f"{package_name} Node WASM entry point is invalid")
+        if any(key in manifest for key in ("os", "cpu", "libc")):
+            raise PackageGroupError(f"{package_name} WASM package must not declare platform constraints")
+        if any(key in manifest for key in ("dependencies", "optionalDependencies", "peerDependencies")):
+            raise PackageGroupError(f"{package_name} WASM package must not declare runtime dependencies")
     elif node_files != [f"package/{package_descriptor['node_artifact']}"]:
         raise PackageGroupError(
             f"{package_name} must contain exactly package/{package_descriptor['node_artifact']}"
@@ -299,11 +343,12 @@ def validate_manifest(
         raise PackageGroupError("Node package group source_sha must be a full lowercase Git SHA")
     if descriptor is not None:
         expected_names = [target["name"] for target in descriptor["targets"]] + [
-            descriptor["root"]["name"]
+            descriptor["wasm"]["name"],
+            descriptor["root"]["name"],
         ]
         observed_names = [record["name"] for record in manifest["packages"]]
         if observed_names != expected_names:
-            raise PackageGroupError("Node package group must list every platform before the loader")
+            raise PackageGroupError("Node package group must list every platform and WASM package before the loader")
     return manifest
 
 
@@ -327,10 +372,11 @@ def create_manifest(
     ]
     by_name = {record["name"]: record for record in records}
     expected_names = [target["name"] for target in descriptor["targets"]] + [
-        descriptor["root"]["name"]
+        descriptor["wasm"]["name"],
+        descriptor["root"]["name"],
     ]
     if set(by_name) != set(expected_names) or len(records) != len(expected_names):
-        raise PackageGroupError("artifact directory must contain exactly the six Node npm packages")
+        raise PackageGroupError("artifact directory must contain exactly the seven Node npm packages")
     manifest = validate_manifest(
         {
             "schema_version": 1,

--- a/scripts/release_projection.py
+++ b/scripts/release_projection.py
@@ -114,11 +114,12 @@ class _NodePackageEntry:
 class _NodePackageCatalog:
     version: str
     root: _NodePackageEntry
+    wasm: _NodePackageEntry
     targets: tuple[_NodePackageEntry, ...]
 
     @property
     def entries(self) -> tuple[_NodePackageEntry, ...]:
-        return (self.root, *self.targets)
+        return (self.root, self.wasm, *self.targets)
 
 
 class RepositoryView:
@@ -567,9 +568,10 @@ def _collect_cargo_lock_versions(
             )
             continue
         actual = matches[0].get("version")
+        lock_label = str(label or lock_path).replace("\\", "/")
         observations.append(
             VersionObservation(
-                f"{label or lock_path} package {package_name}",
+                f"{lock_label} package {package_name}",
                 lock_path,
                 catalog.authority.canonical,
                 actual if isinstance(actual, str) else "<missing>",
@@ -610,9 +612,10 @@ def _collect_independent_lock_versions(
             )
             continue
         actual = matches[0].get("version")
+        lock_label = str(label or lock_path).replace("\\", "/")
         observations.append(
             VersionObservation(
-                f"{label or lock_path} independent package {package_name}",
+                f"{lock_label} independent package {package_name}",
                 lock_path,
                 expected_version,
                 actual if isinstance(actual, str) else "<missing>",
@@ -700,6 +703,10 @@ def _node_package_catalog(view: RepositoryView) -> _NodePackageCatalog:
         descriptor.get("root"),
         f"{NODE_DESCRIPTOR}.root",
     )
+    wasm = _node_package_entry(
+        descriptor.get("wasm"),
+        f"{NODE_DESCRIPTOR}.wasm",
+    )
     raw_targets = descriptor.get("targets")
     if not isinstance(raw_targets, list):
         raise ReleaseProjectionError(
@@ -712,7 +719,7 @@ def _node_package_catalog(view: RepositoryView) -> _NodePackageCatalog:
         )
         for index, raw_target in enumerate(raw_targets)
     )
-    return _NodePackageCatalog(version=version, root=root, targets=targets)
+    return _NodePackageCatalog(version=version, root=root, wasm=wasm, targets=targets)
 
 
 def _collect_node_candidate_projection(

--- a/scripts/test_node_package_group.py
+++ b/scripts/test_node_package_group.py
@@ -25,6 +25,7 @@ class NodePackageGroupTests(unittest.TestCase):
         self.version = self.descriptor["version"]
         for target in self.descriptor["targets"]:
             self._write_package(target["name"], role="platform", target=target)
+        self._write_package(self.descriptor["wasm"]["name"], role="wasm")
         self._write_package(self.descriptor["root"]["name"], role="loader")
 
     def tearDown(self) -> None:
@@ -60,6 +61,11 @@ class NodePackageGroupTests(unittest.TestCase):
             }
             for required in node_package_group.REQUIRED_LOADER_FILES:
                 files[required] = b"loader"
+        elif role == "wasm":
+            manifest["main"] = "./dist/index.mjs"
+            manifest["types"] = "./dist/index.d.ts"
+            for required in node_package_group.REQUIRED_WASM_FILES:
+                files[required] = b"wasm"
         else:
             assert target is not None
             manifest["main"] = f"./{target['node_artifact']}"
@@ -94,6 +100,7 @@ class NodePackageGroupTests(unittest.TestCase):
         self.assertEqual(
             [record["name"] for record in manifest["packages"]],
             [target["name"] for target in self.descriptor["targets"]]
+            + [self.descriptor["wasm"]["name"]]
             + [self.descriptor["root"]["name"]],
         )
 

--- a/scripts/test_release_projection.py
+++ b/scripts/test_release_projection.py
@@ -66,7 +66,7 @@ def node_package_surface() -> dict:
 
 def node_package_manifests(descriptor: dict | None = None) -> list[Path]:
     surface = descriptor or node_package_surface()
-    entries = [surface["root"], *surface["targets"]]
+    entries = [surface["root"], surface["wasm"], *surface["targets"]]
     return [
         release_projection.NODE_ROOT / entry["directory"] / "package.json"
         for entry in entries

--- a/scripts/test_release_workflow_security.py
+++ b/scripts/test_release_workflow_security.py
@@ -300,6 +300,24 @@ jobs:
                 self.assertIn("main is allowed only for a non-publishing build", text)
                 self.assertRegex(text, r"\[\[ \"\$SOURCE_REF\" =~ \^\[0-9a-f\]\{40\}\$ \]\]")
 
+    def test_node_publish_supports_verified_cross_run_recovery(self) -> None:
+        text = read(WORKFLOW_ROOT / "release-node.yml")
+        publish = workflow_job(text, "publish")
+        self.assertIn("recovery_run_id:", text)
+        self.assertIn("DISPATCH_RECOVERY_RUN_ID", text)
+        self.assertIn("recovery_run_id requires publish_to_npm=true", text)
+        self.assertIn("actions: read", publish)
+        self.assertIn("always()", publish)
+        self.assertIn(
+            "needs.package-group.result == 'success' || needs.validate-inputs.outputs.recovery_run_id != ''",
+            publish,
+        )
+        self.assertIn("github-token: ${{ github.token }}", publish)
+        self.assertIn(
+            "run-id: ${{ needs.validate-inputs.outputs.recovery_run_id != '' && needs.validate-inputs.outputs.recovery_run_id || github.run_id }}",
+            publish,
+        )
+
     def test_performance_pull_requests_are_read_only_and_summary_only(self) -> None:
         text = read(WORKFLOW_ROOT / "performance.yml")
         self.assertNotIn("pull-requests: write", text)


### PR DESCRIPTION
## Summary

- Add the explicit `@mermanjs/node-wasm` npm package for Node.js 22+ deployments that cannot load a native addon.
- Keep `@mermanjs/node` native-only; there is no silent browser-WASM or Node-WASM fallback.
- Make the seven-package Node npm group lockstep and verify native/WASM artifact ownership, provenance, install smoke, and publication order.
- Add an immutable `recovery_run_id` path so first-publish bootstrap and partial-release recovery reuse the exact verified package-group tarballs across workflow runs.
- Exercise Node-WASM npm assembly, packing, isolated installation, and rendering in PR CI.
- Document the Node SVG pipeline contract: `parity` remains the default for trusted/static parity output; `resvg-safe` is opt-in for strict SVG/raster publication; browser DOM admission remains a Web-surface concern.

## Contract

- `@mermanjs/node`: native N-API loader with exact-version platform optional dependencies.
- `@mermanjs/node-wasm`: dependency-free Node-targeted wasm-bindgen package; it does not reuse `@mermanjs/web`.
- Supported pipelines: `parity`, `readable`, and `resvg-safe`.
- Math, browser DOM APIs, browser fallback, binary export, and text-measurement callbacks remain outside the Node package surface.

## Verification

- `npm test --prefix platforms/node` (96 passed)
- `npm run check:packages --prefix platforms/node`
- Real `node-wasm` build with wasm-pack 0.15.0
- Real `@mermanjs/node-wasm` pack, isolated install, and render smoke
- PR-equivalent Node-WASM package assembly/install/render smoke
- `cargo nextest run --manifest-path crates/merman-node/Cargo.toml --locked --no-default-features --features layout-cytoscape,layout-elk,svg,transport-napi --cargo-quiet` (16 passed)
- `cargo run --locked -p xtask -- verify-feature-matrix` (11/11 builds passed)
- `python scripts/verify_artifact_dependency_closures.py --representative-targets`
- `python scripts/verify-third-party-licenses.py`
- Targeted release/CI Python contract suites
- `actionlint` for touched workflows
- `cargo deny check advisories bans licenses sources`

Deferred to CI/release owner: `zizmor` is not installed locally; `cargo-about 0.9.1` is not installed locally. The pre-existing Windows CRLF fuzz seed causes the unrelated `scripts.test_fuzz_config` LF assertion to fail and is outside this PR.