### PR TITLE
docs(release): reconcile alpha6 publication status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on *Keep a Changelog*, and this project adheres to *Semantic
 
 ## [0.8.0-alpha.6] - 2026-09-02
 
-Alpha.6 is a deliberately breaking prerelease and the first 0.8 release aligned with Mermaid `11.17.2`. It unifies operation control across Rust and first-party bindings, expands terminal and editor workflows, and brings the native, Web, Node.js, Flutter, Python, Apple, Android, and Typst surfaces onto explicit contracts. This entry remains a source candidate until release preflight and the independently owned publication surfaces are complete. See the [alpha.5 to alpha.6 upgrade guide](docs/release/ALPHA5_TO_ALPHA6_UPGRADE_GUIDE.md).
+Alpha.6 is a deliberately breaking prerelease and the first 0.8 release aligned with Mermaid `11.17.2`. It unifies operation control across Rust and first-party bindings, expands terminal and editor workflows, and brings the native, Web, Node.js, Flutter, Python, Apple, Android, and Typst surfaces onto explicit contracts. The workspace crates and CLI/LSP archives are published from immutable tag `v0.8.0-alpha.6`; Web, Node.js, Flutter, Python, Apple, Android, and Typst remain independent publication tracks whose availability must be checked separately. See the [alpha.5 to alpha.6 upgrade guide](docs/release/ALPHA5_TO_ALPHA6_UPGRADE_GUIDE.md).
 
 ### Highlights
 
@@ -77,7 +77,7 @@ The detailed contracts remain in **Breaking changes** below. Before mixing alpha
 
 ### Availability and known limitations
 
-- Alpha.6 is a breaking prerelease. Workspace version, source candidate, and registry/package availability are separate; install or deploy matching generated bindings and native/WebAssembly artifacts together.
+- The workspace crates and CLI/LSP archives are published as `0.8.0-alpha.6` from immutable tag `v0.8.0-alpha.6`. Web, Node.js, Flutter, Python, Apple, Android, and Typst are independent channels and may still target alpha.5 or require a separate authorized publication; verify each channel before installing it.
 - The default Android, Apple, Python, and Flutter profiles intentionally omit math, PNG, JPEG, PDF, and native runtime adapters. Use the runtime catalog or a custom artifact when those capabilities are required; ELK requires `complete-svg-elk` or `layout-elk`.
 - The Node.js package group and Typst `0.3.0` package remain experimental and follow independent publication tracks. Their channels may lag the workspace release and must not be inferred from the alpha.6 version alone.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ sanitization, and SVG structure are checked against pinned Mermaid source and fi
 
 > [!NOTE]
 > This README documents the current `main` branch. The operation-scoped `Renderer` API was
-> introduced after the published `0.8.0-alpha.5` tag. If you depend on that release, use its
+> introduced in the published `0.8.0-alpha.6` release. If you depend on `0.8.0-alpha.5`, use its
 > [tagged README](https://github.com/Latias94/merman/blob/v0.8.0-alpha.5/README.md).
 
 > **Used by Zed.** Zed uses Merman as its Rust Mermaid backend. [Read the merged integration](https://github.com/zed-industries/zed/pull/57644).

--- a/crates/merman-cli/README.md
+++ b/crates/merman-cli/README.md
@@ -15,13 +15,13 @@ The command line has four explicit workflows:
 
 ## Install
 
-This README describes the prepared alpha.6 source candidate. It is not a claim that alpha.6 is already published. For the published channel, prefer the complete prebuilt binary from the selected release, with a source-build fallback when no official archive is available for the current target:
+This README describes the published `merman-cli` `0.8.0-alpha.6` package and binary channel. Prefer the complete prebuilt binary from the selected release, with a source-build fallback when no official archive is available for the current target:
 
 ```sh
-cargo binstall merman-cli@0.8.0-alpha.5
+cargo binstall merman-cli@0.8.0-alpha.6
 ```
 
-The published binary channel currently ends at alpha.5. Merman's cargo-binstall metadata uses the repository's cargo-dist GitHub Release archive for the selected version, disables third-party QuickInstall artifacts, and preserves `cargo install` as the fallback when an official archive is unavailable. Check `merman-cli --version` first; use a checkout at the exact alpha.6 preflight commit when you need the candidate contract documented here.
+The alpha.6 binary channel is published. Merman's cargo-binstall metadata uses the repository's cargo-dist GitHub Release archive for the selected version, disables third-party QuickInstall artifacts, and preserves `cargo install` as the fallback when an official archive is unavailable. Check `merman-cli --version` first; use a checkout at tag `v0.8.0-alpha.6` when you need the source contract documented here.
 
 Homebrew users can install the stable formula:
 
@@ -33,7 +33,7 @@ The formula follows stable releases and may trail this pre-release documentation
 
 Starting with `0.8.0-alpha.5`, version-specific [GitHub Releases](https://github.com/Latias94/merman/releases) also provide `merman-cli-installer.sh` and `merman-cli-installer.ps1`. Download an installer from the chosen release rather than a moving URL; it installs only the binary and fails closed if the archive SHA-256 cannot be verified.
 
-From a checkout at the exact commit accepted by alpha.6 preflight:
+From a checkout at tag `v0.8.0-alpha.6`:
 
 ```sh
 cargo install --path crates/merman-cli --locked

--- a/docs/release/ALPHA3_TO_ALPHA5_UPGRADE_GUIDE.md
+++ b/docs/release/ALPHA3_TO_ALPHA5_UPGRADE_GUIDE.md
@@ -6,7 +6,7 @@
 > before relying on an alpha.5 API or capability. The later Web and Node npm alpha.5 packages were
 > bootstrapped from verified workflow artifacts built at a reviewed commit newer than the workspace
 > tag and are not byte-identical tag artifacts. Those bootstrap registry artifacts do not expose npm
-> provenance attestations. Source integrations moving from alpha.5 to the prepared alpha.6 candidate must also apply the [alpha.5 to alpha.6 upgrade guide](ALPHA5_TO_ALPHA6_UPGRADE_GUIDE.md), and final release benchmarks must be regenerated against the tagged release commit.
+> provenance attestations. Source integrations moving from alpha.5 to the published alpha.6 workspace release must also apply the [alpha.5 to alpha.6 upgrade guide](ALPHA5_TO_ALPHA6_UPGRADE_GUIDE.md), and final release benchmarks must be regenerated against the tagged release commit.
 
 Alpha.5 is a broad prerelease upgrade, not a drop-in patch. It expands the Mermaid baseline to
 11.16, admits all 35 diagram families, replaces implementation-oriented feature bundles with observable capabilities, splits the browser SDK into standalone packages, and finalizes separate alpha.5 native transport contracts: C/Flutter use ABI 3, Android uses direct JNI transport API 1, the browser transport uses API 3, and Apple/Python use UniFFI API 3. Published artifacts may advance on their own channel; always compare the loaded runtime catalog before mixing a generated wrapper with a native library.

--- a/docs/release/ALPHA5_TO_ALPHA6_UPGRADE_GUIDE.md
+++ b/docs/release/ALPHA5_TO_ALPHA6_UPGRADE_GUIDE.md
@@ -1,7 +1,7 @@
 # Upgrade from 0.8.0-alpha.5 to 0.8.0-alpha.6
 
 > [!IMPORTANT]
-> Alpha.6 is a prepared prerelease candidate. This document does not imply that a registry package, tag, or platform artifact has been published. Use the exact reviewed source revision for candidate integrations and upgrade each generated binding together with its matching native or WebAssembly artifact.
+> Alpha.6 is published for the workspace crates and CLI/LSP archives from immutable tag `v0.8.0-alpha.6`. Web, Node.js, Flutter, Python, Apple, Android, and Typst remain independent publication tracks; verify the matching channel before installing a generated binding or native/WebAssembly artifact.
 
 Alpha.6 is intentionally breaking across the Rust rendering, analysis/editor, and native transport surfaces. The migration is organized by contract owner so a host can update one boundary at a time without relying on compatibility aliases that no longer exist.
 
@@ -55,7 +55,7 @@ Generated bindings and native artifacts are version-coupled. Runtime catalogs an
 - Flutter now uses Dart `package_ffi` and Native Assets with Dart `3.10` / Flutter `3.38` minimums; legacy plugin registrars, platform wrapper glue, and `openMermanLibrary()` are removed, while `Merman.open()` remains the default facade.
 - The default Android, Apple, Python, and Flutter artifacts bundle SVG, Cytoscape/ELK layout, ASCII, analysis, validation, and document analysis, while omitting math, PNG, JPEG, PDF, and native clock/time-zone/random adapters; inspect the runtime catalog before calling optional operations.
 - Typst package `0.3.0` is an independently versioned alpha.6 candidate and is not implied to be present in Typst Universe; the published registry line remains `0.2.0` until the manual package submission is authorized.
-- The alpha.6 source README and package changelogs distinguish published alpha.5 channels from the unreleased candidate; registry installs are not evidence that a package has been rebuilt from the alpha.6 source revision.
+- The alpha.6 source README and package changelogs distinguish the published workspace/crates.io/CLI surfaces from independent alpha.5 channels; a registry install on one channel is not evidence that another package has been rebuilt from the alpha.6 source revision.
 
 ## Capability and output compatibility
 
@@ -72,4 +72,4 @@ Generated bindings and native artifacts are version-coupled. Runtime catalogs an
 2. Regenerate analysis facts, UniFFI projections, Web/WASM glue, and Android JNI sources from the alpha.6 source revision.
 3. Refresh ASCII/SVG snapshots and capability decoders, paying particular attention to viewBox padding and structured-text fallback metadata.
 4. Install the matching native/WebAssembly artifact in each host and verify runtime-catalog identity, binding/transport API versions, and resource schemas before enabling optional outputs.
-5. Treat registry package versions and independent package workflows as separate publication events; do not infer alpha.6 availability from a lockstep workspace version alone.
+5. Treat registry package versions and independent package workflows as separate publication events; the workspace tag confirms only the workspace/crates.io/CLI release surfaces, not every alpha.6 package channel.

--- a/docs/release/PUBLISH_ORDER.md
+++ b/docs/release/PUBLISH_ORDER.md
@@ -1,20 +1,23 @@
 # Publish Order
 
 Status: maintained workspace publish order.
-Last updated: 2026-08-30
+Last updated: 2026-09-02
 
 ## Version Decision
 
-Published workspace prerelease baseline: `0.8.0-alpha.5`.
+Published workspace prerelease baseline: `0.8.0-alpha.6`.
 
-The prepared workspace candidate is `0.8.0-alpha.6`. This local source state does not authorize a
-tag, workflow dispatch, registry publication, or GitHub Release mutation. The browser and
-Node package groups were published as an authorized alpha-channel test at `0.8.0-alpha.5` from
-reviewed commit `d4365ca4860b6b4d51c421e775daab92a815c667`, newer than the workspace
-`v0.8.0-alpha.5` tag. Their verified package-group manifests and workflow artifacts identify that
-commit. Because the first publication was a manual bootstrap, those npm registry artifacts do not
-expose npm provenance attestations; documentation must not imply either an attestation or
-cross-channel byte identity.
+The workspace release is published from immutable tag `v0.8.0-alpha.6` at commit
+`d529f858ea3d337a1bdc8fe12e44e1403ededf2e`. The crates.io workflow published all 20 workspace
+crates, and the GitHub Release published the CLI/LSP archives and their verification assets. The
+browser, Node.js, Flutter, Python, Apple, Android, and Typst package groups remain independent
+publication tracks; their alpha.6 availability must be established by their owning workflow or
+registry rather than inferred from the workspace tag. The browser and Node package groups were
+previously published as an authorized alpha-channel test at `0.8.0-alpha.5` from reviewed commit
+`d4365ca4860b6b4d51c421e775daab92a815c667`, newer than the workspace `v0.8.0-alpha.5` tag. Their
+verified package-group manifests and workflow artifacts identify that commit. Because that first
+publication was a manual bootstrap, those npm registry artifacts do not expose npm provenance
+attestations; documentation must not imply either an attestation or cross-channel byte identity.
 
 Rationale:
 
@@ -25,11 +28,12 @@ Rationale:
   integrations test one coherent version graph. The unpublished VS Code extension follows its own
   `0.1.x` version track and records the bundled workspace runtime separately.
 
-Workspace-coupled manifests are aligned to the prepared `0.8.0-alpha.6` candidate. Python package
-metadata uses the PEP 440 spelling `0.8.0a6`, but manifest alignment does not prove that a surface reached its
-registry or that separately published alpha.5 channels share one source snapshot. The
-independently versioned VS Code extension, Typst wrapper, and `roughr-merman` remain on their own
-release axes. The `tree-sitter-mermaid` language distribution also has an independent version axis.
+Workspace Cargo manifests were published as `0.8.0-alpha.6`. Python package metadata uses the PEP
+440 spelling `0.8.0a6`, but that version remains an independent publication decision; likewise,
+separately published alpha.5 channels do not share a source snapshot with the workspace release by
+implication. The independently versioned VS Code extension, Typst wrapper, and `roughr-merman`
+remain on their own release axes. The `tree-sitter-mermaid` language distribution also has an
+independent version axis.
 Version `0.1.0` is published on crates.io and npm from tag `tree-sitter-mermaid-v0.1.0`, commit
 `34ddaccbfb8b4a7a502e67122b2cd709b4989e19`. Its standalone GitHub Release is intentionally
 deferred so it can be announced alongside the next Merman product release; the two releases retain
@@ -37,7 +41,7 @@ their own tags and version identities.
 
 ## Typst Package Surface
 
-The Typst wrapper is an independent publication surface. The current candidate is `@preview/merman:0.3.0`, built from the prepared Merman `0.8.0-alpha.6` source line and Typst compiler `0.15.0`. It is not published by crates.io: `merman-typst-plugin@0.8.0-alpha.6` is the Cargo transport crate, while `@preview/merman:0.3.0` is the user-facing Typst package containing the frozen wrapper, size-optimized WASM artifact, and third-party legal materials. Build provenance remains in the private artifact directory and is not part of the registry package.
+The Typst wrapper is an independent publication surface. The current candidate is `@preview/merman:0.3.0`, built from the prepared Merman `0.8.0-alpha.6` source line and Typst compiler `0.15.0`. It is not published by crates.io: `merman-typst-plugin@0.8.0-alpha.6` is the published Cargo transport crate, while `@preview/merman:0.3.0` is the user-facing Typst package containing the frozen wrapper, size-optimized WASM artifact, and third-party legal materials. Build provenance remains in the private artifact directory and is not part of the registry package.
 
 Version `0.3.0` is the first Typst package rebuilt after the text-measurement closure reduction. ICU4X collation data and generated font-metric tables are no longer linked into the production artifact; the plugin keeps deterministic measurement and the existing ABI 2 exports. The package version changes because the shipped implementation closure and size characteristics are materially different, while the wrapper protocol remains compatible.
 

--- a/docs/release/UNRELEASED_UPGRADE_GUIDE.md
+++ b/docs/release/UNRELEASED_UPGRADE_GUIDE.md
@@ -1,12 +1,12 @@
-# Alpha.6 Detailed Migration Reference (Source Candidate)
+# Alpha.6 Detailed Migration Reference
 
-> This guide applies to the prepared `0.8.0-alpha.6` source candidate after `v0.8.0-alpha.5`. It does not describe the published alpha.5 artifacts. No registry package, tag, or platform artifact is implied until the exact release source passes preflight.
+> This guide applies to the published `0.8.0-alpha.6` workspace release after `v0.8.0-alpha.5`. It covers the workspace crates and CLI/LSP archives from the immutable alpha.6 tag; Web, Node.js, Flutter, Python, Apple, Android, and Typst remain independent channels with separate publication evidence.
 
 Start with the concise [alpha.5 to alpha.6 upgrade guide](ALPHA5_TO_ALPHA6_UPGRADE_GUIDE.md). This document retains the exhaustive symbol mapping and worked Rust examples for integrations that need a deeper migration reference.
 
 ## Rust analysis and editor migration
 
-The alpha.6 candidate deliberately removes prerelease compatibility shims. Migrate source and generated bindings together.
+The alpha.6 release deliberately removes prerelease compatibility shims. Migrate source and generated bindings together.
 
 | Alpha.5 or development-snapshot API | Alpha.6 replacement |
 | --- | --- |


### PR DESCRIPTION
## Summary

- record the published `v0.8.0-alpha.6` workspace crates and CLI/LSP archives
- update installation and migration guides from candidate wording to the published workspace contract
- retain explicit independent-channel status for Web, Node.js, Flutter, Python, Apple, Android, and Typst

## Validation

- `git diff --check origin/main...HEAD`
- publication-status wording audit (the Typst `0.3.0` candidate is intentionally retained)

No release tag, registry package, or published artifact is changed by this PR.