### PR TITLE
fix(node): avoid retired apt repositories in GNU builds

### DIFF
--- a/platforms/node/Dockerfile.gnu
+++ b/platforms/node/Dockerfile.gnu
@@ -5,9 +5,13 @@ FROM ${RUST_IMAGE} AS rust-toolchain
 
 FROM ${NODE_IMAGE}
 
-RUN apt-get update \
-    && apt-get install --yes --no-install-recommends build-essential ca-certificates git pkg-config python3 \
-    && rm -rf /var/lib/apt/lists/*
+# The full Node image inherits these tools from buildpack-deps. Verify them
+# without refreshing the retired Bullseye package repositories.
+RUN set -eu; \
+    for tool in cc c++ make pkg-config python3 git; do \
+        command -v "$tool"; \
+    done; \
+    test -s /etc/ssl/certs/ca-certificates.crt
 
 COPY --from=rust-toolchain /usr/local/cargo /usr/local/cargo
 COPY --from=rust-toolchain /usr/local/rustup /usr/local/rustup

--- a/platforms/node/README.md
+++ b/platforms/node/README.md
@@ -85,6 +85,19 @@ npm run check:packages --prefix platforms/node
 benchmark contract with test transports. `check:packages` verifies the source manifests; native
 candidate assembly and installed-package smoke run in the target-specific release workflow.
 
+The Linux GNU builder uses the full Node Bullseye image to preserve the declared glibc 2.31
+floor. Its inherited `buildpack-deps` tools and CA bundle are checked during image assembly;
+the Dockerfile does not reinstall them from Bullseye's retired package repositories. Slim
+images are not interchangeable with this build image. After pulling the base images, the
+build steps can be verified without network access:
+
+```sh
+docker build --network=none --platform linux/amd64 --file platforms/node/Dockerfile.gnu --tag merman-node-gnu:check platforms/node
+```
+
+This keeps the existing compatibility builder usable; it does not restore security maintenance
+for Bullseye. A maintained replacement needs separate glibc-floor and native-package evidence.
+
 The package group is versioned and published in lockstep. See the [package surface
 guide](../../docs/release/PACKAGE_SURFACES.md) for the artifact, target, provenance, and release
 contract.


### PR DESCRIPTION
## Summary

Restore Linux GNU Node image builds after the Bullseye security repository metadata expired, while keeping the existing glibc 2.31 compatibility floor. The full Node image already contains the required tools and CA certificates, so image assembly can verify them without contacting the retired package repositories.

## What changed

- Replace redundant APT update/install with fail-fast checks for inherited build tools and the CA bundle.
- Document network-isolated image verification and the remaining legacy-builder maintenance risk.
- Keep release targets, feature recipes, glibc requirements, and CI gate policy unchanged.

## Verification

- [ ] `cargo fmt --all --check` — not applicable; no Rust or Cargo files changed.
- [x] Relevant tests ran: all 96 Node tests passed, and package-contract verification passed.
- [ ] Benchmark or report updated if this affects performance — not applicable; no performance claim.
- Reproduced the original `apt-get update` failure with the unchanged Dockerfile and CI image arguments.
- Built the corrected image with `--network=none` using both `node:24-bullseye` (CI) and `node:24.13.1-bullseye` (release). Both reported Rust 1.95.0 and glibc 2.31.
- `git diff --check` passed.
- Full N-API compilation and runtime smoke remain owned by this PR's CI.

## Performance / parity notes

- Benchmark or report: none required.
- Parity impact: none; renderer code and package capabilities are unchanged.
- Rollback risk: restoring the APT step reintroduces the expired-repository failure.

## Follow-ups

A maintained replacement for the legacy Bullseye builder needs separate glibc-floor and native-package evidence. This fix restores image assembly, not Bullseye security maintenance.

Related: #128
