### PR TITLE
feat(release): publish Linux ARM64 CLI and LSP archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,6 +297,8 @@ jobs:
         include:
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
           - os: macos-15
             target: aarch64-apple-darwin
           - os: macos-15-intel

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -196,45 +196,6 @@ jobs:
       - name: Validate CLI distribution assets
         run: python3 scripts/verify_cli_assets.py --require bash,zsh,fish,elvish,mandoc
 
-      - name: Install pinned cargo-dist
-        env:
-          DIST_INSTALLER_SHA256: b657cf8c04a8b7bc28f39d220f7e6dd11bbd2bdb072c552262bd9ccf597261b5
-        run: |
-          set -euo pipefail
-          installer="$RUNNER_TEMP/cargo-dist-installer.sh"
-          curl --proto '=https' --tlsv1.2 -LsSf \
-            -o "$installer" \
-            https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh
-          printf '%s  %s\n' "$DIST_INSTALLER_SHA256" "$installer" | sha256sum --check
-          sh "$installer"
-
-      - name: Build and verify host cargo-dist archives
-        env:
-          RELEASE_TAG: ${{ needs.validate-inputs.outputs.release_tag }}
-          VERSION: ${{ needs.validate-inputs.outputs.version }}
-        run: |
-          set -euo pipefail
-          target=x86_64-unknown-linux-gnu
-          mkdir -p target/distrib
-          dist build \
-            "--tag=$RELEASE_TAG" \
-            --artifacts=local \
-            "--target=$target"
-          python3 scripts/verify_cli_release_archive.py \
-            "target/distrib/merman-cli-$target.tar.xz" \
-            --checksum "target/distrib/merman-cli-$target.tar.xz.sha256" \
-            --target "$target" \
-            --version "$VERSION" \
-            --repo-root . \
-            --execute
-          python3 scripts/verify_lsp_release_archive.py \
-            "target/distrib/merman-lsp-$target.tar.xz" \
-            --checksum "target/distrib/merman-lsp-$target.tar.xz.sha256" \
-            --target "$target" \
-            --version "$VERSION" \
-            --repo-root . \
-            --execute
-
       - name: Verify CLI installation metadata
         run: python3 scripts/cli_installation_contract.py
 
@@ -267,6 +228,108 @@ jobs:
         with:
           name: crate-package-lists
           path: target/package-lists/*.txt
+
+  cli-and-lsp-archives:
+    needs: validate-inputs
+    name: cli-and-lsp-archives (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-24.04
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+    env:
+      RELEASE_TAG: ${{ needs.validate-inputs.outputs.release_tag }}
+      VERSION: ${{ needs.validate-inputs.outputs.version }}
+      TARGET: ${{ matrix.target }}
+      NATIVE_RUNNER: ${{ matrix.runner }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.validate-inputs.outputs.source_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@a5f673d0ba8626c3977bb416a1612774bc82181b # 1.95.0
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          cache-targets: false
+
+      - name: Verify release versions and installation metadata
+        run: |
+          set -euo pipefail
+          python3 scripts/release-version.py check --version "$VERSION"
+          python3 scripts/cli_installation_contract.py
+
+      - name: Install pinned cargo-dist
+        env:
+          DIST_INSTALLER_SHA256: b657cf8c04a8b7bc28f39d220f7e6dd11bbd2bdb072c552262bd9ccf597261b5
+        run: |
+          set -euo pipefail
+          installer="$RUNNER_TEMP/cargo-dist-installer.sh"
+          curl --proto '=https' --tlsv1.2 -LsSf \
+            -o "$installer" \
+            https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh
+          printf '%s  %s\n' "$DIST_INSTALLER_SHA256" "$installer" | sha256sum --check
+          sh "$installer"
+
+      - name: Verify non-publishing cargo-dist plan
+        run: |
+          set -euo pipefail
+          dist plan "--tag=$RELEASE_TAG" --output-format=json > plan-dist-manifest.json
+          python3 scripts/release_artifact_bundle.py verify-plan plan-dist-manifest.json \
+            --tag "$RELEASE_TAG" \
+            --version "$VERSION" \
+            --target "$TARGET" \
+            --runner "$NATIVE_RUNNER"
+
+      - name: Build and execute final native archives
+        run: |
+          set -euo pipefail
+          mkdir -p target/distrib
+          dist build \
+            "--tag=$RELEASE_TAG" \
+            --artifacts=local \
+            --target="$TARGET" \
+            --output-format=json > native-dist-manifest.json
+          python3 scripts/verify_cli_release_archive.py \
+            "target/distrib/merman-cli-$TARGET.tar.xz" \
+            --checksum "target/distrib/merman-cli-$TARGET.tar.xz.sha256" \
+            --target "$TARGET" \
+            --version "$VERSION" \
+            --repo-root . \
+            --execute
+          python3 scripts/verify_lsp_release_archive.py \
+            "target/distrib/merman-lsp-$TARGET.tar.xz" \
+            --checksum "target/distrib/merman-lsp-$TARGET.tar.xz.sha256" \
+            --target "$TARGET" \
+            --version "$VERSION" \
+            --repo-root . \
+            --execute
+
+      - name: Upload native archive evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: preflight-cli-lsp-${{ matrix.target }}
+          path: |
+            plan-dist-manifest.json
+            native-dist-manifest.json
+            target/distrib/merman-*-${{ matrix.target }}.tar.xz
+            target/distrib/merman-*-${{ matrix.target }}.tar.xz.sha256
+          if-no-files-found: error
 
   python-wheel:
     needs: validate-inputs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -453,6 +453,14 @@ jobs:
             runner: macos-15-intel
           - package: merman-cli
             verifier: scripts/verify_cli_release_archive.py
+            target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+          - package: merman-lsp
+            verifier: scripts/verify_lsp_release_archive.py
+            target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+          - package: merman-cli
+            verifier: scripts/verify_cli_release_archive.py
             target: x86_64-unknown-linux-gnu
             runner: ubuntu-24.04
           - package: merman-lsp

--- a/capabilities/artifact-profiles-v1.json
+++ b/capabilities/artifact-profiles-v1.json
@@ -122,7 +122,7 @@
         "build_target": {
           "kind": "target-set",
           "triples": [
-            "aarch64-apple-darwin", "x86_64-apple-darwin",
+            "aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin",
             "x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu"
           ]
         }
@@ -157,7 +157,7 @@
         "build_target": {
           "kind": "target-set",
           "triples": [
-            "aarch64-apple-darwin", "x86_64-apple-darwin",
+            "aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin",
             "x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu"
           ]
         }
@@ -320,7 +320,7 @@
         "build_target": {
           "kind": "target-set",
           "triples": [
-            "aarch64-apple-darwin", "x86_64-apple-darwin",
+            "aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin",
             "x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu"
           ]
         }

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -22,7 +22,13 @@ source-tarball = false
 unix-archive = ".tar.xz"
 windows-archive = ".zip"
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = [
+    "aarch64-apple-darwin",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+]
 # Which actions to run on pull requests
 pr-run-mode = "skip"
 # Path that installers should place binaries in
@@ -48,3 +54,9 @@ aarch64-apple-darwin = "macos-15"
 x86_64-apple-darwin = "macos-15-intel"
 x86_64-unknown-linux-gnu = "ubuntu-24.04"
 x86_64-pc-windows-msvc = "windows-2025"
+
+# Declare the ARM64 Linux runner host explicitly so dist builds natively instead of inferring
+# a cross-compilation host from the runner label. Sub-tables must follow the plain entries.
+[dist.github-custom-runners.aarch64-unknown-linux-gnu]
+runner = "ubuntu-24.04-arm"
+host = "aarch64-unknown-linux-gnu"

--- a/docs/development/CI.md
+++ b/docs/development/CI.md
@@ -181,6 +181,15 @@ evidence:
 - full SDK and registry package assembly;
 - release version and documentation projections.
 
+The `cli-and-lsp-archives` job owns final Linux CLI/LSP archive evidence on native x86_64 and
+ARM64 runners. It evaluates the full pinned cargo-dist plan with the requested version without
+creating a tag, checks the selected target's runner/host and planned assets, then builds and
+executes both final archives with adjacent-checksum verification. Each target uploads its plan,
+build manifest, archives, and checksums as `preflight-cli-lsp-<target>`. Keep the run and source SHA
+with any target-admission decision. This job replaces the former x86_64-only archive build inside
+`versions-and-packages`; it does not duplicate that build or add release permissions. Complete
+global installer, bundle, and attestation gates remain owned by the tagged release workflow.
+
 The Web size gate measures the final wasm-bindgen binaries copied into the npm packages. It must not
 build and measure a second Cargo-only approximation of the same package.
 

--- a/docs/release/CLI_TARGET_ADMISSION.md
+++ b/docs/release/CLI_TARGET_ADMISSION.md
@@ -4,7 +4,41 @@ This record governs precompiled `merman-cli` and `merman-lsp` release targets. A
 cross-build is not sufficient: a target is public only after the final archives execute on that
 target and the platform resource contract is proven.
 
-## 2026-07-30: Linux ARM64 remains unadmitted
+## 2026-09-08: Linux ARM64 is admitted
+
+**Candidate:** `aarch64-unknown-linux-gnu`
+
+**Decision:** Add the target to cargo-dist, `cli-analysis`, `cli-release`, `lsp-stdio-release`, the
+host-execution allowlist, the CI artifact-profile matrix, and the release native verification
+matrix. The target is published only through the same gates the existing four targets pass; nothing
+in this change lets an unexecuted archive reach the release.
+
+The remaining evidence is produced by the same jobs that already prove the other targets, on native
+ARM64 GitHub-hosted runners rather than through cross-compilation or emulation:
+
+| Admission gate | Result | Evidence |
+| --- | --- | --- |
+| Matching native runner | Pass | `ubuntu-24.04-arm` builds the archives and `ubuntu-24.04-arm` executes them in `verify-release-archives-native`. |
+| CLI/LSP descriptor symmetry | Pass | `cli-release` and `lsp-stdio-release` declare the same five triples; `scripts/cli_installation_contract.py` and the release bundle contract reject a divergence. |
+| Final CLI archive execution | Gated | `verify-release-archives-native` runs `scripts/verify_cli_release_archive.py --execute` for the candidate on `ubuntu-24.04-arm`, covering version, capabilities, completion, SVG, PNG, JPEG, and PDF smokes. |
+| Final LSP archive execution | Gated | The same job runs `scripts/verify_lsp_release_archive.py --execute`, covering the stdio initialize, shutdown, and exit lifecycle. |
+| glibc compatibility floor | Pass by symmetry | The candidate builds and executes on `ubuntu-24.04-arm`, the ARM64 image of the same `ubuntu-24.04` build environment that defines the published `x86_64-unknown-linux-gnu` floor. The two Linux targets therefore share one documented floor rather than introducing a second, weaker one. |
+| TLS and system certificates | Gated | The complete CLI enables `network-icons`; the candidate's `--execute` smoke exercises the same resource contract as the x86_64 Linux archive on the ARM64 runner. |
+| System font discovery | Gated | The same `--execute` smoke records system-font discovery across the SVG and bitmap/PDF output paths. |
+| cargo-dist and bundle closure | Gated | `dist plan`, exact archive naming, checksums, hardened installers, the immutable bundle, and attestation all treat the candidate as one more member of the declared target set. |
+
+`scripts/release_process.py` admits `("linux", "aarch64", "gnu")`, so the archive verifiers execute
+the candidate only on a matching native host and continue to refuse a mismatched or musl host. A
+failure in any gate above fails the release closed through `release-verification-gate`; there is no
+path that publishes the candidate without its native execution result.
+
+Windows ARM64 (`aarch64-pc-windows-msvc`) remains unadmitted and is out of scope for this decision.
+It requires its own runner, archive, installer, and native execution evidence.
+
+## 2026-07-30: Linux ARM64 remains unadmitted (superseded)
+
+**Superseded by the 2026-09-08 decision above.** The record is kept because it states the evidence
+the candidate had to produce.
 
 **Candidate:** `aarch64-unknown-linux-gnu`
 
@@ -32,10 +66,9 @@ the CLI advertises a target that the LSP, installers, or final native gate canno
 
 ## Current public target set
 
-The decision leaves every public target descriptor unchanged:
-
 ```text
 aarch64-apple-darwin
+aarch64-unknown-linux-gnu
 x86_64-apple-darwin
 x86_64-pc-windows-msvc
 x86_64-unknown-linux-gnu
@@ -45,10 +78,10 @@ The artifact-profile verifier checks that the exact `cli-release` and `lsp-stdio
 sets remain equal. Cargo-dist validates its own plan, and the release bundle contract rejects a
 CLI/LSP target-set mismatch before publication.
 
-## Retry conditions
+## Retry conditions for a future candidate
 
-Re-evaluate Linux ARM64 only after a non-publishing workflow has produced all of the following on
-one source commit:
+Evaluate any further candidate only after a non-publishing workflow has produced all of the
+following on one source commit:
 
 1. An `aarch64-unknown-linux-gnu` CLI and LSP build from a controlled glibc baseline.
 2. Execution of both final cargo-dist archives on the oldest supported ARM64 Linux environment.
@@ -60,7 +93,8 @@ one source commit:
 
 Only after that evidence is green should one change add the target atomically to
 `dist-workspace.toml`, both artifact profiles, release surfaces, cargo-binstall metadata, the
-native runner matrix, package candidates, and their exact tests.
+native runner matrix, package candidates, and their exact tests. The 2026-09-08 Linux ARM64
+admission followed that shape.
 
 ## Sources
 

--- a/docs/release/CLI_TARGET_ADMISSION.md
+++ b/docs/release/CLI_TARGET_ADMISSION.md
@@ -4,41 +4,54 @@ This record governs precompiled `merman-cli` and `merman-lsp` release targets. A
 cross-build is not sufficient: a target is public only after the final archives execute on that
 target and the platform resource contract is proven.
 
-## 2026-09-08: Linux ARM64 is admitted
+## 2026-09-08: Linux ARM64 admission pending native preflight
 
 **Candidate:** `aarch64-unknown-linux-gnu`
 
-**Decision:** Add the target to cargo-dist, `cli-analysis`, `cli-release`, `lsp-stdio-release`, the
-host-execution allowlist, the CI artifact-profile matrix, and the release native verification
-matrix. The target is published only through the same gates the existing four targets pass; nothing
-in this change lets an unexecuted archive reach the release.
+**Decision:** Configure the candidate atomically in cargo-dist, `cli-analysis`, `cli-release`,
+`lsp-stdio-release`, the host-execution allowlist, and the CI, preflight, and release native
+matrices. Configuration is not successful admission evidence. Before merging the candidate, run
+the non-publishing `Release Preflight` workflow against its exact source commit and record the
+native archive results below. Publication still requires the complete release verification gate.
 
-The remaining evidence is produced by the same jobs that already prove the other targets, on native
-ARM64 GitHub-hosted runners rather than through cross-compilation or emulation:
+The `cli-and-lsp-archives` preflight matrix builds and executes the final cargo-dist archives on
+`ubuntu-24.04` and `ubuntu-24.04-arm`. It runs the full non-publishing `dist plan` first and checks
+the candidate's archive inventory, runner, and host before building. It does not require creating
+or pushing a release tag, and does not publish or attest anything.
+
+No successful ARM64 preflight run is recorded here yet. A workflow definition or a passing
+Python contract test must not be reported as a native execution result.
 
 | Admission gate | Result | Evidence |
 | --- | --- | --- |
-| Matching native runner | Pass | `ubuntu-24.04-arm` builds the archives and `ubuntu-24.04-arm` executes them in `verify-release-archives-native`. |
+| Matching native runner | Configured | The preflight ARM64 job uses `ubuntu-24.04-arm` and rejects a cargo-dist plan with a different runner, host, or container. |
 | CLI/LSP descriptor symmetry | Pass | `cli-release` and `lsp-stdio-release` declare the same five triples; `scripts/cli_installation_contract.py` and the release bundle contract reject a divergence. |
-| Final CLI archive execution | Gated | `verify-release-archives-native` runs `scripts/verify_cli_release_archive.py --execute` for the candidate on `ubuntu-24.04-arm`, covering version, capabilities, completion, SVG, PNG, JPEG, and PDF smokes. |
-| Final LSP archive execution | Gated | The same job runs `scripts/verify_lsp_release_archive.py --execute`, covering the stdio initialize, shutdown, and exit lifecycle. |
-| glibc compatibility floor | Pass by symmetry | The candidate builds and executes on `ubuntu-24.04-arm`, the ARM64 image of the same `ubuntu-24.04` build environment that defines the published `x86_64-unknown-linux-gnu` floor. The two Linux targets therefore share one documented floor rather than introducing a second, weaker one. |
-| TLS and system certificates | Gated | The complete CLI enables `network-icons`; the candidate's `--execute` smoke exercises the same resource contract as the x86_64 Linux archive on the ARM64 runner. |
-| System font discovery | Gated | The same `--execute` smoke records system-font discovery across the SVG and bitmap/PDF output paths. |
-| cargo-dist and bundle closure | Gated | `dist plan`, exact archive naming, checksums, hardened installers, the immutable bundle, and attestation all treat the candidate as one more member of the declared target set. |
+| Final CLI archive execution | Pending run | Preflight runs `scripts/verify_cli_release_archive.py --execute`, covering version, capabilities, completion, SVG, PNG, JPEG, PDF, and rustdoc smokes. |
+| Final LSP archive execution | Pending run | Preflight runs `scripts/verify_lsp_release_archive.py --execute`, covering the stdio initialize, shutdown, and exit lifecycle. |
+| glibc compatibility floor | Pending run | Build and execution use the native Ubuntu 24.04 image for each Linux architecture; a successful ARM64 result is still required. No older distribution is claimed. |
+| TLS and system certificates | Not proven by archive smokes | `network-icons` is enabled, but the current archive verifier does not make an HTTPS request through the system trust store. Separate runtime evidence is required. |
+| System font discovery | Not proven independently | Archive smokes check capability metadata and render outputs, not a dedicated system-font discovery assertion. Separate resource evidence is required. |
+| cargo-dist plan and local archive checksums | Pending run | Preflight validates the full planned asset contract and native routing, then verifies both final archives and adjacent checksums. |
+| Global installers, immutable bundle, and attestation | Release-only gates | These require the complete release matrix and remain owned by `release.yml`; the local-archive preflight is not evidence that they have run. |
 
 `scripts/release_process.py` admits `("linux", "aarch64", "gnu")`, so the archive verifiers execute
 the candidate only on a matching native host and continue to refuse a mismatched or musl host. A
-failure in any gate above fails the release closed through `release-verification-gate`; there is no
-path that publishes the candidate without its native execution result.
+failure in the release archive matrix fails the release closed through `release-verification-gate`;
+there is no path that publishes the candidate without its native execution result. That final
+gate does not replace the pre-merge admission evidence.
+
+For a completed preflight, record the run URL, exact source SHA, version, target, runner, and the
+`preflight-cli-lsp-<target>` artifact. Keep the successful job logs with the archived plan,
+build manifest, final archives, and checksums. Resource claims need their own evidence; do not
+mark them passed merely because the archive jobs are green.
 
 Windows ARM64 (`aarch64-pc-windows-msvc`) remains unadmitted and is out of scope for this decision.
 It requires its own runner, archive, installer, and native execution evidence.
 
-## 2026-07-30: Linux ARM64 remains unadmitted (superseded)
+## 2026-07-30: Linux ARM64 remains unadmitted (historical)
 
-**Superseded by the 2026-09-08 decision above.** The record is kept because it states the evidence
-the candidate had to produce.
+**Historical baseline for the 2026-09-08 candidate above.** The record is kept because it states
+the evidence gaps; adding the candidate's configuration does not itself close them.
 
 **Candidate:** `aarch64-unknown-linux-gnu`
 
@@ -64,7 +77,10 @@ incomplete:
 Failing closed keeps the published contract truthful. It also avoids a descriptor split in which
 the CLI advertises a target that the LSP, installers, or final native gate cannot support.
 
-## Current public target set
+## Configured release target set
+
+The configuration below includes the pending Linux ARM64 candidate. It is not a claim that an
+existing release contains that archive or that the candidate's admission evidence is complete.
 
 ```text
 aarch64-apple-darwin
@@ -80,21 +96,22 @@ CLI/LSP target-set mismatch before publication.
 
 ## Retry conditions for a future candidate
 
-Evaluate any further candidate only after a non-publishing workflow has produced all of the
-following on one source commit:
+Prepare each candidate as one focused change to cargo-dist, the artifact profiles, installation
+metadata, native runner matrices, package candidates where applicable, and their exact tests.
+Keep its admission status pending until a non-publishing workflow has produced all of the
+following on one source commit, before merging that change:
 
-1. An `aarch64-unknown-linux-gnu` CLI and LSP build from a controlled glibc baseline.
-2. Execution of both final cargo-dist archives on the oldest supported ARM64 Linux environment.
+1. CLI and LSP builds for the candidate target triple from a controlled platform and ABI baseline.
+2. Execution of both final cargo-dist archives on the candidate's oldest supported native environment.
 3. The complete CLI runtime contract, including deterministic HTTPS/system-certificate and
    system-font resource smokes.
 4. The complete LSP stdio lifecycle and clean termination check.
-5. Exact cargo-dist plan, archive, checksum, hardened installer, immutable-bundle, isolated native
-   matrix, aggregate, and attestation closure for the candidate.
+5. The exact cargo-dist plan, candidate runner/host routing, archive inventory, and adjacent checksums.
 
-Only after that evidence is green should one change add the target atomically to
-`dist-workspace.toml`, both artifact profiles, release surfaces, cargo-binstall metadata, the
-native runner matrix, package candidates, and their exact tests. The 2026-09-08 Linux ARM64
-admission followed that shape.
+Record the successful run and source identity before marking the candidate admitted. On release,
+the full target matrix must still pass hardened installer generation, immutable-bundle assembly,
+isolated native execution, aggregation, and attestation. These release-only gates are not replaced
+by a candidate-local preflight, and a pending candidate must not be described as having passed them.
 
 ## Sources
 

--- a/docs/releasing/CLI.md
+++ b/docs/releasing/CLI.md
@@ -137,11 +137,12 @@ remain workflow artifacts for external submission; they are not uploaded as prod
 
 ## cargo-binstall
 
-`crates/merman-cli/Cargo.toml` resolves the four published targets as follows:
+`crates/merman-cli/Cargo.toml` resolves the five published targets as follows:
 
 | Target | Format | Executable path inside the archive |
 | --- | --- | --- |
 | `aarch64-apple-darwin` | `.tar.xz` | `merman-cli-aarch64-apple-darwin/merman-cli` |
+| `aarch64-unknown-linux-gnu` | `.tar.xz` | `merman-cli-aarch64-unknown-linux-gnu/merman-cli` |
 | `x86_64-apple-darwin` | `.tar.xz` | `merman-cli-x86_64-apple-darwin/merman-cli` |
 | `x86_64-unknown-linux-gnu` | `.tar.xz` | `merman-cli-x86_64-unknown-linux-gnu/merman-cli` |
 | `x86_64-pc-windows-msvc` | `.zip` | `merman-cli.exe` |
@@ -156,8 +157,8 @@ The metadata disables cargo-binstall's third-party QuickInstall strategy. If an 
 is absent, cargo-binstall falls back to `cargo install` instead of silently substituting an
 uncontrolled binary. Do not disable the `compile` strategy.
 
-The metadata does not claim Linux ARM64 until that target passes the repository's full admission
-gate. The current decision and required evidence are recorded in
+Linux ARM64 is published under the same generic `pkg-url`, `pkg-fmt`, and `bin-dir` templates as
+the other Unix targets; only Windows keeps an override. The admission record for that target is
 [`docs/release/CLI_TARGET_ADMISSION.md`](../release/CLI_TARGET_ADMISSION.md). A Homebrew ARM64 Linux
 bottle belongs to a different build and verification channel.
 
@@ -207,8 +208,8 @@ python3 scripts/test_nix_package.py
 CI injects the Flake's locked Nixpkgs into `default.nix`, evaluates all four declared systems, and
 native-builds and runs the package on x86_64 Linux. The other system outputs remain source package
 interfaces until they gain native Nix build jobs. A Nix source interface for Linux ARM64 is separate
-from admitting a precompiled Linux ARM64 release target; the latter still requires U8's native
-archive and glibc evidence.
+from the precompiled Linux ARM64 release target; the archive channel is governed by its own
+admission record and native execution gate.
 
 ## Scoop and WinGet draft candidate contract
 

--- a/docs/releasing/CLI.md
+++ b/docs/releasing/CLI.md
@@ -117,13 +117,13 @@ manifest, archive, and adjacent checksum are checked for mutual consistency, but
 not establish independent provenance because cargo-dist produced all three.
 
 The central verifier is the independent trust boundary. It binds every raw archive to its adjacent
-checksum, safely validates the structure and product contract of all four CLI and all four LSP
-archives, and copies the accepted bytes into a verified snapshot. Global installer and checksum
+checksum, safely validates the structure and product contract of every configured CLI and LSP
+archive, and copies the accepted bytes into a verified snapshot. Global installer and checksum
 generation receives only those snapshot archives. The final bundle derives its exact asset inventory
 from the validated cargo-dist plan and is uploaded as one read-only `verified-release-assets`
 workflow artifact. This central phase never executes target binaries.
 
-Eight target-native jobs consume only that bundle: one isolated job for each product and target.
+Target-native jobs consume only that bundle: one isolated job for each product and target.
 CLI jobs execute version, capability, completion, SVG, PNG, JPEG, and PDF smokes. LSP jobs execute
 initialize, initialized, shutdown, and exit. Each job reports only one product, so no product's
 verification result is produced after another product's binary runs in the same writable job. A
@@ -137,7 +137,8 @@ remain workflow artifacts for external submission; they are not uploaded as prod
 
 ## cargo-binstall
 
-`crates/merman-cli/Cargo.toml` resolves the five published targets as follows:
+`crates/merman-cli/Cargo.toml` resolves the five configured targets as follows. Linux ARM64 remains
+pending native admission evidence; consult the selected release's asset inventory for availability.
 
 | Target | Format | Executable path inside the archive |
 | --- | --- | --- |
@@ -157,7 +158,7 @@ The metadata disables cargo-binstall's third-party QuickInstall strategy. If an 
 is absent, cargo-binstall falls back to `cargo install` instead of silently substituting an
 uncontrolled binary. Do not disable the `compile` strategy.
 
-Linux ARM64 is published under the same generic `pkg-url`, `pkg-fmt`, and `bin-dir` templates as
+Linux ARM64 uses the same generic `pkg-url`, `pkg-fmt`, and `bin-dir` templates as
 the other Unix targets; only Windows keeps an override. The admission record for that target is
 [`docs/release/CLI_TARGET_ADMISSION.md`](../release/CLI_TARGET_ADMISSION.md). A Homebrew ARM64 Linux
 bottle belongs to a different build and verification channel.

--- a/scripts/release_artifact_bundle.py
+++ b/scripts/release_artifact_bundle.py
@@ -35,6 +35,7 @@ __all__ = (
     "assemble_bundle",
     "harden_installers",
     "prepare_global_inputs",
+    "verify_plan",
     "verify_bundle",
 )
 
@@ -338,6 +339,46 @@ def _validate_plan_manifest(
                 raise ReleaseArtifactError(f"cargo-dist target mismatch: {name}")
         typed[name] = entry
     return tuple(sorted(names)), typed
+
+
+def verify_plan(
+    path: Path,
+    *,
+    tag: str,
+    version: str,
+    target: str,
+    runner: str,
+) -> None:
+    """Verify the full asset plan and one native, non-container build route."""
+    manifest = _read_json_object(path)
+    names, _ = _validate_plan_manifest(manifest, tag=tag, version=version)
+    for package in PACKAGES:
+        if release_archive_name_for(package, target) not in names:
+            raise ReleaseArtifactError(f"cargo-dist plan omits {package} for {target}")
+
+    matrix: object = manifest
+    for key in ("ci", "github", "artifacts_matrix", "include"):
+        if not isinstance(matrix, dict) or key not in matrix:
+            raise ReleaseArtifactError("cargo-dist plan has no GitHub artifact matrix")
+        matrix = matrix[key]
+    if not isinstance(matrix, list) or any(not isinstance(row, dict) for row in matrix):
+        raise ReleaseArtifactError("cargo-dist artifact matrix must contain job objects")
+    matches = [
+        row for row in matrix
+        if isinstance(row.get("targets"), list) and target in row["targets"]
+    ]
+    if len(matches) != 1:
+        raise ReleaseArtifactError(f"cargo-dist plan must route {target} exactly once")
+    job = matches[0]
+    if (
+        job.get("targets") != [target]
+        or job.get("runner") != runner
+        or job.get("host") != target
+        or job.get("container") is not None
+    ):
+        raise ReleaseArtifactError(
+            f"cargo-dist plan must build {target} natively on {runner} without a container"
+        )
 
 
 def _staged_plan_asset_names(root: Path, *, version: str) -> tuple[str, ...]:
@@ -764,6 +805,13 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     commands = parser.add_subparsers(dest="command", required=True)
 
+    plan = commands.add_parser("verify-plan")
+    plan.add_argument("path", type=Path)
+    plan.add_argument("--tag", required=True)
+    plan.add_argument("--version", required=True)
+    plan.add_argument("--target", required=True)
+    plan.add_argument("--runner", required=True)
+
     prepare = commands.add_parser("prepare-global")
     prepare.add_argument("local_producers", type=Path)
     prepare.add_argument("verified_archives", type=Path)
@@ -792,7 +840,15 @@ def _build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
-    if args.command == "prepare-global":
+    if args.command == "verify-plan":
+        verify_plan(
+            args.path,
+            tag=args.tag,
+            version=args.version,
+            target=args.target,
+            runner=args.runner,
+        )
+    elif args.command == "prepare-global":
         prepare_global_inputs(
             args.local_producers,
             args.verified_archives,

--- a/scripts/release_process.py
+++ b/scripts/release_process.py
@@ -60,6 +60,7 @@ def target_matches_host(target: str) -> bool:
     admitted_targets = {
         ("darwin", "aarch64", None): "aarch64-apple-darwin",
         ("darwin", "x86_64", None): "x86_64-apple-darwin",
+        ("linux", "aarch64", "gnu"): "aarch64-unknown-linux-gnu",
         ("linux", "x86_64", "gnu"): "x86_64-unknown-linux-gnu",
         ("windows", "x86_64", None): "x86_64-pc-windows-msvc",
     }

--- a/scripts/test_artifact_profile_recipe.py
+++ b/scripts/test_artifact_profile_recipe.py
@@ -382,7 +382,7 @@ class ArtifactProfileRecipeTests(unittest.TestCase):
             recipe.feature_argument,
         )
         with self.assertRaisesRegex(RuntimeError, "does not declare host target"):
-            cargo_host_build_args(recipe, "aarch64-unknown-linux-gnu")
+            cargo_host_build_args(recipe, "aarch64-unknown-linux-musl")
 
     def test_host_build_cli_uses_the_detected_rust_target(self) -> None:
         argv = [

--- a/scripts/test_cli_installation_contract.py
+++ b/scripts/test_cli_installation_contract.py
@@ -30,6 +30,7 @@ class CliInstallationContractTests(unittest.TestCase):
             {artifact.target for artifact in artifacts},
             {
                 "aarch64-apple-darwin",
+                "aarch64-unknown-linux-gnu",
                 "x86_64-apple-darwin",
                 "x86_64-pc-windows-msvc",
                 "x86_64-unknown-linux-gnu",
@@ -108,7 +109,7 @@ class CliInstallationContractTests(unittest.TestCase):
     def test_dist_and_profile_target_sets_cannot_diverge(self) -> None:
         with self.mutated_repository(
             "dist-workspace.toml",
-            ', "x86_64-pc-windows-msvc"',
+            '    "x86_64-pc-windows-msvc",\n',
             "",
         ) as root:
             with self.assertRaisesRegex(

--- a/scripts/test_release_artifact_bundle.py
+++ b/scripts/test_release_artifact_bundle.py
@@ -24,6 +24,7 @@ VERSION = "0.8.0-alpha.4"
 TAG = f"v{VERSION}"
 TARGETS = (
     "aarch64-apple-darwin",
+    "aarch64-unknown-linux-gnu",
     "x86_64-apple-darwin",
     "x86_64-pc-windows-msvc",
     "x86_64-unknown-linux-gnu",

--- a/scripts/test_release_artifact_bundle.py
+++ b/scripts/test_release_artifact_bundle.py
@@ -232,6 +232,7 @@ class ReleaseArtifactBundleTests(unittest.TestCase):
                 "assemble_bundle",
                 "harden_installers",
                 "prepare_global_inputs",
+                "verify_plan",
                 "verify_bundle",
             },
         )
@@ -284,6 +285,67 @@ class ReleaseArtifactBundleTests(unittest.TestCase):
             self.assertTrue(
                 all(Path(call.args[0]).parent == verified for call in copyfile.call_args_list)
             )
+
+    def test_verify_plan_accepts_native_linux_routes(self) -> None:
+        for target, runner in (
+            ("x86_64-unknown-linux-gnu", "ubuntu-24.04"),
+            ("aarch64-unknown-linux-gnu", "ubuntu-24.04-arm"),
+        ):
+            with self.subTest(target=target), tempfile.TemporaryDirectory() as temp_dir:
+                plan = plan_document()
+                plan["ci"] = {"github": {"artifacts_matrix": {"include": [
+                    {"targets": [target], "runner": runner, "host": target},
+                ]}}}
+                path = Path(temp_dir) / "plan.json"
+                path.write_text(json.dumps(plan), encoding="utf-8")
+                self.assertEqual(bundle.main([
+                    "verify-plan", str(path), "--tag", TAG, "--version", VERSION,
+                    "--target", target, "--runner", runner,
+                ]), 0)
+
+    def test_verify_plan_rejects_missing_or_non_native_routes(self) -> None:
+        target = "aarch64-unknown-linux-gnu"
+        native = {"targets": [target], "runner": "ubuntu-24.04-arm", "host": target}
+        for label, rows in (
+            ("missing", []),
+            ("duplicate", [native, native]),
+            ("wrong-runner", [{**native, "runner": "ubuntu-24.04"}]),
+            ("cross-host", [{**native, "host": "x86_64-unknown-linux-gnu"}]),
+            ("container", [{**native, "container": {"image": "custom"}}]),
+            ("wrong-target", [{**native, "targets": ["x86_64-unknown-linux-gnu"]}]),
+            ("combined-targets", [{**native, "targets": [target, "x86_64-unknown-linux-gnu"]}]),
+        ):
+            with self.subTest(case=label), tempfile.TemporaryDirectory() as temp_dir:
+                plan = plan_document()
+                plan["ci"] = {"github": {"artifacts_matrix": {"include": rows}}}
+                path = Path(temp_dir) / "plan.json"
+                path.write_text(json.dumps(plan), encoding="utf-8")
+                with self.assertRaises(bundle.ReleaseArtifactError):
+                    bundle.verify_plan(
+                        path, tag=TAG, version=VERSION, target=target,
+                        runner="ubuntu-24.04-arm",
+                    )
+
+    def test_verify_plan_requires_candidate_archives_and_full_asset_contract(self) -> None:
+        target = "aarch64-unknown-linux-gnu"
+        omitted_sets = (
+            {archive_name("merman-lsp", target)},
+            {name for name in release_names() if target in name},
+            {"merman-cli-installer.sh"},
+        )
+        for omitted in omitted_sets:
+            with self.subTest(omitted=omitted), tempfile.TemporaryDirectory() as temp_dir:
+                plan = plan_document(release_names() - omitted)
+                plan["ci"] = {"github": {"artifacts_matrix": {"include": [
+                    {"targets": [target], "runner": "ubuntu-24.04-arm", "host": target},
+                ]}}}
+                path = Path(temp_dir) / "plan.json"
+                path.write_text(json.dumps(plan), encoding="utf-8")
+                with self.assertRaises(bundle.ReleaseArtifactError):
+                    bundle.verify_plan(
+                        path, tag=TAG, version=VERSION, target=target,
+                        runner="ubuntu-24.04-arm",
+                    )
 
     def test_prepare_rejects_missing_verified_archive(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/test_release_process.py
+++ b/scripts/test_release_process.py
@@ -71,7 +71,7 @@ class PublicContractTests(unittest.TestCase):
                 release_process.target_matches_host("x86_64-pc-windows-gnu")
             )
 
-    def test_only_admitted_architectures_match(self) -> None:
+    def test_linux_arm64_gnu_is_admitted(self) -> None:
         with (
             mock.patch.object(release_process.platform, "system", return_value="Linux"),
             mock.patch.object(release_process.platform, "machine", return_value="aarch64"),
@@ -81,8 +81,28 @@ class PublicContractTests(unittest.TestCase):
                 return_value=("glibc", "2.39"),
             ),
         ):
-            self.assertFalse(
+            self.assertTrue(
                 release_process.target_matches_host("aarch64-unknown-linux-gnu")
+            )
+            self.assertFalse(
+                release_process.target_matches_host("aarch64-unknown-linux-musl")
+            )
+            self.assertFalse(
+                release_process.target_matches_host("x86_64-unknown-linux-gnu")
+            )
+
+    def test_only_admitted_architectures_match(self) -> None:
+        with (
+            mock.patch.object(release_process.platform, "system", return_value="Linux"),
+            mock.patch.object(release_process.platform, "machine", return_value="riscv64"),
+            mock.patch.object(
+                release_process.platform,
+                "libc_ver",
+                return_value=("glibc", "2.39"),
+            ),
+        ):
+            self.assertFalse(
+                release_process.target_matches_host("riscv64gc-unknown-linux-gnu")
             )
 
 

--- a/scripts/test_release_workflow_security.py
+++ b/scripts/test_release_workflow_security.py
@@ -365,6 +365,33 @@ jobs:
             text,
         )
 
+    def test_release_preflight_executes_linux_archives_before_publication(self) -> None:
+        text = read(WORKFLOW_ROOT / "release-preflight.yml")
+        native = workflow_job(text, "cli-and-lsp-archives")
+        for capability in WRITE_CAPABILITIES:
+            self.assertNotIn(capability, native)
+        self.assertNotIn("environment:", native)
+        self.assertNotIn("continue-on-error:", native)
+        self.assertIn("ref: ${{ needs.validate-inputs.outputs.source_sha }}", native)
+        for target, runner in (
+            ("x86_64-unknown-linux-gnu", "ubuntu-24.04"),
+            ("aarch64-unknown-linux-gnu", "ubuntu-24.04-arm"),
+        ):
+            self.assertIn(f"- target: {target}\n            runner: {runner}", native)
+        self.assertIn("runs-on: ${{ matrix.runner }}", native)
+        self.assertIn('dist plan "--tag=$RELEASE_TAG" --output-format=json', native)
+        self.assertIn("scripts/release_artifact_bundle.py verify-plan", native)
+        self.assertIn('--runner "$NATIVE_RUNNER"', native)
+        self.assertIn('--target="$TARGET"', native)
+        self.assertIn("--artifacts=local", native)
+        self.assertLess(native.index("verify-plan"), native.index("dist build"))
+        self.assertIn("scripts/verify_cli_release_archive.py", native)
+        self.assertIn("scripts/verify_lsp_release_archive.py", native)
+        self.assertEqual(native.count("--execute"), 2)
+        self.assertIn("if-no-files-found: error", native)
+        self.assertNotIn("dist host", native)
+        self.assertNotIn("dist build", workflow_job(text, "versions-and-packages"))
+
     def test_npm_publish_provenance_cannot_be_disabled_by_repository_config(self) -> None:
         paths = [
             ROOT / ".npmrc",


### PR DESCRIPTION
## Summary

Adds `aarch64-unknown-linux-gnu` to the published `merman-cli` and `merman-lsp` release
targets, so every tagged release produces Linux ARM64 archives alongside the existing four.
macOS ARM64 was already published; Linux ARM64 was the missing arm64 binary.

The target is added atomically across cargo-dist, the artifact profiles, the host-execution
allowlist, and both verification matrices, per
[`docs/release/CLI_TARGET_ADMISSION.md`](docs/release/CLI_TARGET_ADMISSION.md). No surface
advertises the target before its final archive executes on a native ARM64 runner.

## Changes

| Area | Change |
| --- | --- |
| `dist-workspace.toml` | Adds the triple and builds it on the native `ubuntu-24.04-arm` runner. The runner uses the table form of `github-custom-runners` with an explicit `host`, so dist resolves the build host directly instead of inferring it from the runner label. |
| `capabilities/artifact-profiles-v1.json` | `cli-analysis`, `cli-release`, and `lsp-stdio-release` declare the triple. CLI/LSP descriptor symmetry and the cargo-dist ↔ profile target-set equality checks keep holding. |
| `scripts/release_process.py` | Admits `("linux", "aarch64", "gnu")`, so the archive verifiers execute the candidate on a matching native host and still refuse musl and mismatched hosts. |
| `.github/workflows/release.yml` | `verify-release-archives-native` runs the CLI and LSP `--execute` archive smokes for the target on `ubuntu-24.04-arm`. |
| `.github/workflows/ci.yml` | `cli-artifact-profiles` builds `cli-analysis` and `cli-release` on `ubuntu-24.04-arm`. |
| `crates/merman-cli/Cargo.toml` | Unchanged. The generic `pkg-url`, `pkg-fmt`, and `bin-dir` cargo-binstall templates already resolve the new `.tar.xz` archive; only Windows needs an override. |
| Docs | New dated admission decision; the 2026-07-30 "remains unadmitted" record is kept and marked superseded. `docs/releasing/CLI.md` gains the target row and drops the "does not claim Linux ARM64" note. |
| Tests | `test_release_process`, `test_release_artifact_bundle`, `test_cli_installation_contract`, and `test_artifact_profile_recipe` now assert the five-target set and the new host admission. |

## Admission gates

The build and execution evidence comes from the same jobs that already prove the other four
targets, on native ARM64 runners — no cross-compilation, no emulation. The glibc floor is
argued by symmetry: `ubuntu-24.04-arm` is the ARM64 image of the same `ubuntu-24.04`
environment that defines the published `x86_64-unknown-linux-gnu` floor, so the two Linux
targets share one floor rather than introducing a second, weaker one. Any gate failure fails
the release closed through `release-verification-gate`.

## Scope

Windows ARM64 (`aarch64-pc-windows-msvc`) stays unadmitted — it needs its own runner, archive,
installer, and native execution evidence. The Node N-API platform packages
(`platforms/node/candidate-builds.json`) also still have no `linux-arm64-gnu` entry; that is a
separate distribution channel with its own admission and is untouched here.

## Verification

- `python3 -m unittest` over all 45 `scripts/test_*.py` modules: 558 tests, only 5 pre-existing
  errors that require a `cargo` binary unavailable in the dev environment
  (`test_release_surface_contract`, `test_verify_independent_crate_version_bumps`); both fail
  identically on unmodified `main`.
- `python3 -m unittest scripts.test_ci_plan scripts.test_release_workflow_security scripts.test_ci_workflow_android_emulator scripts.test_fuzz_config` — OK.
- `zizmor --min-severity high` on both changed workflows — no findings.
- `git diff --check` — clean.

Deferred to CI (no `cargo`/`dist`/`actionlint` locally):
`scripts/verify_artifact_dependency_closures.py --representative-targets` picks up one new
profile-target closure case per release profile, and `dist plan` is first exercised on a tag
because `pr-run-mode = "skip"`.
