### PR TITLE
fix(render): harden fallback cascade for source-context CSS

### DIFF
--- a/crates/merman-render/src/svg/fallback.rs
+++ b/crates/merman-render/src/svg/fallback.rs
@@ -111,6 +111,7 @@ fn foreign_object_label_fallback_svg_text_with_checkpoints<E>(
     let mut generated_elements = 0usize;
     let mut g_stack: Vec<GFrame> = Vec::new();
     let mut source_stack: Vec<SourceElement> = Vec::new();
+    let mut source_stack_overflow_depth = 0usize;
     let mut cascade_index = None;
     let mut i = 0usize;
     let mut iteration = 0usize;
@@ -139,7 +140,9 @@ fn foreign_object_label_fallback_svg_text_with_checkpoints<E>(
             if name.eq_ignore_ascii_case("g") {
                 let _ = g_stack.pop();
             }
-            if source_stack
+            if source_stack_overflow_depth > 0 {
+                source_stack_overflow_depth -= 1;
+            } else if source_stack
                 .last()
                 .is_some_and(|element| element.local_name.eq_ignore_ascii_case(name))
             {
@@ -192,21 +195,23 @@ fn foreign_object_label_fallback_svg_text_with_checkpoints<E>(
                 checkpoint()?;
                 let raw_lines = htmlish_to_text_lines(inner, checkpoint)?;
                 if !raw_lines.is_empty() {
-                    let cascade = match cascade_index.as_ref() {
+                    let cascade = match cascade_index.as_mut() {
                         Some(cascade) => cascade,
                         None => {
-                            let cascade = CascadeIndex::new(svg, checkpoint)?;
-                            if let Some((actual, maximum)) = cascade.universal_postings_overflow() {
-                                selector_limit(actual, maximum)?;
-                            }
+                            let cascade = CascadeIndex::new(svg, checkpoint, selector_limit)?;
                             cascade_index = Some(cascade);
                             cascade_index
-                                .as_ref()
+                                .as_mut()
                                 .expect("cascade index was initialized")
                         }
                     };
-                    let typography =
-                        cascade.resolve_foreign_object(&source_stack, tag, inner, checkpoint)?;
+                    let typography = cascade.resolve_foreign_object(
+                        &source_stack,
+                        tag,
+                        inner,
+                        checkpoint,
+                        selector_limit,
+                    )?;
                     let source_attr = if from_switch {
                         r#" data-merman-foreignobject-source="switch-native-fallback""#
                     } else {
@@ -341,11 +346,21 @@ fn foreign_object_label_fallback_svg_text_with_checkpoints<E>(
                 g_stack.push(GFrame::from_g_tag(tag, checkpoint)?);
             }
             if !is_self_closing(tag) {
-                source_stack.push(CascadeIndex::source_element(
-                    tag,
-                    Namespace::Svg,
-                    checkpoint,
-                )?);
+                if source_stack_overflow_depth > 0 {
+                    source_stack_overflow_depth = source_stack_overflow_depth.saturating_add(1);
+                } else if source_stack.len() >= cascade::MAX_SELECTOR_ANCESTRY_DEPTH {
+                    selector_limit(
+                        source_stack.len().saturating_add(1),
+                        cascade::MAX_SELECTOR_ANCESTRY_DEPTH,
+                    )?;
+                    source_stack_overflow_depth = 1;
+                } else {
+                    source_stack.push(CascadeIndex::source_element(
+                        tag,
+                        Namespace::Svg,
+                        checkpoint,
+                    )?);
+                }
             }
         }
 
@@ -571,6 +586,29 @@ mod tests {
             !fallback.contains("rgba(232, 232, 232, 0.5)"),
             "explicit background-color: initial must not become the compatibility gray: {out}"
         );
+
+        for clear in ["transparent", "initial"] {
+            let svg = format!(
+                r#"<svg xmlns="http://www.w3.org/2000/svg"><style>.labelBkg{{background-color:#ff0000}}.labelBkg .clear{{background-color:{clear}}}</style><foreignObject x="10" y="20" width="30" height="24"><div xmlns="http://www.w3.org/1999/xhtml" class="labelBkg"><span class="clear">Hello</span></div></foreignObject></svg>"#,
+            );
+            let out = foreign_object_label_fallback_svg_text(&svg);
+            let fallback = out
+                .split(r#"data-merman-foreignobject="fallback""#)
+                .nth(1)
+                .unwrap_or_else(|| panic!("expected fallback output: {out}"));
+            assert!(
+                !fallback.contains(r##"fill="#ff0000""##)
+                    && !fallback.contains("rgba(232, 232, 232, 0.5)"),
+                "a specified {clear} descendant must clear the parent fallback background: {out}"
+            );
+        }
+
+        let inherited_child = r#"<svg xmlns="http://www.w3.org/2000/svg"><style>.labelBkg{background-color:#ff0000}.labelBkg .keep{background-color:inherit}</style><foreignObject x="10" y="20" width="30" height="24"><div xmlns="http://www.w3.org/1999/xhtml" class="labelBkg"><span class="keep">Hello</span></div></foreignObject></svg>"#;
+        let out = foreign_object_label_fallback_svg_text(inherited_child);
+        assert!(
+            out.contains(r##"fill="#ff0000""##),
+            "an explicit inherit descendant must retain the nearest resolved background: {out}"
+        );
     }
 
     #[test]
@@ -747,6 +785,17 @@ mod tests {
             "a valid-but-unadmitted sibling must not discard an admitted branch: {out}"
         );
 
+        for selector in [".a + .b", ".a ~ .b", "svg|a", "*|span", "a||b"] {
+            let svg = format!(
+                r#"<svg xmlns="http://www.w3.org/2000/svg"><style>{selector},.nodeLabel{{font-size:13px}}</style><g><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel">Alpha</span></div></foreignObject></g></svg>"#,
+            );
+            let out = foreign_object_label_fallback_svg_text(&svg);
+            assert!(
+                out.contains("font-size: 13px"),
+                "valid unsupported selector must preserve its admitted sibling ({selector}): {out}"
+            );
+        }
+
         let invalid = r#"
 <svg xmlns="http://www.w3.org/2000/svg"><style>.nodeLabel,{font-size:13px}</style><g><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel">Alpha</span></div></foreignObject></g></svg>"#;
         let out = foreign_object_label_fallback_svg_text(invalid);
@@ -790,6 +839,24 @@ mod tests {
             out.contains("font-size: 16px") && !out.contains("font-size: 13px"),
             "a malformed attribute selector must invalidate its complete selector list: {out}"
         );
+
+        for malformed_selector in [
+            "span:hover@bad",
+            "span:hover$bad",
+            "span:hover #",
+            "span:hover .",
+            "span:hover [data-tags=\"foo\" junk]",
+            "a | b",
+        ] {
+            let svg = format!(
+                r#"<svg xmlns="http://www.w3.org/2000/svg"><style>{malformed_selector},.nodeLabel{{font-size:13px}}</style><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel">Alpha</span></div></foreignObject></svg>"#,
+            );
+            let out = foreign_object_label_fallback_svg_text(&svg);
+            assert!(
+                out.contains("font-size: 16px") && !out.contains("font-size: 13px"),
+                "malformed unsupported selector must invalidate its sibling list ({malformed_selector}): {out}"
+            );
+        }
     }
 
     #[test]
@@ -880,6 +947,8 @@ mod tests {
             "hsl(1 2 3)",
             "hsla(10,20%,30%,oops)",
             "rgb(1,2,3)garbage",
+            "rgb(1, 2 3)",
+            "hsl(1, 2% 3%)",
         ] {
             let svg = format!(
                 r##"<svg xmlns="http://www.w3.org/2000/svg"><style>.nodeLabel{{color:#123456;color:{invalid} !important}}</style><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel">Alpha</span></div></foreignObject></svg>"##,
@@ -895,12 +964,20 @@ mod tests {
             );
         }
 
-        let valid = r#"<svg xmlns="http://www.w3.org/2000/svg"><style>.nodeLabel{color:rgb(18 52 86 / .5)}</style><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel">Alpha</span></div></foreignObject></svg>"#;
-        let out = foreign_object_label_fallback_svg_text(valid);
-        assert!(
-            out.contains(r#"fill="rgb(18 52 86 / .5)""#),
-            "a valid Mermaid functional paint must remain admitted: {out}"
-        );
+        for valid in [
+            "rgb(18 52 86 / .5)",
+            "rgb(18, 52, 86)",
+            "hsl(210, 65%, 20%)",
+        ] {
+            let svg = format!(
+                r#"<svg xmlns="http://www.w3.org/2000/svg"><style>.nodeLabel{{color:{valid}}}</style><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel">Alpha</span></div></foreignObject></svg>"#,
+            );
+            let out = foreign_object_label_fallback_svg_text(&svg);
+            assert!(
+                out.contains(&format!(r#"fill="{valid}""#)),
+                "a valid Mermaid functional paint must remain admitted ({valid}): {out}"
+            );
+        }
     }
 
     #[test]
@@ -956,12 +1033,16 @@ mod tests {
     #[test]
     fn foreign_object_overlay_bounds_ordinary_selector_postings() {
         let mut svg = String::from(r#"<svg xmlns="http://www.w3.org/2000/svg"><style>"#);
-        for _ in 0..super::cascade::MAX_SELECTOR_POSTINGS {
-            svg.push_str(".nodeLabel{font-size:12px}");
+        for index in 0..super::cascade::MAX_SELECTOR_POSTINGS {
+            if index > 0 {
+                svg.push(',');
+            }
+            svg.push_str(".posting");
+            svg.push_str(&index.to_string());
         }
-        svg.push_str(
-            r#".nodeLabel{font-size:19px}</style><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel">Alpha</span></div></foreignObject></svg>"#,
-        );
+        svg.push_str(r#"{font-size:12px}.nodeLabel{font-size:19px}</style><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel posting"#);
+        svg.push_str(&(super::cascade::MAX_SELECTOR_POSTINGS - 1).to_string());
+        svg.push_str(r#"">Alpha</span></div></foreignObject></svg>"#);
 
         let out = foreign_object_label_fallback_svg_text(&svg);
         let fallback = out
@@ -1020,6 +1101,211 @@ mod tests {
         );
 
         assert_eq!(result, Err("selector limit"));
+
+        let session = crate::environment::RenderEnvironment::deterministic()
+            .with_resource_policy(
+                crate::resources::RenderResourcePolicy::unbounded_for_trusted_input(),
+            )
+            .begin_session()
+            .unwrap();
+        let error = crate::svg::pipeline::SvgPipeline::resvg_safe()
+            .process_to_string(&svg, &session)
+            .expect_err("the public pipeline must preserve the selector resource error");
+        let crate::Error::ResourceLimitExceeded(limit) = error else {
+            panic!("expected a resource limit error");
+        };
+        assert_eq!(
+            limit.phase,
+            crate::resources::ResourceLimitPhase::SvgPostprocess
+        );
+        assert_eq!(limit.limit, "svg_fallback_selector_index");
+        assert_eq!(limit.cause, crate::resources::ResourceLimitCause::Ceiling);
+        assert_eq!(
+            (limit.actual, limit.max),
+            (
+                super::cascade::MAX_SELECTOR_STYLESHEET_BYTES + 1,
+                super::cascade::MAX_SELECTOR_STYLESHEET_BYTES,
+            )
+        );
+    }
+
+    #[test]
+    fn foreign_object_overlay_discards_a_rule_over_the_declaration_cap() {
+        let mut svg = String::from(
+            r#"<svg xmlns="http://www.w3.org/2000/svg"><style>.nodeLabel{font-size:12px;"#,
+        );
+        for _ in 1..super::cascade::MAX_SELECTOR_DECLARATIONS_PER_RULE {
+            svg.push_str("font-weight:400;");
+        }
+        svg.push_str(
+            r#"font-size:19px}</style><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel">Alpha</span></div></foreignObject></svg>"#,
+        );
+
+        let out = foreign_object_label_fallback_svg_text(&svg);
+        let fallback = out
+            .split(r#"data-merman-foreignobject="fallback""#)
+            .nth(1)
+            .unwrap_or_else(|| panic!("expected fallback output: {out}"));
+        assert!(
+            fallback.contains("font-size: 16px")
+                && !fallback.contains("font-size: 12px")
+                && !fallback.contains("font-size: 19px"),
+            "an over-limit declaration block must be discarded atomically: {out}"
+        );
+
+        let measurer = VendoredFontMetricsTextMeasurer::default();
+        let mut checkpoint = || Ok::<(), &'static str>(());
+        let mut selector_limit = |actual, maximum| {
+            assert_eq!(
+                actual,
+                super::cascade::MAX_SELECTOR_DECLARATIONS_PER_RULE + 1
+            );
+            assert_eq!(maximum, super::cascade::MAX_SELECTOR_DECLARATIONS_PER_RULE);
+            Err("selector limit")
+        };
+        let mut preflight = |_, _| Ok::<(), &'static str>(());
+        let result = super::foreign_object_label_fallback_svg_text_with_checkpoints(
+            &svg,
+            &measurer,
+            &mut checkpoint,
+            &mut selector_limit,
+            &mut preflight,
+        );
+        assert_eq!(result, Err("selector limit"));
+    }
+
+    #[test]
+    fn foreign_object_overlay_discards_a_selector_list_over_the_component_cap() {
+        let mut svg = String::from(r#"<svg xmlns="http://www.w3.org/2000/svg"><style>.nodeLabel"#);
+        for _ in 0..super::cascade::MAX_SELECTOR_COMPONENTS_PER_BRANCH {
+            svg.push_str(".extra");
+        }
+        svg.push_str(
+            r#",.nodeLabel{font-size:19px}</style><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel">Alpha</span></div></foreignObject></svg>"#,
+        );
+
+        let out = foreign_object_label_fallback_svg_text(&svg);
+        let fallback = out
+            .split(r#"data-merman-foreignobject="fallback""#)
+            .nth(1)
+            .unwrap_or_else(|| panic!("expected fallback output: {out}"));
+        assert!(
+            fallback.contains("font-size: 16px") && !fallback.contains("font-size: 19px"),
+            "a selector-list resource overflow must not retain an admitted sibling: {out}"
+        );
+
+        let measurer = VendoredFontMetricsTextMeasurer::default();
+        let mut checkpoint = || Ok::<(), &'static str>(());
+        let mut selector_limit = |actual, maximum| {
+            assert_eq!(
+                actual,
+                super::cascade::MAX_SELECTOR_COMPONENTS_PER_BRANCH + 1
+            );
+            assert_eq!(maximum, super::cascade::MAX_SELECTOR_COMPONENTS_PER_BRANCH);
+            Err("selector limit")
+        };
+        let mut preflight = |_, _| Ok::<(), &'static str>(());
+        let result = super::foreign_object_label_fallback_svg_text_with_checkpoints(
+            &svg,
+            &measurer,
+            &mut checkpoint,
+            &mut selector_limit,
+            &mut preflight,
+        );
+        assert_eq!(result, Err("selector limit"));
+    }
+
+    #[test]
+    fn foreign_object_overlay_accounts_for_source_selector_width_in_match_work() {
+        let mut svg = String::from(r#"<svg xmlns="http://www.w3.org/2000/svg"><style>"#);
+        for index in 0..512 {
+            if index > 0 {
+                svg.push(',');
+            }
+            svg.push_str(".hit.missing");
+            svg.push_str(&index.to_string());
+        }
+        svg.push_str(
+            r#"{font-size:12px}.hit{font-size:19px}</style><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><span class="hit"#,
+        );
+        for index in 0..3000 {
+            svg.push_str(" filler");
+            svg.push_str(&index.to_string());
+        }
+        svg.push_str(r#"">Alpha</span></div></foreignObject></svg>"#);
+
+        let out = foreign_object_label_fallback_svg_text(&svg);
+        let fallback = out
+            .split(r#"data-merman-foreignobject="fallback""#)
+            .nth(1)
+            .unwrap_or_else(|| panic!("expected fallback output"));
+        assert!(
+            fallback.contains("font-size: 16px")
+                && !fallback.contains("font-size: 12px")
+                && !fallback.contains("font-size: 19px"),
+            "an exhausted match budget must skip all stylesheet candidates for the element"
+        );
+
+        let measurer = VendoredFontMetricsTextMeasurer::default();
+        let mut checkpoint = || Ok::<(), &'static str>(());
+        let mut selector_limit = |actual, maximum| {
+            assert!(actual > maximum);
+            assert_eq!(maximum, super::cascade::MAX_SELECTOR_MATCH_WORK);
+            Err("selector limit")
+        };
+        let mut preflight = |_, _| Ok::<(), &'static str>(());
+        let result = super::foreign_object_label_fallback_svg_text_with_checkpoints(
+            &svg,
+            &measurer,
+            &mut checkpoint,
+            &mut selector_limit,
+            &mut preflight,
+        );
+        assert_eq!(result, Err("selector limit"));
+    }
+
+    #[test]
+    fn foreign_object_overlay_bounds_source_ancestry_before_building_paths() {
+        let mut svg = String::from(
+            r#"<svg xmlns="http://www.w3.org/2000/svg"><style>a{font-size:12px}</style>"#,
+        );
+        for _ in 0..=super::cascade::MAX_SELECTOR_ANCESTRY_DEPTH {
+            svg.push_str("<a>");
+        }
+        svg.push_str(
+            r#"<foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml">Alpha</div></foreignObject>"#,
+        );
+        for _ in 0..=super::cascade::MAX_SELECTOR_ANCESTRY_DEPTH {
+            svg.push_str("</a>");
+        }
+        svg.push_str("</svg>");
+
+        let out = foreign_object_label_fallback_svg_text(&svg);
+        let fallback = out
+            .split(r#"data-merman-foreignobject="fallback""#)
+            .nth(1)
+            .unwrap_or_else(|| panic!("expected fallback output: {out}"));
+        assert!(
+            fallback.contains("font-size: 16px") && !fallback.contains("font-size: 12px"),
+            "an over-deep source path must use the bounded fallback defaults: {out}"
+        );
+
+        let measurer = VendoredFontMetricsTextMeasurer::default();
+        let mut checkpoint = || Ok::<(), &'static str>(());
+        let mut selector_limit = |actual, maximum| {
+            assert_eq!(actual, super::cascade::MAX_SELECTOR_ANCESTRY_DEPTH + 1);
+            assert_eq!(maximum, super::cascade::MAX_SELECTOR_ANCESTRY_DEPTH);
+            Err("selector limit")
+        };
+        let mut preflight = |_, _| Ok::<(), &'static str>(());
+        let result = super::foreign_object_label_fallback_svg_text_with_checkpoints(
+            &svg,
+            &measurer,
+            &mut checkpoint,
+            &mut selector_limit,
+            &mut preflight,
+        );
+        assert_eq!(result, Err("selector limit"));
     }
 
     #[test]
@@ -1042,6 +1328,21 @@ mod tests {
             out.contains(r##"<rect x="0" y="0" width="80" height="30" fill="#c0ffee"/>"##),
             "a classless common XHTML background owner must drive the fallback rect: {out}"
         );
+
+        let shorthand = r##"<svg xmlns="http://www.w3.org/2000/svg"><style>.edgeLabel{background:#ececff}</style><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><span class="edgeLabel">Alpha</span></div></foreignObject></svg>"##;
+        let out = foreign_object_label_fallback_svg_text(shorthand);
+        assert!(
+            out.contains(r##"<rect x="0" y="0" width="80" height="30" fill="#ececff"/>"##),
+            "a color-only background shorthand must resolve on the real XHTML owner: {out}"
+        );
+
+        let current_color = r##"<svg xmlns="http://www.w3.org/2000/svg"><style>.edgeLabel{color:#123456;background-color:currentColor}</style><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><span class="edgeLabel">Alpha</span></div></foreignObject></svg>"##;
+        let out = foreign_object_label_fallback_svg_text(current_color);
+        assert!(
+            out.contains(r##"<rect x="0" y="0" width="80" height="30" fill="#123456"/>"##)
+                && !out.contains(r#"fill="currentcolor""#),
+            "background currentColor must be materialized before leaving XHTML context: {out}"
+        );
     }
 
     #[test]
@@ -1063,6 +1364,17 @@ mod tests {
         assert!(out.contains("font-size: 13px"), "got: {out}");
         assert!(out.contains("font-weight: 600"), "got: {out}");
         assert!(out.contains("font-style: italic"), "got: {out}");
+    }
+
+    #[test]
+    fn foreign_object_overlay_keeps_unprefixed_type_selectors_namespace_neutral() {
+        let svg = r#"<svg xmlns="http://www.w3.org/2000/svg"><style>a{font-size:13px}</style><a><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><span>Alpha</span></div></foreignObject></a></svg>"#;
+        let out = foreign_object_label_fallback_svg_text(svg);
+
+        assert!(
+            out.contains("font-size: 13px"),
+            "an unprefixed type selector must match the real SVG ancestor namespace: {out}"
+        );
     }
 
     #[test]

--- a/crates/merman-render/src/svg/fallback.rs
+++ b/crates/merman-render/src/svg/fallback.rs
@@ -770,6 +770,26 @@ mod tests {
             out.contains("font-size: 16px") && !out.contains("font-size: 10px"),
             "an invalid compound must invalidate its complete selector list: {out}"
         );
+
+        for operator in ["|=", "^=", "$=", "*="] {
+            let selector = format!("[data-tags{operator}choice],.nodeLabel");
+            let svg = format!(
+                r#"<svg xmlns="http://www.w3.org/2000/svg"><style>{selector}{{font-size:13px}}</style><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel">Alpha</span></div></foreignObject></svg>"#,
+            );
+            let out = foreign_object_label_fallback_svg_text(&svg);
+            assert!(
+                out.contains("font-size: 13px"),
+                "a valid-but-unadmitted attribute operator must preserve an admitted sibling ({operator}): {out}"
+            );
+        }
+
+        let malformed_attribute = r#"
+<svg xmlns="http://www.w3.org/2000/svg"><style>[data-tags^=],.nodeLabel{font-size:13px}</style><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel">Alpha</span></div></foreignObject></svg>"#;
+        let out = foreign_object_label_fallback_svg_text(malformed_attribute);
+        assert!(
+            out.contains("font-size: 16px") && !out.contains("font-size: 13px"),
+            "a malformed attribute selector must invalidate its complete selector list: {out}"
+        );
     }
 
     #[test]
@@ -853,6 +873,37 @@ mod tests {
     }
 
     #[test]
+    fn foreign_object_overlay_rejects_malformed_functional_paints() {
+        for invalid in [
+            "rgb(foo)",
+            "rgba(1)",
+            "hsl(1 2 3)",
+            "hsla(10,20%,30%,oops)",
+            "rgb(1,2,3)garbage",
+        ] {
+            let svg = format!(
+                r##"<svg xmlns="http://www.w3.org/2000/svg"><style>.nodeLabel{{color:#123456;color:{invalid} !important}}</style><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel">Alpha</span></div></foreignObject></svg>"##,
+            );
+            let out = foreign_object_label_fallback_svg_text(&svg);
+            let fallback = out
+                .split(r#"data-merman-foreignobject="fallback""#)
+                .nth(1)
+                .unwrap_or_else(|| panic!("expected fallback output: {out}"));
+            assert!(
+                fallback.contains(r##"fill="#123456""##) && !fallback.contains(invalid),
+                "an invalid functional paint must not hide a lower valid declaration ({invalid}): {out}"
+            );
+        }
+
+        let valid = r#"<svg xmlns="http://www.w3.org/2000/svg"><style>.nodeLabel{color:rgb(18 52 86 / .5)}</style><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel">Alpha</span></div></foreignObject></svg>"#;
+        let out = foreign_object_label_fallback_svg_text(valid);
+        assert!(
+            out.contains(r#"fill="rgb(18 52 86 / .5)""#),
+            "a valid Mermaid functional paint must remain admitted: {out}"
+        );
+    }
+
+    #[test]
     fn foreign_object_overlay_keeps_late_universal_winners() {
         let mut svg = String::from(r#"<svg xmlns="http://www.w3.org/2000/svg"><style>"#);
         for _ in 0..super::cascade::MAX_UNIVERSAL_POSTINGS {
@@ -903,6 +954,75 @@ mod tests {
     }
 
     #[test]
+    fn foreign_object_overlay_bounds_ordinary_selector_postings() {
+        let mut svg = String::from(r#"<svg xmlns="http://www.w3.org/2000/svg"><style>"#);
+        for _ in 0..super::cascade::MAX_SELECTOR_POSTINGS {
+            svg.push_str(".nodeLabel{font-size:12px}");
+        }
+        svg.push_str(
+            r#".nodeLabel{font-size:19px}</style><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><span class="nodeLabel">Alpha</span></div></foreignObject></svg>"#,
+        );
+
+        let out = foreign_object_label_fallback_svg_text(&svg);
+        let fallback = out
+            .split(r#"data-merman-foreignobject="fallback""#)
+            .nth(1)
+            .unwrap_or_else(|| panic!("expected fallback output: {out}"));
+        assert!(
+            fallback.contains("font-size: 12px") && !fallback.contains("font-size: 19px"),
+            "the infallible helper must ignore ordinary postings beyond the private cap: {out}"
+        );
+
+        let measurer = VendoredFontMetricsTextMeasurer::default();
+        let mut checkpoint = || Ok::<(), &'static str>(());
+        let mut selector_limit = |actual, maximum| {
+            assert_eq!(actual, super::cascade::MAX_SELECTOR_POSTINGS + 1);
+            assert_eq!(maximum, super::cascade::MAX_SELECTOR_POSTINGS);
+            Err("selector limit")
+        };
+        let mut preflight = |_, _| Ok::<(), &'static str>(());
+        let result = super::foreign_object_label_fallback_svg_text_with_checkpoints(
+            &svg,
+            &measurer,
+            &mut checkpoint,
+            &mut selector_limit,
+            &mut preflight,
+        );
+
+        assert_eq!(result, Err("selector limit"));
+    }
+
+    #[test]
+    fn foreign_object_overlay_rejects_oversized_selector_stylesheet() {
+        let mut svg = String::from(r#"<svg xmlns="http://www.w3.org/2000/svg"><style>"#);
+        svg.extend(std::iter::repeat_n(
+            ' ',
+            super::cascade::MAX_SELECTOR_STYLESHEET_BYTES + 1,
+        ));
+        svg.push_str(
+            r#"</style><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><span>Alpha</span></div></foreignObject></svg>"#,
+        );
+
+        let measurer = VendoredFontMetricsTextMeasurer::default();
+        let mut checkpoint = || Ok::<(), &'static str>(());
+        let mut selector_limit = |actual, maximum| {
+            assert_eq!(actual, super::cascade::MAX_SELECTOR_STYLESHEET_BYTES + 1);
+            assert_eq!(maximum, super::cascade::MAX_SELECTOR_STYLESHEET_BYTES);
+            Err("selector limit")
+        };
+        let mut preflight = |_, _| Ok::<(), &'static str>(());
+        let result = super::foreign_object_label_fallback_svg_text_with_checkpoints(
+            &svg,
+            &measurer,
+            &mut checkpoint,
+            &mut selector_limit,
+            &mut preflight,
+        );
+
+        assert_eq!(result, Err("selector limit"));
+    }
+
+    #[test]
     fn foreign_object_overlay_resolves_nested_label_background_descendants() {
         let svg = r##"<svg xmlns="http://www.w3.org/2000/svg"><style>.labelBkg .nested{background-color:#c0ffee}</style><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml" class="labelBkg"><span class="nested">Alpha</span></div></foreignObject></svg>"##;
         let out = foreign_object_label_fallback_svg_text(svg);
@@ -910,6 +1030,28 @@ mod tests {
         assert!(
             out.contains(r##"fill="#c0ffee""##),
             "a nested XHTML background declaration must drive the fallback rect: {out}"
+        );
+    }
+
+    #[test]
+    fn foreign_object_overlay_resolves_classless_common_background_owner() {
+        let svg = r##"<svg xmlns="http://www.w3.org/2000/svg"><style>.edgeLabel{background-color:#c0ffee}</style><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><span class="edgeLabel">Alpha</span></div></foreignObject></svg>"##;
+        let out = foreign_object_label_fallback_svg_text(svg);
+
+        assert!(
+            out.contains(r##"<rect x="0" y="0" width="80" height="30" fill="#c0ffee"/>"##),
+            "a classless common XHTML background owner must drive the fallback rect: {out}"
+        );
+    }
+
+    #[test]
+    fn foreign_object_overlay_does_not_expand_partial_run_background() {
+        let svg = r##"<svg xmlns="http://www.w3.org/2000/svg"><style>.highlight{background-color:#c0ffee}</style><foreignObject width="80" height="30"><div xmlns="http://www.w3.org/1999/xhtml"><span class="highlight">Alpha</span><span>Beta</span></div></foreignObject></svg>"##;
+        let out = foreign_object_label_fallback_svg_text(svg);
+
+        assert!(
+            !out.contains(r##"<rect x="0" y="0" width="80" height="30" fill="#c0ffee"/>"##),
+            "a background that covers only one rich-text run must not expand to the complete fallback label: {out}"
         );
     }
 

--- a/crates/merman-render/src/svg/fallback/cascade.rs
+++ b/crates/merman-render/src/svg/fallback/cascade.rs
@@ -1,14 +1,15 @@
-use super::css::split_style_declarations;
+use super::css::StyleDeclarationScanner;
 use crate::svg::pipeline::{
     SvgTagScanner, checkpoint_loop, end_tag_name, find_tag_end_with_checkpoints,
     find_with_checkpoints, start_tag_name, trim_with_checkpoints,
 };
 use crate::text::TextStyle;
 use cssparser::{
-    AtRuleParser, CowRcStr, ParseError, Parser, ParserInput, ParserState, QualifiedRuleParser,
-    StyleSheetParser, Token,
+    AtRuleParser, BasicParseErrorKind, CowRcStr, ParseError, Parser, ParserInput, ParserState,
+    QualifiedRuleParser, StyleSheetParser, Token,
 };
-use std::collections::HashMap;
+use merman_core::theme_color::ThemeColor;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 const DEFAULT_FONT_SIZE: f64 = 16.0;
@@ -18,7 +19,21 @@ const DEFAULT_COLOR: &str = "#000";
 // Fallback text is a bounded adapter, so pathological CSS magnitudes must not enter output or
 // overflow relative-unit and line-height calculations.
 const MAX_CSS_NUMERIC_VALUE: f64 = 1_000_000.0;
+pub(super) const MAX_SELECTOR_STYLESHEET_BYTES: usize = 2 * 1024 * 1024;
+const MAX_SELECTOR_BYTES: usize = 1024 * 1024;
+const MAX_SELECTOR_QUALIFIED_RULES: usize = 8192;
+const MAX_SELECTOR_BRANCHES: usize = 16_384;
+const MAX_SELECTOR_RULES: usize = 16_384;
+const MAX_SELECTOR_COMPONENTS: usize = 65_536;
+pub(super) const MAX_SELECTOR_COMPONENTS_PER_BRANCH: usize = 64;
+const MAX_SELECTOR_DECLARATIONS: usize = 32_768;
+pub(super) const MAX_SELECTOR_DECLARATIONS_PER_RULE: usize = 256;
+pub(super) const MAX_SELECTOR_POSTINGS: usize = 8192;
 pub(super) const MAX_UNIVERSAL_POSTINGS: usize = 4096;
+// Matching work is byte-weighted so repeated class/attribute string scans cannot hide behind a
+// small selector-component count. Keep enough headroom for normal multi-label Mermaid diagrams.
+pub(super) const MAX_SELECTOR_MATCH_WORK: usize = 16 * 1024 * 1024;
+pub(super) const MAX_SELECTOR_ANCESTRY_DEPTH: usize = crate::resources::MAX_RESVG_TREE_DEPTH;
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub(super) enum Namespace {
@@ -31,10 +46,11 @@ pub(super) struct SourceElement {
     pub(super) namespace: Namespace,
     pub(super) local_name: String,
     pub(super) id: Option<String>,
-    pub(super) classes: Vec<String>,
-    attributes: Vec<SourceAttribute>,
+    pub(super) classes: Arc<HashSet<String>>,
+    attributes: Arc<HashMap<String, Option<String>>>,
     pub(super) inline: Vec<Declaration>,
     pub(super) presentation: Vec<Declaration>,
+    selector_weight: usize,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -141,13 +157,219 @@ struct Branch {
     compounds: Vec<Compound>,
     combinators: Vec<Combinator>,
     specificity: Specificity,
+    component_count: usize,
+    selector_weight: usize,
 }
 
 #[derive(Clone, Debug)]
 struct Rule {
     branch: Branch,
     declarations: Arc<[Declaration]>,
+    declaration_match_weight: usize,
     source_order: usize,
+}
+
+#[derive(Debug, Default)]
+struct SelectorBudget {
+    stylesheet_bytes: usize,
+    selector_bytes: usize,
+    qualified_rules: usize,
+    branches: usize,
+    rules: usize,
+    components: usize,
+    declarations: usize,
+    postings: usize,
+    match_work: usize,
+    admission_exhausted: bool,
+    postings_exhausted: bool,
+    matching_exhausted: bool,
+}
+
+fn checked_charge<E>(
+    used: &mut usize,
+    exhausted: &mut bool,
+    additional: usize,
+    maximum: usize,
+    selector_limit: &mut impl FnMut(usize, usize) -> Result<(), E>,
+) -> Result<bool, E> {
+    if *exhausted {
+        return Ok(false);
+    }
+    let actual = used.checked_add(additional).unwrap_or(usize::MAX);
+    if actual > maximum {
+        *exhausted = true;
+        selector_limit(actual, maximum)?;
+        return Ok(false);
+    }
+    *used = actual;
+    Ok(true)
+}
+
+impl SelectorBudget {
+    fn reject_admission<E>(
+        &mut self,
+        actual: usize,
+        maximum: usize,
+        selector_limit: &mut impl FnMut(usize, usize) -> Result<(), E>,
+    ) -> Result<bool, E> {
+        self.admission_exhausted = true;
+        selector_limit(actual, maximum)?;
+        Ok(false)
+    }
+
+    fn charge_stylesheet_bytes<E>(
+        &mut self,
+        additional: usize,
+        selector_limit: &mut impl FnMut(usize, usize) -> Result<(), E>,
+    ) -> Result<bool, E> {
+        checked_charge(
+            &mut self.stylesheet_bytes,
+            &mut self.admission_exhausted,
+            additional,
+            MAX_SELECTOR_STYLESHEET_BYTES,
+            selector_limit,
+        )
+    }
+
+    fn charge_selector_bytes<E>(
+        &mut self,
+        additional: usize,
+        selector_limit: &mut impl FnMut(usize, usize) -> Result<(), E>,
+    ) -> Result<bool, E> {
+        checked_charge(
+            &mut self.selector_bytes,
+            &mut self.admission_exhausted,
+            additional,
+            MAX_SELECTOR_BYTES,
+            selector_limit,
+        )
+    }
+
+    fn charge_qualified_rule<E>(
+        &mut self,
+        selector_limit: &mut impl FnMut(usize, usize) -> Result<(), E>,
+    ) -> Result<bool, E> {
+        checked_charge(
+            &mut self.qualified_rules,
+            &mut self.admission_exhausted,
+            1,
+            MAX_SELECTOR_QUALIFIED_RULES,
+            selector_limit,
+        )
+    }
+
+    fn charge_branch<E>(
+        &mut self,
+        selector_limit: &mut impl FnMut(usize, usize) -> Result<(), E>,
+    ) -> Result<bool, E> {
+        checked_charge(
+            &mut self.branches,
+            &mut self.admission_exhausted,
+            1,
+            MAX_SELECTOR_BRANCHES,
+            selector_limit,
+        )
+    }
+
+    fn charge_rules<E>(
+        &mut self,
+        additional: usize,
+        selector_limit: &mut impl FnMut(usize, usize) -> Result<(), E>,
+    ) -> Result<bool, E> {
+        checked_charge(
+            &mut self.rules,
+            &mut self.admission_exhausted,
+            additional,
+            MAX_SELECTOR_RULES,
+            selector_limit,
+        )
+    }
+
+    fn charge_components<E>(
+        &mut self,
+        additional: usize,
+        selector_limit: &mut impl FnMut(usize, usize) -> Result<(), E>,
+    ) -> Result<bool, E> {
+        checked_charge(
+            &mut self.components,
+            &mut self.admission_exhausted,
+            additional,
+            MAX_SELECTOR_COMPONENTS,
+            selector_limit,
+        )
+    }
+
+    fn charge_declarations<E>(
+        &mut self,
+        additional: usize,
+        selector_limit: &mut impl FnMut(usize, usize) -> Result<(), E>,
+    ) -> Result<bool, E> {
+        checked_charge(
+            &mut self.declarations,
+            &mut self.admission_exhausted,
+            additional,
+            MAX_SELECTOR_DECLARATIONS,
+            selector_limit,
+        )
+    }
+
+    fn charge_posting_group<E>(
+        &mut self,
+        additional: usize,
+        universal_additional: usize,
+        current_universal: usize,
+        selector_limit: &mut impl FnMut(usize, usize) -> Result<(), E>,
+    ) -> Result<bool, E> {
+        if self.postings_exhausted {
+            return Ok(false);
+        }
+        let actual = self.postings.checked_add(additional).unwrap_or(usize::MAX);
+        if actual > MAX_SELECTOR_POSTINGS {
+            self.postings_exhausted = true;
+            selector_limit(actual, MAX_SELECTOR_POSTINGS)?;
+            return Ok(false);
+        }
+        let universal_actual = current_universal
+            .checked_add(universal_additional)
+            .unwrap_or(usize::MAX);
+        if universal_actual > MAX_UNIVERSAL_POSTINGS {
+            self.postings_exhausted = true;
+            selector_limit(universal_actual, MAX_UNIVERSAL_POSTINGS)?;
+            return Ok(false);
+        }
+        self.postings = actual;
+        Ok(true)
+    }
+
+    fn charge_match_work<E>(
+        &mut self,
+        additional: usize,
+        selector_limit: &mut impl FnMut(usize, usize) -> Result<(), E>,
+    ) -> Result<bool, E> {
+        checked_charge(
+            &mut self.match_work,
+            &mut self.matching_exhausted,
+            additional,
+            MAX_SELECTOR_MATCH_WORK,
+            selector_limit,
+        )
+    }
+
+    fn check_ancestry_depth<E>(
+        &mut self,
+        actual: usize,
+        selector_limit: &mut impl FnMut(usize, usize) -> Result<(), E>,
+    ) -> Result<bool, E> {
+        if self.matching_exhausted {
+            return Ok(false);
+        }
+        if actual > MAX_SELECTOR_ANCESTRY_DEPTH {
+            self.matching_exhausted = true;
+            selector_limit(actual, MAX_SELECTOR_ANCESTRY_DEPTH)?;
+            return Ok(false);
+        }
+        Ok(true)
+    }
 }
 
 #[derive(Debug)]
@@ -155,16 +377,18 @@ pub(super) struct CascadeIndex {
     rules: Vec<Rule>,
     id_postings: HashMap<String, Vec<usize>>,
     class_postings: HashMap<String, Vec<usize>>,
-    type_postings: HashMap<(Namespace, String), Vec<usize>>,
+    type_postings: HashMap<String, Vec<usize>>,
     attribute_postings: HashMap<String, Vec<usize>>,
     universal_postings: Vec<usize>,
-    universal_postings_overflow: bool,
+    budget: SelectorBudget,
 }
 
 impl CascadeIndex {
     fn with_postings<E>(
         rules: Vec<Rule>,
+        budget: SelectorBudget,
         checkpoint: &mut impl FnMut() -> Result<(), E>,
+        selector_limit: &mut impl FnMut(usize, usize) -> Result<(), E>,
     ) -> Result<Self, E> {
         let mut index = Self {
             rules,
@@ -173,64 +397,93 @@ impl CascadeIndex {
             type_postings: HashMap::new(),
             attribute_postings: HashMap::new(),
             universal_postings: Vec::new(),
-            universal_postings_overflow: false,
+            budget,
         };
-        for (rule_index, rule) in index.rules.iter().enumerate() {
-            checkpoint_loop(rule_index, checkpoint)?;
-            let target = rule
-                .branch
-                .compounds
-                .last()
-                .expect("admitted selector branches have a rightmost compound");
-            if let Some(id) = &target.id {
-                index
-                    .id_postings
-                    .entry(id.clone())
-                    .or_default()
-                    .push(rule_index);
-            } else if let Some(class) = target.classes.first() {
-                index
-                    .class_postings
-                    .entry(class.clone())
-                    .or_default()
-                    .push(rule_index);
-            } else if let Some(attribute) = target.attributes.first() {
-                index
-                    .attribute_postings
-                    .entry(attribute.name.clone())
-                    .or_default()
-                    .push(rule_index);
-            } else if let (Some(namespace), Some(local_name)) =
-                (target.namespace, &target.local_name)
+        // Rules produced by one selector list share a source-order value. Admit each such
+        // group atomically so a posting cap cannot retain only part of a CSS selector list.
+        let mut retained_rules = 0usize;
+        let mut group_start = 0usize;
+        while group_start < index.rules.len() {
+            let source_order = index.rules[group_start].source_order;
+            let mut group_end = group_start + 1;
+            while group_end < index.rules.len()
+                && index.rules[group_end].source_order == source_order
             {
-                index
-                    .type_postings
-                    .entry((namespace, local_name.clone()))
-                    .or_default()
-                    .push(rule_index);
-            } else {
-                // A universal rightmost selector cannot be narrowed by source-element postings.
-                // Keep this bucket bounded: controlled callers reject overflow, while the
-                // infallible helper remains best-effort and ignores rules beyond the cap.
-                if index.universal_postings.len() < MAX_UNIVERSAL_POSTINGS {
-                    index.universal_postings.push(rule_index);
+                group_end += 1;
+            }
+            checkpoint_loop(group_start, checkpoint)?;
+
+            let universal_additional = (group_start..group_end)
+                .filter(|rule_index| {
+                    let target = index.rules[*rule_index]
+                        .branch
+                        .compounds
+                        .last()
+                        .expect("admitted selector branches have a rightmost compound");
+                    target.id.is_none()
+                        && target.classes.is_empty()
+                        && target.attributes.is_empty()
+                        && target.local_name.is_none()
+                })
+                .count();
+            if !index.budget.charge_posting_group(
+                group_end - group_start,
+                universal_additional,
+                index.universal_postings.len(),
+                selector_limit,
+            )? {
+                break;
+            }
+
+            for rule_index in group_start..group_end {
+                checkpoint_loop(rule_index, checkpoint)?;
+                let target = index.rules[rule_index]
+                    .branch
+                    .compounds
+                    .last()
+                    .expect("admitted selector branches have a rightmost compound");
+                if let Some(id) = &target.id {
+                    index
+                        .id_postings
+                        .entry(id.clone())
+                        .or_default()
+                        .push(rule_index);
+                } else if let Some(class) = target.classes.first() {
+                    index
+                        .class_postings
+                        .entry(class.clone())
+                        .or_default()
+                        .push(rule_index);
+                } else if let Some(attribute) = target.attributes.first() {
+                    index
+                        .attribute_postings
+                        .entry(attribute.name.clone())
+                        .or_default()
+                        .push(rule_index);
+                } else if let Some(local_name) = &target.local_name {
+                    index
+                        .type_postings
+                        .entry(local_name.clone())
+                        .or_default()
+                        .push(rule_index);
                 } else {
-                    index.universal_postings_overflow = true;
+                    // A universal rightmost selector cannot be narrowed by source-element
+                    // postings, so keep it in the bounded universal bucket.
+                    index.universal_postings.push(rule_index);
                 }
             }
+            retained_rules = group_end;
+            group_start = group_end;
         }
+        index.rules.truncate(retained_rules);
         checkpoint()?;
         Ok(index)
     }
 
-    pub(super) fn universal_postings_overflow(&self) -> Option<(usize, usize)> {
-        self.universal_postings_overflow.then_some((
-            MAX_UNIVERSAL_POSTINGS.saturating_add(1),
-            MAX_UNIVERSAL_POSTINGS,
-        ))
-    }
-
     fn candidate_rule_indices(&self, element: &SourceElement) -> Vec<usize> {
+        if self.budget.matching_exhausted {
+            return Vec::new();
+        }
         // Each branch is assigned exactly one primary rightmost posting when
         // indexed, so these buckets are disjoint and need no per-label
         // de-duplication. Candidate order is irrelevant because the cascade
@@ -241,19 +494,19 @@ impl CascadeIndex {
         {
             candidates.extend(postings);
         }
-        for class in &element.classes {
+        for class in element.classes.iter() {
             if let Some(postings) = self.class_postings.get(class) {
                 candidates.extend(postings);
             }
         }
         if let Some(postings) = self
             .type_postings
-            .get(&(element.namespace, element.local_name.to_ascii_lowercase()))
+            .get(&element.local_name.to_ascii_lowercase())
         {
             candidates.extend(postings);
         }
-        for attribute in &element.attributes {
-            if let Some(postings) = self.attribute_postings.get(&attribute.name) {
+        for attribute_name in element.attributes.keys() {
+            if let Some(postings) = self.attribute_postings.get(attribute_name) {
                 candidates.extend(postings);
             }
         }
@@ -263,9 +516,11 @@ impl CascadeIndex {
     pub(super) fn new<E>(
         svg: &str,
         checkpoint: &mut impl FnMut() -> Result<(), E>,
+        selector_limit: &mut impl FnMut(usize, usize) -> Result<(), E>,
     ) -> Result<Self, E> {
         let mut rules = Vec::new();
         let mut source_order = 0usize;
+        let mut budget = SelectorBudget::default();
         let mut scanner = SvgTagScanner::new(svg);
         let mut style_index = 0usize;
         while let Some(tag) = scanner.next_with_checkpoints(checkpoint)? {
@@ -284,10 +539,21 @@ impl CascadeIndex {
             }
             let Some(close_tag) = close_tag else { break };
             let css = &svg[content_start..close_tag.start()];
-            parse_stylesheet(css, &mut rules, &mut source_order, checkpoint)?;
+            if !budget.charge_stylesheet_bytes(css.len(), selector_limit)?
+                || !parse_stylesheet(
+                    css,
+                    &mut rules,
+                    &mut source_order,
+                    &mut budget,
+                    checkpoint,
+                    selector_limit,
+                )?
+            {
+                break;
+            }
         }
         checkpoint()?;
-        Self::with_postings(rules, checkpoint)
+        Self::with_postings(rules, budget, checkpoint, selector_limit)
     }
 
     pub(super) fn source_element<E>(
@@ -330,31 +596,75 @@ impl CascadeIndex {
                 });
             }
         }
+        let attributes = attributes
+            .into_iter()
+            .map(|attribute| (attribute.name, attribute.value))
+            .collect::<HashMap<_, _>>();
+        let selector_weight =
+            source_selector_weight(&local_name, id.as_deref(), &classes, &attributes);
         checkpoint()?;
         Ok(SourceElement {
             namespace,
             local_name,
             id,
-            classes,
-            attributes,
+            classes: Arc::new(classes),
+            attributes: Arc::new(attributes),
             inline,
             presentation,
+            selector_weight,
         })
     }
 
     pub(super) fn resolve_path<E>(
-        &self,
+        &mut self,
         path: &[SourceElement],
         inherited: Option<&ResolvedStyle>,
         root_font_size: f64,
         checkpoint: &mut impl FnMut() -> Result<(), E>,
+        selector_limit: &mut impl FnMut(usize, usize) -> Result<(), E>,
     ) -> Result<ResolvedStyle, E> {
         let element = path.last().expect("source path is non-empty");
         let parent = inherited.cloned().unwrap_or_else(default_style);
         let mut specified: HashMap<String, Specified> = HashMap::new();
-        for (candidate_index, rule_index) in
-            self.candidate_rule_indices(element).into_iter().enumerate()
-        {
+        let may_collect_candidates = self
+            .budget
+            .check_ancestry_depth(path.len(), selector_limit)?
+            && self
+                .budget
+                .charge_match_work(element.selector_weight, selector_limit)?;
+        let mut candidate_rule_indices = if may_collect_candidates {
+            self.candidate_rule_indices(element)
+        } else {
+            Vec::new()
+        };
+        let path_source_weight = path
+            .iter()
+            .try_fold(0usize, |total, element| {
+                total.checked_add(element.selector_weight)
+            })
+            .unwrap_or(usize::MAX);
+        let match_work = candidate_rule_indices
+            .iter()
+            .fold(0usize, |total, rule_index| {
+                let rule = &self.rules[*rule_index];
+                let branch_work = rule
+                    .branch
+                    .selector_weight
+                    .checked_mul(path.len())
+                    .and_then(|work| {
+                        rule.branch
+                            .component_count
+                            .checked_mul(path_source_weight)
+                            .and_then(|source_work| work.checked_add(source_work))
+                    })
+                    .and_then(|work| work.checked_add(rule.declaration_match_weight))
+                    .unwrap_or(usize::MAX);
+                total.checked_add(branch_work).unwrap_or(usize::MAX)
+            });
+        if !self.budget.charge_match_work(match_work, selector_limit)? {
+            candidate_rule_indices.clear();
+        }
+        for (candidate_index, rule_index) in candidate_rule_indices.into_iter().enumerate() {
             checkpoint_loop(candidate_index, checkpoint)?;
             let rule = &self.rules[rule_index];
             if !matches_branch(&rule.branch, path, checkpoint)? {
@@ -446,12 +756,18 @@ impl CascadeIndex {
             specified.get("color").map(|value| value.value.as_str()),
             parent.color.as_deref(),
         );
-        let background_color = resolve_background(
+        let mut background_color = resolve_background(
             specified
                 .get("background-color")
                 .map(|value| value.value.as_str()),
             parent.background_color.as_deref(),
         );
+        if background_color
+            .as_deref()
+            .is_some_and(|value| value.eq_ignore_ascii_case("currentcolor"))
+        {
+            background_color = Some(color.as_deref().unwrap_or(DEFAULT_COLOR).to_string());
+        }
         let background_color_specified = specified.contains_key("background-color");
         checkpoint()?;
         Ok(ResolvedStyle {
@@ -468,18 +784,27 @@ impl CascadeIndex {
     }
 
     pub(super) fn resolve_foreign_object<E>(
-        &self,
+        &mut self,
         svg_ancestors: &[SourceElement],
         foreign_object_tag: &str,
         html: &str,
         checkpoint: &mut impl FnMut() -> Result<(), E>,
+        selector_limit: &mut impl FnMut(usize, usize) -> Result<(), E>,
     ) -> Result<ResolvedFallbackTypography, E> {
+        let base_depth = svg_ancestors.len().checked_add(1).unwrap_or(usize::MAX);
+        if !self
+            .budget
+            .check_ancestry_depth(base_depth, selector_limit)?
+        {
+            return Ok(default_fallback_typography());
+        }
         let foreign_object = Self::source_element(foreign_object_tag, Namespace::Svg, checkpoint)?;
         let mut base_path = svg_ancestors.to_vec();
         base_path.push(foreign_object);
         let mut html_stack = Vec::new();
-        let mut text_paths = Vec::new();
-        let mut label_background_path = None;
+        let mut first_style = None;
+        let mut all_same_style = true;
+        let mut common_path = None;
         let mut cursor = 0usize;
         let mut iteration = 0usize;
         while let Some(relative) = find_with_checkpoints(&html[cursor..], "<", checkpoint)? {
@@ -487,7 +812,17 @@ impl CascadeIndex {
             iteration = iteration.saturating_add(1);
             let start = cursor + relative;
             if html_text_is_visible(&html[cursor..start]) {
-                text_paths.push(join_path(&base_path, &html_stack));
+                self.observe_text_path(
+                    join_path(&base_path, &html_stack),
+                    &mut first_style,
+                    &mut all_same_style,
+                    &mut common_path,
+                    checkpoint,
+                    selector_limit,
+                )?;
+                if self.budget.matching_exhausted {
+                    return Ok(default_fallback_typography());
+                }
             }
             let Some(end) = find_tag_end_with_checkpoints(html, start, checkpoint)? else {
                 break;
@@ -509,15 +844,19 @@ impl CascadeIndex {
                 continue;
             }
             if start_tag_name(tag).is_some() {
+                let next_depth = base_path
+                    .len()
+                    .checked_add(html_stack.len())
+                    .and_then(|depth| depth.checked_add(1))
+                    .unwrap_or(usize::MAX);
+                if !self
+                    .budget
+                    .check_ancestry_depth(next_depth, selector_limit)?
+                {
+                    return Ok(default_fallback_typography());
+                }
                 let element = Self::source_element(tag, Namespace::Xhtml, checkpoint)?;
                 html_stack.push(element);
-                if html_stack
-                    .last()
-                    .is_some_and(|element| element.classes.iter().any(|class| class == "labelBkg"))
-                    && label_background_path.is_none()
-                {
-                    label_background_path = Some(join_path(&base_path, &html_stack));
-                }
                 if is_void_html_element(
                     html_stack
                         .last()
@@ -532,70 +871,104 @@ impl CascadeIndex {
             cursor = end;
         }
         if html_text_is_visible(&html[cursor..]) {
-            text_paths.push(join_path(&base_path, &html_stack));
+            self.observe_text_path(
+                join_path(&base_path, &html_stack),
+                &mut first_style,
+                &mut all_same_style,
+                &mut common_path,
+                checkpoint,
+                selector_limit,
+            )?;
+            if self.budget.matching_exhausted {
+                return Ok(default_fallback_typography());
+            }
         }
-        if text_paths.is_empty() {
-            text_paths.push(base_path.clone());
+        if first_style.is_none() {
+            self.observe_text_path(
+                base_path.clone(),
+                &mut first_style,
+                &mut all_same_style,
+                &mut common_path,
+                checkpoint,
+                selector_limit,
+            )?;
+            if self.budget.matching_exhausted {
+                return Ok(default_fallback_typography());
+            }
         }
 
-        let styles = text_paths
-            .iter()
-            .map(|path| self.resolve_full_path(path, checkpoint))
-            .collect::<Result<Vec<_>, _>>()?;
-        let style = if styles
-            .windows(2)
-            .all(|pair| same_effective_typography(&pair[0], &pair[1]))
-        {
-            styles.into_iter().next().expect("at least one text style")
+        let common_path = common_path.unwrap_or_else(|| base_path.clone());
+        let style = if all_same_style {
+            first_style.expect("at least one text style")
         } else {
-            let common_path = deepest_common_path(&text_paths);
-            self.resolve_full_path(&common_path, checkpoint)?
+            self.resolve_full_path(&common_path, checkpoint, selector_limit)?
         };
-        let label_background = if let Some(label_path) = label_background_path.as_ref() {
-            let mut background_color = None;
-            let mut background_color_specified = false;
-            let label_style = self.resolve_full_path(label_path, checkpoint)?;
-            if label_style.background_color_specified {
+        let mut label_background = None;
+        let mut background_color_specified = false;
+        let mut label_background_marker = false;
+        for depth in base_path.len()..common_path.len() {
+            let element = &common_path[depth];
+            label_background_marker |= element.classes.contains("labelBkg");
+            let background_style =
+                self.resolve_full_path(&common_path[..=depth], checkpoint, selector_limit)?;
+            if background_style.background_color_specified {
                 background_color_specified = true;
-                background_color = label_style.background_color;
-            }
-            for path in &text_paths {
-                if !path.starts_with(label_path.as_slice()) {
-                    continue;
-                }
-                for depth in label_path.len()..path.len() {
-                    let style = self.resolve_full_path(&path[..=depth], checkpoint)?;
-                    if style.background_color_specified {
-                        background_color_specified = true;
-                        background_color = style.background_color;
+                match background_style.background_color {
+                    Some(color) if !color.eq_ignore_ascii_case("transparent") => {
+                        label_background = Some(color);
                     }
+                    // `transparent`, `initial`, and `unset` are specified values that
+                    // clear an earlier owner background; they must not leave a stale
+                    // parent rectangle visible in the generated fallback.
+                    Some(_) | None => label_background = None,
                 }
             }
-            if background_color_specified {
-                background_color
-            } else {
-                Some("rgba(232, 232, 232, 0.5)".to_string())
+        }
+        if label_background.is_none() && label_background_marker && !background_color_specified {
+            label_background = Some("rgba(232, 232, 232, 0.5)".to_string());
+        }
+        if self.budget.matching_exhausted {
+            return Ok(default_fallback_typography());
+        }
+        checkpoint()?;
+        Ok(fallback_typography(style, label_background))
+    }
+
+    fn observe_text_path<E>(
+        &mut self,
+        path: Vec<SourceElement>,
+        first_style: &mut Option<ResolvedStyle>,
+        all_same_style: &mut bool,
+        common_path: &mut Option<Vec<SourceElement>>,
+        checkpoint: &mut impl FnMut() -> Result<(), E>,
+        selector_limit: &mut impl FnMut(usize, usize) -> Result<(), E>,
+    ) -> Result<(), E> {
+        let style = self.resolve_full_path(&path, checkpoint, selector_limit)?;
+        if let Some(first_style) = first_style.as_ref() {
+            if !same_effective_typography(first_style, &style) {
+                *all_same_style = false;
             }
         } else {
-            None
-        };
-        let fill = effective_html_text_paint(&style).to_string();
-        checkpoint()?;
-        Ok(ResolvedFallbackTypography {
-            font_size: style.font_size,
-            font_family: style.font_family,
-            font_weight: style.font_weight,
-            font_style: style.font_style,
-            line_height: style.line_height.pixels(style.font_size),
-            fill,
-            label_background,
-        })
+            *first_style = Some(style);
+        }
+        if let Some(common) = common_path.as_mut() {
+            let common_len = common
+                .iter()
+                .zip(path.iter())
+                .take_while(|(left, right)| *left == *right)
+                .count();
+            common.truncate(common_len);
+        } else {
+            *common_path = Some(path);
+        }
+        Ok(())
     }
 
     fn resolve_full_path<E>(
-        &self,
+        &mut self,
         path: &[SourceElement],
         checkpoint: &mut impl FnMut() -> Result<(), E>,
+        selector_limit: &mut impl FnMut(usize, usize) -> Result<(), E>,
     ) -> Result<ResolvedStyle, E> {
         let mut computed = None;
         let mut root_font_size = DEFAULT_FONT_SIZE;
@@ -606,6 +979,7 @@ impl CascadeIndex {
                 computed.as_ref(),
                 root_font_size,
                 checkpoint,
+                selector_limit,
             )?;
             if index == 0 {
                 root_font_size = style.font_size;
@@ -751,6 +1125,28 @@ fn attribute_value<'a>(attributes: &'a [SourceAttribute], name: &str) -> Option<
         .and_then(|attribute| attribute.value.as_deref())
 }
 
+fn source_selector_weight(
+    local_name: &str,
+    id: Option<&str>,
+    classes: &HashSet<String>,
+    attributes: &HashMap<String, Option<String>>,
+) -> usize {
+    let mut weight = 1usize.saturating_add(local_name.len());
+    if let Some(id) = id {
+        weight = weight.saturating_add(1).saturating_add(id.len());
+    }
+    for class in classes {
+        weight = weight.saturating_add(1).saturating_add(class.len());
+    }
+    for (name, value) in attributes {
+        weight = weight.saturating_add(1).saturating_add(name.len());
+        if let Some(value) = value {
+            weight = weight.saturating_add(1).saturating_add(value.len());
+        }
+    }
+    weight
+}
+
 fn join_path(base_path: &[SourceElement], html_stack: &[SourceElement]) -> Vec<SourceElement> {
     let mut path = Vec::with_capacity(base_path.len().saturating_add(html_stack.len()));
     path.extend_from_slice(base_path);
@@ -780,115 +1176,6 @@ fn is_void_html_element(name: &str) -> bool {
             | "track"
             | "wbr"
     )
-}
-
-fn is_xhtml_element_name(name: &str) -> bool {
-    matches!(
-        name,
-        "a" | "abbr"
-            | "address"
-            | "article"
-            | "aside"
-            | "audio"
-            | "b"
-            | "bdi"
-            | "bdo"
-            | "blockquote"
-            | "br"
-            | "button"
-            | "canvas"
-            | "caption"
-            | "cite"
-            | "code"
-            | "col"
-            | "data"
-            | "datalist"
-            | "dd"
-            | "del"
-            | "details"
-            | "dfn"
-            | "div"
-            | "dl"
-            | "dt"
-            | "em"
-            | "fieldset"
-            | "figcaption"
-            | "figure"
-            | "footer"
-            | "form"
-            | "h1"
-            | "h2"
-            | "h3"
-            | "h4"
-            | "h5"
-            | "h6"
-            | "header"
-            | "hgroup"
-            | "hr"
-            | "i"
-            | "iframe"
-            | "img"
-            | "input"
-            | "ins"
-            | "kbd"
-            | "label"
-            | "legend"
-            | "li"
-            | "main"
-            | "mark"
-            | "menu"
-            | "meter"
-            | "nav"
-            | "object"
-            | "ol"
-            | "optgroup"
-            | "option"
-            | "output"
-            | "p"
-            | "picture"
-            | "pre"
-            | "progress"
-            | "q"
-            | "s"
-            | "samp"
-            | "section"
-            | "select"
-            | "small"
-            | "span"
-            | "strong"
-            | "sub"
-            | "summary"
-            | "sup"
-            | "table"
-            | "tbody"
-            | "td"
-            | "template"
-            | "textarea"
-            | "tfoot"
-            | "th"
-            | "thead"
-            | "time"
-            | "tr"
-            | "u"
-            | "ul"
-            | "var"
-            | "video"
-            | "wbr"
-    )
-}
-
-fn deepest_common_path(paths: &[Vec<SourceElement>]) -> Vec<SourceElement> {
-    let Some(first) = paths.first() else {
-        return Vec::new();
-    };
-    let mut common = first.len();
-    for path in &paths[1..] {
-        common = common.min(path.len());
-        while common > 0 && first[..common] != path[..common] {
-            common -= 1;
-        }
-    }
-    first[..common].to_vec()
 }
 
 fn same_effective_typography(left: &ResolvedStyle, right: &ResolvedStyle) -> bool {
@@ -922,17 +1209,22 @@ fn select_specified(
     priority: Priority,
     presentation: bool,
 ) {
-    if !is_supported_property(&declaration.property)
-        || !is_admitted_value(&declaration.property, &declaration.value, presentation)
+    let property = if declaration.property == "background" {
+        "background-color"
+    } else {
+        declaration.property.as_str()
+    };
+    if !is_supported_property(property)
+        || !is_admitted_value(property, &declaration.value, presentation)
     {
         return;
     }
     if specified
-        .get(&declaration.property)
+        .get(property)
         .is_none_or(|current| priority > current.priority)
     {
         specified.insert(
-            declaration.property.clone(),
+            property.to_string(),
             Specified {
                 priority,
                 value: declaration.value.clone(),
@@ -953,6 +1245,27 @@ fn default_style() -> ResolvedStyle {
         color: None,
         background_color: None,
         background_color_specified: false,
+    }
+}
+
+fn default_fallback_typography() -> ResolvedFallbackTypography {
+    fallback_typography(default_style(), None)
+}
+
+fn fallback_typography(
+    style: ResolvedStyle,
+    label_background: Option<String>,
+) -> ResolvedFallbackTypography {
+    let fill = effective_html_text_paint(&style).to_string();
+    let line_height = style.line_height.pixels(style.font_size);
+    ResolvedFallbackTypography {
+        font_size: style.font_size,
+        font_family: style.font_family,
+        font_weight: style.font_weight,
+        font_style: style.font_style,
+        line_height,
+        fill,
+        label_background,
     }
 }
 
@@ -1068,14 +1381,43 @@ fn is_admitted_paint(value: &str) -> bool {
         return false;
     };
     let name = &value[..open];
-    if !matches!(name, "rgb" | "rgba" | "hsl" | "hsla") || !value.ends_with(')') {
+    matches!(name, "rgb" | "rgba" | "hsl" | "hsla")
+        && has_consistent_color_function_separators(value, name, open)
+        && ThemeColor::parse(value).is_ok()
+}
+
+fn has_consistent_color_function_separators(value: &str, name: &str, open: usize) -> bool {
+    let Some(without_close) = value.strip_suffix(')') else {
+        return false;
+    };
+    let Some(body) = without_close.get(open + 1..) else {
+        return false;
+    };
+    if !body.contains(',') {
+        return true;
+    }
+    if body.contains('/') {
         return false;
     }
-    let body = &value[open + 1..value.len() - 1];
-    !body.is_empty()
-        && !body.chars().any(|character| {
-            character.is_control() || matches!(character, '{' | '}' | ';' | '"' | '\'')
-        })
+
+    let rgb_like = matches!(name, "rgb" | "rgba");
+    let mut component_count = 0usize;
+    let mut rgb_channels_are_percent = None;
+    for component in body.split(',') {
+        let component = component.trim();
+        if component.is_empty() || component.chars().any(char::is_whitespace) {
+            return false;
+        }
+        if rgb_like && component_count < 3 {
+            let is_percent = component.ends_with('%');
+            if rgb_channels_are_percent.is_some_and(|expected| expected != is_percent) {
+                return false;
+            }
+            rgb_channels_are_percent.get_or_insert(is_percent);
+        }
+        component_count = component_count.saturating_add(1);
+    }
+    matches!(component_count, 3 | 4)
 }
 
 struct ParsedQualifiedRule {
@@ -1086,16 +1428,11 @@ struct ParsedQualifiedRule {
 struct FallbackStylesheetParser;
 
 fn consume_css_parser_tokens<'i, 't>(input: &mut Parser<'i, 't>) -> Result<(), ParseError<'i, ()>> {
-    while !input.is_exhausted() {
-        let token = input.next_including_whitespace_and_comments()?.clone();
-        if matches!(
-            token,
-            Token::Function(_)
-                | Token::ParenthesisBlock
-                | Token::SquareBracketBlock
-                | Token::CurlyBracketBlock
-        ) {
-            input.parse_nested_block(consume_css_parser_tokens)?;
+    loop {
+        match input.next_including_whitespace_and_comments() {
+            Ok(_) => {}
+            Err(error) if matches!(&error.kind, BasicParseErrorKind::EndOfInput) => break,
+            Err(error) => return Err(error.into()),
         }
     }
     Ok(())
@@ -1167,14 +1504,13 @@ fn parse_stylesheet<E>(
     css: &str,
     rules: &mut Vec<Rule>,
     source_order: &mut usize,
+    budget: &mut SelectorBudget,
     checkpoint: &mut impl FnMut() -> Result<(), E>,
-) -> Result<(), E> {
+    selector_limit: &mut impl FnMut(usize, usize) -> Result<(), E>,
+) -> Result<bool, E> {
     let css = css.trim();
-    let css = css
-        .strip_prefix("<![CDATA[")
-        .unwrap_or(css)
-        .strip_suffix("]]>")
-        .unwrap_or(css);
+    let css = css.strip_prefix("<![CDATA[").unwrap_or(css);
+    let css = css.strip_suffix("]]>").unwrap_or(css);
     let css = strip_css_comments(css, checkpoint)?;
     let mut input = ParserInput::new(&css);
     let mut parser = Parser::new(&mut input);
@@ -1186,32 +1522,85 @@ fn parse_stylesheet<E>(
         let Ok(Some(parsed)) = parsed else {
             continue;
         };
+        if !budget.charge_qualified_rule(selector_limit)? {
+            return Ok(false);
+        }
         let selector = trim_with_checkpoints(&parsed.selector, checkpoint)?;
-        let declarations = parse_declarations(&parsed.body, checkpoint)?;
+        if !budget.charge_selector_bytes(selector.len(), selector_limit)? {
+            return Ok(false);
+        }
+        let parsed_declarations = parse_declarations_with_limit(
+            &parsed.body,
+            MAX_SELECTOR_DECLARATIONS_PER_RULE,
+            checkpoint,
+        )?;
+        if let Some((actual, maximum)) = parsed_declarations.limit_exceeded {
+            return budget.reject_admission(actual, maximum, selector_limit);
+        }
+        let declarations = parsed_declarations.declarations;
         if declarations.is_empty() {
             continue;
         }
-        let branches = split_selector_branches(selector, checkpoint)?;
+        if !budget.charge_declarations(declarations.len(), selector_limit)? {
+            return Ok(false);
+        }
+        let Some(branches) = split_selector_branches(selector, budget, checkpoint, selector_limit)?
+        else {
+            return Ok(false);
+        };
         let mut parsed_branches = Vec::new();
         let mut invalid = false;
         for branch in branches {
             match parse_branch(branch, checkpoint)? {
-                BranchParse::Admitted(branch) => parsed_branches.push(branch),
+                BranchParse::Admitted(branch) => {
+                    if branch.component_count > MAX_SELECTOR_COMPONENTS_PER_BRANCH {
+                        return budget.reject_admission(
+                            branch.component_count,
+                            MAX_SELECTOR_COMPONENTS_PER_BRANCH,
+                            selector_limit,
+                        );
+                    }
+                    if !budget.charge_components(branch.component_count, selector_limit)? {
+                        return Ok(false);
+                    }
+                    parsed_branches.push(branch);
+                }
                 // A branch can be ordinary CSS syntax but outside the
                 // deliberately small fallback matcher subset. Keeping
                 // admitted siblings is safe because we never widen the
                 // unadmitted branch into a class-only match.
                 BranchParse::ValidButUnadmitted => {}
                 BranchParse::Invalid => invalid = true,
+                BranchParse::LimitExceeded(actual) => {
+                    return budget.reject_admission(
+                        actual,
+                        MAX_SELECTOR_COMPONENTS_PER_BRANCH,
+                        selector_limit,
+                    );
+                }
             }
         }
         if !invalid {
+            if !budget.charge_rules(parsed_branches.len(), selector_limit)? {
+                return Ok(false);
+            }
             let rule_order = *source_order;
+            let declaration_match_weight =
+                declarations.iter().fold(0usize, |total, declaration| {
+                    total
+                        .checked_add(
+                            1usize
+                                .saturating_add(declaration.property.len())
+                                .saturating_add(declaration.value.len()),
+                        )
+                        .unwrap_or(usize::MAX)
+                });
             let declarations: Arc<[Declaration]> = declarations.into();
             for branch in parsed_branches {
                 rules.push(Rule {
                     branch,
                     declarations: declarations.clone(),
+                    declaration_match_weight,
                     source_order: rule_order,
                 });
             }
@@ -1219,7 +1608,7 @@ fn parse_stylesheet<E>(
         }
     }
     checkpoint()?;
-    Ok(())
+    Ok(true)
 }
 
 /// Removes CSS comments without treating comment-looking text inside a quoted
@@ -1276,8 +1665,10 @@ fn strip_css_comments<E>(
 
 fn split_selector_branches<'a, E>(
     selector: &'a str,
+    budget: &mut SelectorBudget,
     checkpoint: &mut impl FnMut() -> Result<(), E>,
-) -> Result<Vec<&'a str>, E> {
+    selector_limit: &mut impl FnMut(usize, usize) -> Result<(), E>,
+) -> Result<Option<Vec<&'a str>>, E> {
     let mut result = Vec::new();
     let mut start = 0usize;
     let mut quote = None;
@@ -1293,21 +1684,279 @@ fn split_selector_branches<'a, E>(
             '(' if quote.is_none() => paren_depth = paren_depth.saturating_add(1),
             ')' if quote.is_none() => paren_depth = paren_depth.saturating_sub(1),
             ',' if quote.is_none() && bracket_depth == 0 && paren_depth == 0 => {
+                if !budget.charge_branch(selector_limit)? {
+                    return Ok(None);
+                }
                 result.push(selector[start..index].trim());
                 start = index + ch.len_utf8();
             }
             _ => {}
         }
     }
+    if !budget.charge_branch(selector_limit)? {
+        return Ok(None);
+    }
     result.push(selector[start..].trim());
     checkpoint()?;
-    Ok(result)
+    Ok(Some(result))
 }
 
 enum BranchParse {
     Admitted(Branch),
     ValidButUnadmitted,
     Invalid,
+    LimitExceeded(usize),
+}
+
+enum CompoundParse {
+    Admitted(Compound),
+    ValidButUnadmitted,
+    Invalid,
+    LimitExceeded(usize),
+}
+
+enum AttributeParse {
+    Admitted(AttributeSelector),
+    ValidButUnadmitted,
+    Invalid,
+}
+
+enum SelectorTokenError {
+    Invalid,
+    LimitExceeded(usize),
+}
+
+fn validate_unadmitted_selector(selector: &str) -> bool {
+    let mut bracket_depth = 0usize;
+    let mut paren_depth = 0usize;
+    let mut bracket_start = None;
+    let mut quote = None;
+    let mut escaped = false;
+    let mut compound_active = false;
+    let mut descendant_pending = false;
+    let mut operator_pending = false;
+    let mut saw_compound = false;
+    let mut skipped_column_pipe = None;
+
+    for (index, ch) in selector.char_indices() {
+        if skipped_column_pipe == Some(index) {
+            skipped_column_pipe = None;
+            continue;
+        }
+        if escaped {
+            escaped = false;
+            if bracket_depth == 0 && paren_depth == 0 {
+                if descendant_pending {
+                    descendant_pending = false;
+                }
+                operator_pending = false;
+                compound_active = true;
+                saw_compound = true;
+            }
+            continue;
+        }
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+        if let Some(current_quote) = quote {
+            if ch == current_quote {
+                quote = None;
+            }
+            continue;
+        }
+        if bracket_depth > 0 {
+            match ch {
+                '\'' | '"' => quote = Some(ch),
+                '[' => bracket_depth = bracket_depth.saturating_add(1),
+                ']' => {
+                    if bracket_depth == 1 {
+                        let start = bracket_start.take().unwrap_or(index);
+                        if !validate_attribute_fragment(&selector[start + 1..index]) {
+                            return false;
+                        }
+                    }
+                    bracket_depth -= 1;
+                }
+                _ => {}
+            }
+            continue;
+        }
+        if paren_depth > 0 {
+            match ch {
+                '\'' | '"' => quote = Some(ch),
+                '(' => paren_depth = paren_depth.saturating_add(1),
+                ')' => paren_depth -= 1,
+                _ => {}
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' | '"' | ')' => return false,
+            '[' => {
+                if descendant_pending {
+                    descendant_pending = false;
+                }
+                operator_pending = false;
+                compound_active = true;
+                saw_compound = true;
+                bracket_start = Some(index);
+                bracket_depth = 1;
+            }
+            '(' => {
+                if !compound_active || operator_pending {
+                    return false;
+                }
+                paren_depth = 1;
+            }
+            character if character.is_whitespace() => {
+                if compound_active {
+                    descendant_pending = true;
+                }
+            }
+            '+' | '~' | '>' => {
+                if !compound_active || operator_pending {
+                    return false;
+                }
+                operator_pending = true;
+                compound_active = false;
+                descendant_pending = false;
+            }
+            '|' => {
+                let next_index = index + ch.len_utf8();
+                let next = selector[next_index..].chars().next();
+                if next == Some('|') {
+                    if !compound_active || operator_pending {
+                        return false;
+                    }
+                    operator_pending = true;
+                    compound_active = false;
+                    descendant_pending = false;
+                    skipped_column_pipe = Some(next_index);
+                } else {
+                    let previous = selector[..index].chars().next_back();
+                    if operator_pending
+                        || matches!(next, Some('+' | '~' | '>' | '|' | ','))
+                        || previous.is_some_and(char::is_whitespace)
+                        || next.is_none_or(char::is_whitespace)
+                    {
+                        return false;
+                    }
+                    // A single pipe is a namespace separator. CSS does not allow
+                    // whitespace around it; only the `||` column combinator may be
+                    // separated from its neighboring compounds.
+                    descendant_pending = false;
+                }
+            }
+            '#' | '.' => {
+                let next = selector[index + ch.len_utf8()..].chars().next();
+                if next.is_none_or(|character| !is_selector_ident_start(character)) {
+                    return false;
+                }
+                if descendant_pending {
+                    descendant_pending = false;
+                }
+                operator_pending = false;
+                compound_active = true;
+                saw_compound = true;
+            }
+            '*' => {
+                if descendant_pending {
+                    descendant_pending = false;
+                }
+                operator_pending = false;
+                compound_active = true;
+                saw_compound = true;
+            }
+            ':' => {
+                let mut next_index = index + ch.len_utf8();
+                let Some((_, next)) = selector[next_index..].char_indices().next() else {
+                    return false;
+                };
+                if next == ':' {
+                    next_index += next.len_utf8();
+                }
+                let Some((_, name_start)) = selector[next_index..].char_indices().next() else {
+                    return false;
+                };
+                if !is_selector_ident_start(name_start) {
+                    return false;
+                }
+                if descendant_pending {
+                    descendant_pending = false;
+                }
+                operator_pending = false;
+                compound_active = true;
+                saw_compound = true;
+            }
+            _ if !is_selector_ident_start(ch) => return false,
+            _ => {
+                if descendant_pending {
+                    descendant_pending = false;
+                }
+                operator_pending = false;
+                compound_active = true;
+                saw_compound = true;
+            }
+        }
+    }
+
+    !escaped
+        && quote.is_none()
+        && bracket_depth == 0
+        && paren_depth == 0
+        && saw_compound
+        && !operator_pending
+}
+
+fn is_selector_ident_start(character: char) -> bool {
+    character == '_'
+        || character == '-'
+        || character == '\\'
+        || character.is_ascii_alphanumeric()
+        || !character.is_ascii()
+}
+
+fn validate_attribute_fragment(fragment: &str) -> bool {
+    let fragment = fragment.trim();
+    let mut name_end = 0usize;
+    for (index, character) in fragment.char_indices() {
+        if is_selector_ident_start(character) {
+            name_end = index + character.len_utf8();
+        } else {
+            break;
+        }
+    }
+    if name_end == 0 {
+        return false;
+    }
+    let rest = fragment[name_end..].trim_start();
+    if rest.is_empty() {
+        return true;
+    }
+    let operator = ["~=", "|=", "^=", "$=", "*=", "!=", "="]
+        .into_iter()
+        .find(|operator| rest.starts_with(operator));
+    let Some(operator) = operator else {
+        return false;
+    };
+    let value = rest[operator.len()..].trim();
+    if value.is_empty() {
+        return false;
+    }
+    if value.starts_with('\'') || value.starts_with('"') {
+        let quote = value.chars().next().unwrap_or_default();
+        value.len() >= 2 && value.ends_with(quote)
+    } else {
+        value.chars().all(|character| {
+            !character.is_whitespace()
+                && !matches!(
+                    character,
+                    '[' | ']' | '(' | ')' | ',' | '>' | '+' | '~' | '|'
+                )
+        })
+    }
 }
 
 fn parse_branch<E>(
@@ -1322,6 +1971,7 @@ fn parse_branch<E>(
     let mut token = String::new();
     let mut pending = None;
     let mut unsupported = false;
+    let mut component_floor = 0usize;
     let mut quote = None;
     let mut bracket_depth = 0usize;
     let mut paren_depth = 0usize;
@@ -1363,20 +2013,36 @@ fn parse_branch<E>(
             }
             ch if bracket_depth > 0 || paren_depth > 0 => token.push(ch),
             ch if ch.is_whitespace() => {
-                if flush_selector_token(&mut token, &mut compounds, &mut combinators, &mut pending)
-                    .is_err()
-                {
-                    return Ok(BranchParse::Invalid);
+                match flush_selector_token(
+                    &mut token,
+                    &mut compounds,
+                    &mut combinators,
+                    &mut pending,
+                    &mut component_floor,
+                ) {
+                    Ok(()) => {}
+                    Err(SelectorTokenError::Invalid) => return Ok(BranchParse::Invalid),
+                    Err(SelectorTokenError::LimitExceeded(actual)) => {
+                        return Ok(BranchParse::LimitExceeded(actual));
+                    }
                 }
                 if !compounds.is_empty() {
                     pending.get_or_insert(Combinator::Descendant);
                 }
             }
             '>' => {
-                if flush_selector_token(&mut token, &mut compounds, &mut combinators, &mut pending)
-                    .is_err()
-                {
-                    return Ok(BranchParse::Invalid);
+                match flush_selector_token(
+                    &mut token,
+                    &mut compounds,
+                    &mut combinators,
+                    &mut pending,
+                    &mut component_floor,
+                ) {
+                    Ok(()) => {}
+                    Err(SelectorTokenError::Invalid) => return Ok(BranchParse::Invalid),
+                    Err(SelectorTokenError::LimitExceeded(actual)) => {
+                        return Ok(BranchParse::LimitExceeded(actual));
+                    }
                 }
                 if compounds.is_empty() {
                     return Ok(BranchParse::Invalid);
@@ -1398,20 +2064,41 @@ fn parse_branch<E>(
     if quote.is_some() || bracket_depth != 0 || paren_depth != 0 {
         return Ok(BranchParse::Invalid);
     }
-    if flush_selector_token(&mut token, &mut compounds, &mut combinators, &mut pending).is_err() {
-        return Ok(BranchParse::Invalid);
+    match flush_selector_token(
+        &mut token,
+        &mut compounds,
+        &mut combinators,
+        &mut pending,
+        &mut component_floor,
+    ) {
+        Ok(()) => {}
+        Err(SelectorTokenError::Invalid) => return Ok(BranchParse::Invalid),
+        Err(SelectorTokenError::LimitExceeded(actual)) => {
+            return Ok(BranchParse::LimitExceeded(actual));
+        }
     }
-    if compounds.is_empty() || pending.is_some() || combinators.len() + 1 != compounds.len() {
+    if compounds.is_empty() {
         return Ok(BranchParse::Invalid);
     }
     if unsupported {
-        return Ok(BranchParse::ValidButUnadmitted);
+        return Ok(if validate_unadmitted_selector(selector) {
+            BranchParse::ValidButUnadmitted
+        } else {
+            BranchParse::Invalid
+        });
+    }
+    if pending.is_some() || combinators.len() + 1 != compounds.len() {
+        return Ok(BranchParse::Invalid);
+    }
+    let mut component_count = combinators.len();
+    if component_count > MAX_SELECTOR_COMPONENTS_PER_BRANCH {
+        return Ok(BranchParse::LimitExceeded(component_count));
     }
     let mut specificity = Specificity::default();
     let mut parsed = Vec::new();
     for compound in compounds {
-        match parse_compound(&compound, checkpoint)? {
-            Some(compound) => {
+        match parse_compound(&compound, &mut component_count, checkpoint)? {
+            CompoundParse::Admitted(compound) => {
                 specificity.0 = specificity
                     .0
                     .saturating_add(u32::from(compound.id.is_some()));
@@ -1429,13 +2116,21 @@ fn parse_branch<E>(
                     .saturating_add(u32::from(compound.local_name.is_some()));
                 parsed.push(compound);
             }
-            None => return Ok(BranchParse::Invalid),
+            CompoundParse::ValidButUnadmitted => {
+                return Ok(BranchParse::ValidButUnadmitted);
+            }
+            CompoundParse::Invalid => return Ok(BranchParse::Invalid),
+            CompoundParse::LimitExceeded(actual) => {
+                return Ok(BranchParse::LimitExceeded(actual));
+            }
         }
     }
     Ok(BranchParse::Admitted(Branch {
         compounds: parsed,
         combinators,
         specificity,
+        component_count,
+        selector_weight: selector.len().max(1),
     }))
 }
 
@@ -1444,19 +2139,30 @@ fn flush_selector_token(
     compounds: &mut Vec<String>,
     combinators: &mut Vec<Combinator>,
     pending: &mut Option<Combinator>,
-) -> Result<(), ()> {
+    component_floor: &mut usize,
+) -> Result<(), SelectorTokenError> {
     let value = token.trim();
     if value.is_empty() {
         return Ok(());
     }
-    if let Some(combinator) = pending.take() {
+    if pending.is_some() {
         if compounds.is_empty() || combinators.len() + 1 != compounds.len() {
-            return Err(());
+            return Err(SelectorTokenError::Invalid);
         }
-        combinators.push(combinator);
     } else if !compounds.is_empty() {
-        return Err(());
+        return Err(SelectorTokenError::Invalid);
     }
+    let additional = 1usize.saturating_add(usize::from(pending.is_some()));
+    let actual = component_floor
+        .checked_add(additional)
+        .unwrap_or(usize::MAX);
+    if actual > MAX_SELECTOR_COMPONENTS_PER_BRANCH {
+        return Err(SelectorTokenError::LimitExceeded(actual));
+    }
+    if let Some(combinator) = pending.take() {
+        combinators.push(combinator);
+    }
+    *component_floor = actual;
     compounds.push(value.to_string());
     token.clear();
     Ok(())
@@ -1464,19 +2170,26 @@ fn flush_selector_token(
 
 fn parse_compound<E>(
     token: &str,
+    component_count: &mut usize,
     checkpoint: &mut impl FnMut() -> Result<(), E>,
-) -> Result<Option<Compound>, E> {
+) -> Result<CompoundParse, E> {
     let mut rest = token.trim();
     let mut local_name = None;
     let mut id = None;
     let mut classes = Vec::new();
     let mut attributes = Vec::new();
     if rest.starts_with('*') {
+        if let Err(actual) = charge_branch_component(component_count) {
+            return Ok(CompoundParse::LimitExceeded(actual));
+        }
         rest = &rest[1..];
     } else if !rest.starts_with(['#', '.', '[']) {
         let end = identifier_prefix_len(rest);
         if end == 0 {
-            return Ok(None);
+            return Ok(CompoundParse::Invalid);
+        }
+        if let Err(actual) = charge_branch_component(component_count) {
+            return Ok(CompoundParse::LimitExceeded(actual));
         }
         local_name = Some(rest[..end].to_ascii_lowercase());
         rest = &rest[end..];
@@ -1488,45 +2201,66 @@ fn parse_compound<E>(
                 let value = &rest[marker.len_utf8()..];
                 let end = identifier_prefix_len(value);
                 if end == 0 {
-                    return Ok(None);
+                    return Ok(CompoundParse::Invalid);
                 }
                 let value = &value[..end];
                 if marker == '#' {
                     if id.is_some() {
-                        return Ok(None);
+                        return Ok(CompoundParse::Invalid);
+                    }
+                    if let Err(actual) = charge_branch_component(component_count) {
+                        return Ok(CompoundParse::LimitExceeded(actual));
                     }
                     id = Some(value.to_string());
                 } else {
+                    if let Err(actual) = charge_branch_component(component_count) {
+                        return Ok(CompoundParse::LimitExceeded(actual));
+                    }
                     classes.push(value.to_string());
                 }
                 rest = &rest[marker.len_utf8() + end..];
             }
             '[' => {
                 let Some(end) = find_attribute_selector_end(rest) else {
-                    return Ok(None);
+                    return Ok(CompoundParse::Invalid);
                 };
-                let Some(attribute) = parse_attribute_selector(&rest[1..end], checkpoint)? else {
-                    return Ok(None);
-                };
-                attributes.push(attribute);
+                match parse_attribute_selector(&rest[1..end], checkpoint)? {
+                    AttributeParse::Admitted(attribute) => {
+                        if let Err(actual) = charge_branch_component(component_count) {
+                            return Ok(CompoundParse::LimitExceeded(actual));
+                        }
+                        attributes.push(attribute);
+                    }
+                    AttributeParse::ValidButUnadmitted => {
+                        return Ok(CompoundParse::ValidButUnadmitted);
+                    }
+                    AttributeParse::Invalid => return Ok(CompoundParse::Invalid),
+                }
                 rest = &rest[end + 1..];
             }
-            _ => return Ok(None),
+            _ => return Ok(CompoundParse::Invalid),
         }
     }
     checkpoint()?;
-    let namespace = match local_name.as_deref() {
-        Some(name) if is_xhtml_element_name(name) => Some(Namespace::Xhtml),
-        Some(_) => Some(Namespace::Svg),
-        None => None,
-    };
-    Ok(Some(Compound {
-        namespace,
+    Ok(CompoundParse::Admitted(Compound {
+        // No `@namespace` declarations are admitted by this fallback subset,
+        // so an unprefixed type selector remains namespace-neutral.
+        namespace: None,
         local_name,
         id,
         classes,
         attributes,
     }))
+}
+
+fn charge_branch_component(component_count: &mut usize) -> Result<(), usize> {
+    let actual = component_count.checked_add(1).unwrap_or(usize::MAX);
+    *component_count = actual;
+    if actual > MAX_SELECTOR_COMPONENTS_PER_BRANCH {
+        Err(actual)
+    } else {
+        Ok(())
+    }
 }
 
 fn identifier_prefix_len(value: &str) -> usize {
@@ -1562,45 +2296,55 @@ fn find_attribute_selector_end(value: &str) -> Option<usize> {
 fn parse_attribute_selector<E>(
     source: &str,
     checkpoint: &mut impl FnMut() -> Result<(), E>,
-) -> Result<Option<AttributeSelector>, E> {
-    let source = source.trim();
-    let name_end = identifier_prefix_len(source);
-    if name_end == 0 {
-        return Ok(None);
-    }
-    let name = source[..name_end].to_ascii_lowercase();
-    let rest = source[name_end..].trim();
-    let matcher = if rest.is_empty() {
-        AttributeMatcher::Exists
-    } else if let Some(value) = rest.strip_prefix("~=") {
-        let Some(value) = parse_attribute_selector_value(value) else {
-            return Ok(None);
-        };
-        AttributeMatcher::ContainsToken(value)
-    } else if let Some(value) = rest.strip_prefix('=') {
-        let Some(value) = parse_attribute_selector_value(value) else {
-            return Ok(None);
-        };
-        AttributeMatcher::Exact(value)
-    } else {
-        return Ok(None);
-    };
-    checkpoint()?;
-    Ok(Some(AttributeSelector { name, matcher }))
-}
-
-fn parse_attribute_selector_value(value: &str) -> Option<String> {
-    let value = value.trim();
-    let first = value.chars().next()?;
-    if matches!(first, '\'' | '"') {
-        let tail = &value[first.len_utf8()..];
-        let end = tail.find(first)?;
-        if !tail[end + first.len_utf8()..].trim().is_empty() {
-            return None;
+) -> Result<AttributeParse, E> {
+    let mut input = ParserInput::new(source);
+    let mut parser = Parser::new(&mut input);
+    let parsed = parser.parse_entirely(|input| {
+        let name = input.expect_ident_cloned()?.to_ascii_lowercase();
+        if input.is_exhausted() {
+            return Ok(AttributeParse::Admitted(AttributeSelector {
+                name,
+                matcher: AttributeMatcher::Exists,
+            }));
         }
-        return Some(tail[..end].to_string());
-    }
-    is_identifier(value).then(|| value.to_string())
+
+        let operator = input.next()?.clone();
+        let value = input.expect_ident_or_string()?.to_string();
+        let modifier = if input.is_exhausted() {
+            None
+        } else {
+            let modifier = input.expect_ident_cloned()?;
+            if !matches!(modifier.as_ref(), "i" | "I" | "s" | "S") {
+                return Err(input.new_custom_error::<(), ()>(()));
+            }
+            Some(modifier)
+        };
+
+        let parsed = match operator {
+            Token::Delim('=') if modifier.is_none() => {
+                AttributeParse::Admitted(AttributeSelector {
+                    name,
+                    matcher: AttributeMatcher::Exact(value),
+                })
+            }
+            Token::IncludeMatch if modifier.is_none() => {
+                AttributeParse::Admitted(AttributeSelector {
+                    name,
+                    matcher: AttributeMatcher::ContainsToken(value),
+                })
+            }
+            Token::Delim('=')
+            | Token::IncludeMatch
+            | Token::DashMatch
+            | Token::PrefixMatch
+            | Token::SuffixMatch
+            | Token::SubstringMatch => AttributeParse::ValidButUnadmitted,
+            _ => return Err(input.new_custom_error::<(), ()>(())),
+        };
+        Ok(parsed)
+    });
+    checkpoint()?;
+    Ok(parsed.unwrap_or(AttributeParse::Invalid))
 }
 
 fn is_css_identifier_character(character: char) -> bool {
@@ -1608,10 +2352,6 @@ fn is_css_identifier_character(character: char) -> bool {
         || character == '-'
         || character == '_'
         || !character.is_ascii()
-}
-
-fn is_identifier(value: &str) -> bool {
-    !value.is_empty() && value.chars().all(is_css_identifier_character)
 }
 
 fn matches_branch<E>(
@@ -1672,7 +2412,7 @@ fn matches_compound(compound: &Compound, element: &SourceElement) -> bool {
         && compound
             .classes
             .iter()
-            .all(|class| element.classes.iter().any(|candidate| candidate == class))
+            .all(|class| element.classes.contains(class))
         && compound
             .attributes
             .iter()
@@ -1680,52 +2420,69 @@ fn matches_compound(compound: &Compound, element: &SourceElement) -> bool {
 }
 
 fn attribute_selector_matches(selector: &AttributeSelector, element: &SourceElement) -> bool {
-    let Some(attribute) = element
-        .attributes
-        .iter()
-        .rev()
-        .find(|attribute| attribute.name == selector.name)
-    else {
+    let Some(value) = element.attributes.get(&selector.name) else {
         return false;
     };
     match &selector.matcher {
         AttributeMatcher::Exists => true,
-        AttributeMatcher::Exact(expected) => attribute.value.as_deref() == Some(expected),
-        AttributeMatcher::ContainsToken(expected) => attribute
-            .value
+        AttributeMatcher::Exact(expected) => value.as_deref() == Some(expected),
+        AttributeMatcher::ContainsToken(expected) => value
             .as_deref()
             .is_some_and(|value| value.split_whitespace().any(|token| token == expected)),
     }
+}
+
+struct ParsedDeclarations {
+    declarations: Vec<Declaration>,
+    limit_exceeded: Option<(usize, usize)>,
 }
 
 fn parse_declarations<E>(
     style: &str,
     checkpoint: &mut impl FnMut() -> Result<(), E>,
 ) -> Result<Vec<Declaration>, E> {
+    Ok(parse_declarations_with_limit(style, usize::MAX, checkpoint)?.declarations)
+}
+
+fn parse_declarations_with_limit<E>(
+    style: &str,
+    maximum: usize,
+    checkpoint: &mut impl FnMut() -> Result<(), E>,
+) -> Result<ParsedDeclarations, E> {
     let mut declarations = Vec::new();
-    for (order, raw) in split_style_declarations(style, checkpoint)?
-        .into_iter()
-        .enumerate()
-    {
+    let mut scanner = StyleDeclarationScanner::new(style);
+    let mut order = 0usize;
+    while let Some(raw) = scanner.next_with_checkpoints(checkpoint)? {
         checkpoint_loop(order, checkpoint)?;
         let Some(colon) = find_css_declaration_colon(raw, checkpoint)? else {
+            order = order.saturating_add(1);
             continue;
         };
-        let property = raw[..colon].trim().to_ascii_lowercase();
+        let property = raw[..colon].trim();
         let (value, important) = split_trailing_important(&raw[colon + 1..]);
-        let value = value.to_string();
         if property.is_empty() || value.is_empty() {
+            order = order.saturating_add(1);
             continue;
         }
+        if declarations.len() >= maximum {
+            return Ok(ParsedDeclarations {
+                declarations,
+                limit_exceeded: Some((maximum.saturating_add(1), maximum)),
+            });
+        }
         declarations.push(Declaration {
-            property,
-            value,
+            property: property.to_ascii_lowercase(),
+            value: value.to_string(),
             important,
             order,
         });
+        order = order.saturating_add(1);
     }
     checkpoint()?;
-    Ok(declarations)
+    Ok(ParsedDeclarations {
+        declarations,
+        limit_exceeded: None,
+    })
 }
 
 fn find_css_declaration_colon<E>(
@@ -1915,4 +2672,156 @@ fn finite_positive(value: f64) -> Option<f64> {
 
 fn bounded_positive(value: f64) -> Option<f64> {
     finite_positive(value).filter(|value| *value <= MAX_CSS_NUMERIC_VALUE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::convert::Infallible;
+
+    #[test]
+    fn selector_match_work_budget_accepts_the_boundary_and_rejects_the_next_unit() {
+        let mut budget = SelectorBudget::default();
+        let mut ignore_limit = |_, _| Ok::<(), Infallible>(());
+        assert!(
+            budget
+                .charge_match_work(MAX_SELECTOR_MATCH_WORK, &mut ignore_limit)
+                .unwrap()
+        );
+
+        let mut observed = None;
+        assert!(
+            !budget
+                .charge_match_work(1, &mut |actual, maximum| {
+                    observed = Some((actual, maximum));
+                    Ok::<(), Infallible>(())
+                })
+                .unwrap()
+        );
+        assert_eq!(
+            observed,
+            Some((MAX_SELECTOR_MATCH_WORK + 1, MAX_SELECTOR_MATCH_WORK))
+        );
+    }
+
+    #[test]
+    fn selector_ancestry_budget_accepts_the_boundary_and_rejects_the_next_level() {
+        let mut budget = SelectorBudget::default();
+        let mut ignore_limit = |_, _| Ok::<(), Infallible>(());
+        assert!(
+            budget
+                .check_ancestry_depth(MAX_SELECTOR_ANCESTRY_DEPTH, &mut ignore_limit)
+                .unwrap()
+        );
+
+        let mut observed = None;
+        assert!(
+            !budget
+                .check_ancestry_depth(MAX_SELECTOR_ANCESTRY_DEPTH + 1, &mut |actual, maximum| {
+                    observed = Some((actual, maximum));
+                    Ok::<(), Infallible>(())
+                },)
+                .unwrap()
+        );
+        assert_eq!(
+            observed,
+            Some((MAX_SELECTOR_ANCESTRY_DEPTH + 1, MAX_SELECTOR_ANCESTRY_DEPTH,))
+        );
+    }
+
+    #[test]
+    fn selector_budget_reports_checked_add_overflow_without_wrapping() {
+        let mut used = usize::MAX - 1;
+        let mut exhausted = false;
+        let mut observed = None;
+        assert!(
+            !checked_charge(
+                &mut used,
+                &mut exhausted,
+                2,
+                usize::MAX - 1,
+                &mut |actual, maximum| {
+                    observed = Some((actual, maximum));
+                    Ok::<(), Infallible>(())
+                },
+            )
+            .unwrap()
+        );
+        assert_eq!(observed, Some((usize::MAX, usize::MAX - 1)));
+        assert_eq!(used, usize::MAX - 1);
+        assert!(exhausted);
+    }
+
+    #[test]
+    fn selector_component_floor_also_bounds_unadmitted_branches() {
+        let selector = std::iter::repeat_n("a:", 33).collect::<Vec<_>>().join(" ");
+        let mut checkpoint = || Ok::<(), Infallible>(());
+        let parsed = parse_branch(&selector, &mut checkpoint).unwrap();
+        assert!(matches!(parsed, BranchParse::LimitExceeded(65)));
+    }
+
+    #[test]
+    fn unadmitted_selector_validation_rejects_trailing_operators() {
+        for selector in [
+            "span:",
+            "span::",
+            ".a +",
+            ".a + > .b",
+            ".a ~",
+            ".a |",
+            ".a ||",
+            "a | b",
+            "a| b",
+            "a |b",
+            "span:hover [data-tags^=]",
+        ] {
+            assert!(
+                !validate_unadmitted_selector(selector),
+                "malformed selector should fail closed: {selector}"
+            );
+        }
+    }
+
+    #[test]
+    fn unadmitted_selector_validation_accepts_supported_css_shapes_without_admitting_them() {
+        for selector in [
+            ":root",
+            "span:hover",
+            "span::before",
+            ":not(&)",
+            ".a + .b",
+            ".a ~ .b",
+            "svg|a",
+            "*|span",
+            "a||b",
+            "[data-tags^=choice]",
+        ] {
+            assert!(
+                validate_unadmitted_selector(selector),
+                "valid unsupported selector should remain ignorable: {selector}"
+            );
+        }
+    }
+
+    #[test]
+    fn stylesheet_parser_strips_a_cdata_prefix_even_without_a_suffix() {
+        let mut rules = Vec::new();
+        let mut source_order = 0usize;
+        let mut budget = SelectorBudget::default();
+        let mut checkpoint = || Ok::<(), Infallible>(());
+        let mut selector_limit = |_, _| Ok::<(), Infallible>(());
+
+        assert!(
+            parse_stylesheet(
+                "<![CDATA[.nodeLabel{font-size:13px}",
+                &mut rules,
+                &mut source_order,
+                &mut budget,
+                &mut checkpoint,
+                &mut selector_limit,
+            )
+            .unwrap()
+        );
+        assert_eq!(rules.len(), 1);
+    }
 }

--- a/crates/merman-render/src/svg/fallback/css.rs
+++ b/crates/merman-render/src/svg/fallback/css.rs
@@ -9,11 +9,11 @@ pub(super) fn extract_style_property_with_checkpoints<E>(
     checkpoint: &mut impl FnMut() -> Result<(), E>,
 ) -> Result<Option<String>, E> {
     let mut found = None;
-    for (order, declaration) in split_style_declarations(style, checkpoint)?
-        .into_iter()
-        .enumerate()
-    {
+    let mut declarations = StyleDeclarationScanner::new(style);
+    let mut order = 0usize;
+    while let Some(declaration) = declarations.next_with_checkpoints(checkpoint)? {
         checkpoint_loop(order, checkpoint)?;
+        order = order.saturating_add(1);
         let Some(colon) = declaration.find(':') else {
             continue;
         };
@@ -30,36 +30,56 @@ pub(super) fn extract_style_property_with_checkpoints<E>(
     Ok(found)
 }
 
-pub(super) fn split_style_declarations<'a, E>(
+pub(super) struct StyleDeclarationScanner<'a> {
     style: &'a str,
-    checkpoint: &mut impl FnMut() -> Result<(), E>,
-) -> Result<Vec<&'a str>, E> {
-    let mut declarations = Vec::new();
-    let mut start = 0usize;
-    let mut quote = None;
-    let mut paren_depth = 0usize;
-    for (iteration, (offset, character)) in style.char_indices().enumerate() {
-        checkpoint_loop(iteration, checkpoint)?;
-        if let Some(current_quote) = quote {
-            if character == current_quote {
-                quote = None;
-            }
-            continue;
-        }
-        match character {
-            '\'' | '"' => quote = Some(character),
-            '(' => paren_depth = paren_depth.saturating_add(1),
-            ')' => paren_depth = paren_depth.saturating_sub(1),
-            ';' if paren_depth == 0 => {
-                declarations.push(&style[start..offset]);
-                start = offset + character.len_utf8();
-            }
-            _ => {}
+    cursor: usize,
+    finished: bool,
+}
+
+impl<'a> StyleDeclarationScanner<'a> {
+    pub(super) const fn new(style: &'a str) -> Self {
+        Self {
+            style,
+            cursor: 0,
+            finished: false,
         }
     }
-    declarations.push(&style[start..]);
-    checkpoint()?;
-    Ok(declarations)
+
+    pub(super) fn next_with_checkpoints<E>(
+        &mut self,
+        checkpoint: &mut impl FnMut() -> Result<(), E>,
+    ) -> Result<Option<&'a str>, E> {
+        if self.finished {
+            return Ok(None);
+        }
+        let start = self.cursor;
+        let mut quote = None;
+        let mut paren_depth = 0usize;
+        for (iteration, (relative, character)) in self.style[start..].char_indices().enumerate() {
+            checkpoint_loop(iteration, checkpoint)?;
+            if let Some(current_quote) = quote {
+                if character == current_quote {
+                    quote = None;
+                }
+                continue;
+            }
+            match character {
+                '\'' | '"' => quote = Some(character),
+                '(' => paren_depth = paren_depth.saturating_add(1),
+                ')' => paren_depth = paren_depth.saturating_sub(1),
+                ';' if paren_depth == 0 => {
+                    let end = start + relative;
+                    self.cursor = end + character.len_utf8();
+                    checkpoint()?;
+                    return Ok(Some(&self.style[start..end]));
+                }
+                _ => {}
+            }
+        }
+        self.finished = true;
+        checkpoint()?;
+        Ok(Some(&self.style[start..]))
+    }
 }
 
 fn strip_important(value: &str) -> &str {

--- a/crates/merman/tests/resvg_safe_fixture_smoke.rs
+++ b/crates/merman/tests/resvg_safe_fixture_smoke.rs
@@ -1200,6 +1200,37 @@ fn fallback_owner_representatives_render_typed_resvg_safe() {
 }
 
 #[test]
+fn block_edge_label_fallback_keeps_the_real_mermaid_background_owner() {
+    let relative_name = "fixtures/block/stress_block_font_size_precedence_001.mmd";
+    let source = std::fs::read_to_string(workspace_root().join(relative_name))
+        .unwrap_or_else(|error| panic!("read {relative_name}: {error}"));
+    let svg = render_resvg_safe_for_fixture("block-edge-background", &source, relative_name, false);
+    let document = roxmltree::Document::parse(&svg).expect("valid resvg-safe Block SVG");
+    let fallback = document
+        .descendants()
+        .find(|node| {
+            node.has_tag_name("g")
+                && node.attribute("data-merman-foreignobject") == Some("fallback")
+                && node.descendants().any(|child| {
+                    child
+                        .text()
+                        .is_some_and(|text| text.contains("Wide edge label"))
+                })
+        })
+        .unwrap_or_else(|| panic!("missing Block edge-label fallback group: {svg}"));
+    let fill = fallback
+        .children()
+        .find(|node| node.has_tag_name("rect"))
+        .and_then(|node| node.attribute("fill"))
+        .unwrap_or_else(|| panic!("missing Block edge-label background rect: {svg}"));
+
+    assert!(
+        fill.starts_with("rgba(232,232,232") && fill.contains("0.8"),
+        "the fallback rect must use Block's real span.edgeLabel background: {fill}"
+    );
+}
+
+#[test]
 fn boundary_fixtures_render_typed_resvg_safe() {
     let fixtures = boundary_fixture_paths();
     assert!(

--- a/crates/merman/tests/zed_editor_contract.rs
+++ b/crates/merman/tests/zed_editor_contract.rs
@@ -396,6 +396,33 @@ fn zed_like_pipeline_separates_pre_injection_metrics_from_host_hooks() {
 }
 
 #[test]
+fn zed_like_edge_label_fallback_uses_theme_background() {
+    let svg = render_zed_safe(
+        "zed-edge-label-background",
+        "flowchart TD\n  A[Start] -->|Yes| B[Done]",
+    );
+    assert_zed_safe_svg("zed-edge-label-background", &svg);
+
+    let document = roxmltree::Document::parse(&svg).expect("valid Zed SVG XML");
+    let fallback_group = document.descendants().find(|node| {
+        node.has_tag_name("g")
+            && node.attribute("data-merman-foreignobject") == Some("fallback")
+            && node.descendants().any(|descendant| {
+                descendant.has_tag_name("text")
+                    && descendant.text().is_some_and(|text| text.trim() == "Yes")
+            })
+    });
+    let rect_fill = fallback_group
+        .and_then(|group| group.children().find(|child| child.has_tag_name("rect")))
+        .and_then(|rect| rect.attribute("fill"));
+    assert_eq!(
+        rect_fill,
+        Some("#282c33"),
+        "edge-label fallback should use the configured Zed theme background: {svg}"
+    );
+}
+
+#[test]
 fn zed_like_after_render_css_is_a_paint_only_host_composition() {
     let source = r#"classDiagram
     class User {


### PR DESCRIPTION
This PR follows up on #89 and #92.

## Summary

- Resolve fallback typography from the actual SVG/XHTML source context instead of applying a global 16px rule.
- Bound stylesheet, selector, declaration, posting, ancestry, and matching work.
- Admit selector lists atomically and fail closed on malformed or unsupported selector syntax.
- Preserve resvg-safe label backgrounds, including Zed-like edge-label themes.
- Keep normal SVG parity and generated fallback metadata stable.

## Validation

- `cargo fmt --all -- --check`
- `cargo nextest run --locked -p merman-render --lib`
- Focused Merman SVG and Zed integration tests
- `cargo run --locked -p xtask -- check-alignment`
- `cargo run --locked --release -p xtask -- compare-all-svgs --check-dom --dom-mode structure --dom-decimals 3`

## Compatibility

No FFI or ABI changes are required. C, UniFFI, WASM, Flutter, and Typst callers continue through the shared renderer path.