### PR TITLE
perf(ascii): use FxHash for the graph module's maps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,6 +2349,7 @@ version = "0.8.0-alpha.6"
 dependencies = [
  "dugong",
  "merman-core",
+ "rustc-hash",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/THIRD_PARTY_LICENSES/rust-cargo-dependencies.json
+++ b/THIRD_PARTY_LICENSES/rust-cargo-dependencies.json
@@ -5,7 +5,7 @@
     "version": "0.9.1",
     "command_profile": "workspace-all-features-runtime",
     "offline": true,
-    "cargo_lock_sha256": "ae7cf8b44c86d3e3383eaddaea065d1feb430234734301e346163720130cf943",
+    "cargo_lock_sha256": "13703a41400a09cb9076292db2aefcccef37fc8e70ee0c76c29e8a165d10fa1c",
     "configuration_sha256": "50ee414d81334fe54e34465a8441d8ee5ec237518b06b3759c794056aa3e26a4"
   },
   "licenses": [

--- a/crates/merman-ascii/Cargo.toml
+++ b/crates/merman-ascii/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = { workspace = true, features = ["raw_value"] }
 thiserror.workspace = true
 unicode-segmentation.workspace = true
 unicode-width = { workspace = true, features = ["cjk"] }
+rustc-hash.workspace = true
 
 [dev-dependencies]
 merman-core = { workspace = true, features = ["test-support"] }

--- a/crates/merman-ascii/src/graph/adapter.rs
+++ b/crates/merman-ascii/src/graph/adapter.rs
@@ -20,7 +20,7 @@ use merman_core::diagrams::flowchart::{
     FlowEdgeMarker as CoreFlowEdgeMarker, FlowEdgeStroke as CoreFlowEdgeStroke,
     FlowEdgeVisibility as CoreFlowEdgeVisibility, FlowchartModel, FlowchartRenderContext,
 };
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::num::NonZeroUsize;
 
 const FLOW_PROJECTION_COPY_CHUNK_BYTES: usize = 8 * 1024;
@@ -346,15 +346,15 @@ impl<'a> FlowchartMembershipIndex<'a> {
         let construction_work = resources.checked_work_add(model.subgraphs.len(), member_count)?;
         resources.charge_layout_work(construction_work)?;
 
-        let mut parent_group_by_member = HashMap::new();
+        let mut parent_group_by_member = HashMap::default();
         parent_group_by_member
             .try_reserve(member_count)
             .map_err(|_| projection_allocation_failed())?;
-        let mut group_ids = HashSet::new();
+        let mut group_ids = HashSet::default();
         group_ids
             .try_reserve(model.subgraphs.len())
             .map_err(|_| projection_allocation_failed())?;
-        let mut canonical_slot_by_group_id = HashMap::new();
+        let mut canonical_slot_by_group_id = HashMap::default();
         canonical_slot_by_group_id
             .try_reserve(model.subgraphs.len())
             .map_err(|_| projection_allocation_failed())?;
@@ -386,7 +386,7 @@ impl<'a> FlowchartMembershipIndex<'a> {
                             .try_reserve_exact(subgraph.nodes.len())
                             .map_err(|_| projection_allocation_failed())?;
                         canonical_group_members.push(members);
-                        let mut member_ids = HashSet::new();
+                        let mut member_ids = HashSet::default();
                         member_ids
                             .try_reserve(subgraph.nodes.len())
                             .map_err(|_| projection_allocation_failed())?;
@@ -810,7 +810,7 @@ fn validate_supported_flowchart_model(
         }
     }
 
-    let mut node_ids = HashSet::new();
+    let mut node_ids = HashSet::default();
     node_ids
         .try_reserve(model.nodes.len())
         .map_err(|_| projection_allocation_failed())?;

--- a/crates/merman-ascii/src/graph/draw.rs
+++ b/crates/merman-ascii/src/graph/draw.rs
@@ -299,7 +299,7 @@ fn paint_graph_render_controlled(
         execution,
     )?;
     execution.checkpoint(merman_core::OperationPhase::Emit)?;
-    let mut route_cells = routing::RouteCells::new();
+    let mut route_cells = routing::RouteCells::default();
     route_cells
         .try_reserve(route_scene.planned_cell_count())
         .map_err(|_| AsciiError::AllocationFailed {

--- a/crates/merman-ascii/src/graph/layout/grid.rs
+++ b/crates/merman-ascii/src/graph/layout/grid.rs
@@ -10,7 +10,7 @@ use crate::graph::topology::GraphGroupTopology;
 use crate::operation::AsciiExecution;
 use crate::options::{GraphLayoutPolicy, TerminalWidthProfile};
 use crate::resource::{AsciiResourceLimitId, AsciiResourceLimitPhase, ResourceContext};
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::hash::Hash;
 
 mod rank;
@@ -778,7 +778,7 @@ fn minimum_node_grid_cells(node_count: usize, resources: &ResourceContext) -> Re
 }
 
 fn node_indices_by_id(graph: &AsciiGraph) -> Result<NodeIndexById<'_>> {
-    let mut index_by_id = HashMap::new();
+    let mut index_by_id = HashMap::default();
     try_reserve_hash_map(&mut index_by_id, graph.nodes.len())?;
     for (index, node) in graph.nodes.iter().enumerate() {
         index_by_id.insert(node.id.as_str(), index);
@@ -790,7 +790,7 @@ fn node_coords_by_id<'a>(
     graph: &'a AsciiGraph,
     placements: &[GridCoord],
 ) -> Result<HashMap<&'a str, GridCoord>> {
-    let mut coord_by_id = HashMap::new();
+    let mut coord_by_id = HashMap::default();
     try_reserve_hash_map(&mut coord_by_id, graph.nodes.len())?;
     for (node, coord) in graph.nodes.iter().zip(placements.iter().copied()) {
         coord_by_id.insert(node.id.as_str(), coord);
@@ -802,7 +802,7 @@ fn new_occupied_grid(
     node_count: usize,
     resources: &ResourceContext,
 ) -> Result<HashSet<(usize, usize)>> {
-    let mut occupied = HashSet::new();
+    let mut occupied = HashSet::default();
     try_reserve_hash_set(
         &mut occupied,
         minimum_node_grid_cells(node_count, resources)?,
@@ -811,13 +811,13 @@ fn new_occupied_grid(
 }
 
 fn new_level_positions(node_count: usize) -> Result<LevelPositions> {
-    let mut positions = HashMap::new();
+    let mut positions = HashMap::default();
     try_reserve_hash_map(&mut positions, node_count)?;
     Ok(positions)
 }
 
 fn new_axis_sizes(node_count: usize, resources: &ResourceContext) -> Result<AxisSizes> {
-    let mut axis_sizes = HashMap::new();
+    let mut axis_sizes = HashMap::default();
     let capacity = resources.checked_grid_mul(node_count, AXIS_ENTRIES_PER_NODE)?;
     try_reserve_hash_map(&mut axis_sizes, capacity)?;
     Ok(axis_sizes)
@@ -1105,8 +1105,8 @@ mod tests {
 
         let mut graph = AsciiGraph::new(GraphDirection::TopDown);
         let mut placements = Vec::with_capacity(NODE_COUNT);
-        let mut column_widths = AxisSizes::new();
-        let mut row_heights = AxisSizes::new();
+        let mut column_widths = AxisSizes::default();
+        let mut row_heights = AxisSizes::default();
         for index in 0..NODE_COUNT {
             let id = format!("node-{index}");
             graph.add_node(id.clone(), id);
@@ -1192,8 +1192,8 @@ mod tests {
                 direction,
                 edge,
                 &options,
-                &mut AxisSizes::new(),
-                &mut AxisSizes::new(),
+                &mut AxisSizes::default(),
+                &mut AxisSizes::default(),
                 &measured_resources,
             )
             .expect("unbounded label spacing should pass");
@@ -1208,8 +1208,8 @@ mod tests {
                 direction,
                 edge,
                 &options,
-                &mut AxisSizes::new(),
-                &mut AxisSizes::new(),
+                &mut AxisSizes::default(),
+                &mut AxisSizes::default(),
                 &exact_resources,
             )
             .expect("edge label spacing should pass at the exact work limit");
@@ -1219,8 +1219,8 @@ mod tests {
                 .with_limit(AsciiResourceLimitId::MaxLayoutWorkUnits, exact_work - 1)
                 .expect("layout work limit should be valid");
             let below_resources = ResourceContext::new(below_policy);
-            let mut column_widths = AxisSizes::new();
-            let mut row_heights = AxisSizes::new();
+            let mut column_widths = AxisSizes::default();
+            let mut row_heights = AxisSizes::default();
             let error = apply_test_edge_label_spacing(
                 direction,
                 edge,

--- a/crates/merman-ascii/src/graph/layout/grid/rank.rs
+++ b/crates/merman-ascii/src/graph/layout/grid/rank.rs
@@ -11,7 +11,7 @@ use dugong::graphlib::{Graph, GraphOptions, is_javascript_array_index};
 use dugong::{
     EdgeLabel, GraphLabel as DagreGraphLabel, NodeLabel, RankDir, WorkControl, WorkError,
 };
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 const GRID_UNITS_PER_RANK: usize = 4;
 
@@ -318,7 +318,7 @@ fn project_dagre_rank_levels(
         resources.checked_work_mul(endpoint_count, 4)?,
     )?;
     resources.charge_layout_work(projection_work)?;
-    let mut rank_by_id = HashMap::new();
+    let mut rank_by_id = HashMap::default();
     try_reserve_hash_map(&mut rank_by_id, plan.nodes.len())?;
     for (index, node) in plan.nodes.into_iter().enumerate() {
         checkpoint_layout(execution, index)?;
@@ -371,7 +371,7 @@ fn project_dagre_rank_levels(
     charge_sort_work(occupied_ranks.len(), resources)?;
     occupied_ranks.sort_unstable();
     occupied_ranks.dedup();
-    let mut dense_rank = HashMap::new();
+    let mut dense_rank = HashMap::default();
     try_reserve_hash_map(&mut dense_rank, occupied_ranks.len())?;
     for (index, rank) in occupied_ranks.into_iter().enumerate() {
         checkpoint_layout(execution, index)?;
@@ -722,7 +722,7 @@ fn find_non_cluster_child_anchor(
     let mut stack = Vec::new();
     try_reserve_vec(&mut stack, root_children.len())?;
     stack.extend(root_children.into_iter().rev());
-    let mut visited_groups = HashSet::new();
+    let mut visited_groups = HashSet::default();
     try_reserve_hash_set(&mut visited_groups, graph.groups.len())?;
     let mut reserve = None;
 
@@ -768,7 +768,7 @@ fn ordered_direct_group_children(
     resources.charge_layout_work(group.nodes.len())?;
     let mut children = Vec::new();
     try_reserve_vec(&mut children, group.nodes.len())?;
-    let mut seen = HashSet::new();
+    let mut seen = HashSet::default();
     try_reserve_hash_set(&mut seen, group.nodes.len())?;
     for (creation_index, member_id) in group.nodes.iter().enumerate() {
         let endpoint = match topology.endpoint_index(member_id) {
@@ -824,7 +824,7 @@ fn group_anchor_has_common_edge(
     // Pinned Mermaid snapshots both incident edge lists and compares the endpoint pairs after its
     // intentionally asymmetric `w` rewrite. A hash set preserves that behavior in linear work.
     resources.charge_layout_work(resources.checked_work_mul(graph.edges.len(), 2)?)?;
-    let mut candidate_edges = HashSet::new();
+    let mut candidate_edges = HashSet::default();
     try_reserve_hash_set(&mut candidate_edges, graph.edges.len())?;
     for edge in &graph.edges {
         if edge.from == candidate_id || edge.to == candidate_id {
@@ -885,7 +885,7 @@ fn rank_endpoint_id<'a>(
 }
 
 fn node_indices_by_id(graph: &AsciiGraph) -> Result<NodeIndexById<'_>> {
-    let mut index_by_id = HashMap::new();
+    let mut index_by_id = HashMap::default();
     try_reserve_hash_map(&mut index_by_id, graph.nodes.len())?;
     for (index, node) in graph.nodes.iter().enumerate() {
         index_by_id.insert(node.id.as_str(), index);

--- a/crates/merman-ascii/src/graph/layout/groups.rs
+++ b/crates/merman-ascii/src/graph/layout/groups.rs
@@ -5,7 +5,7 @@ use crate::error::Result;
 use crate::operation::AsciiExecution;
 use crate::options::GraphLayoutPolicy;
 use crate::resource::{AsciiResourceLimitId, ResourceContext};
-use std::collections::HashSet;
+use rustc_hash::FxHashSet as HashSet;
 
 mod bounds;
 mod direction;

--- a/crates/merman-ascii/src/graph/layout/groups/bounds.rs
+++ b/crates/merman-ascii/src/graph/layout/groups/bounds.rs
@@ -9,7 +9,8 @@ use crate::operation::AsciiExecution;
 use crate::options::{GraphLayoutPolicy, TerminalWidthProfile};
 use crate::resource::{AsciiResourceLimitId, AsciiResourceLimitPhase, ResourceContext};
 use merman_core::OperationPhase;
-use std::collections::{HashMap, HashSet, VecDeque};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use std::collections::VecDeque;
 
 const EMPTY_GROUP_RANK_GAP: usize = 2;
 
@@ -619,7 +620,7 @@ fn leaf_group_rank_span(
         return Ok(0);
     }
     resources.charge_layout_work(leaf_group_levels.len())?;
-    let mut size_by_level = HashMap::<usize, usize>::new();
+    let mut size_by_level = HashMap::<usize, usize>::default();
     size_by_level
         .try_reserve(leaf_group_levels.len())
         .map_err(|_| AsciiError::AllocationFailed {
@@ -850,7 +851,7 @@ fn raw_group_bounds(
         return Ok(None);
     }
 
-    let mut layout_bounds_by_id = HashMap::new();
+    let mut layout_bounds_by_id = HashMap::default();
     layout_bounds_by_id
         .try_reserve(layouts.len())
         .map_err(|_| AsciiError::AllocationFailed {
@@ -869,13 +870,13 @@ fn raw_group_bounds(
                 bottom: isize::try_from(bottom).map_err(|_| grid_overflow(resources))?,
             });
     }
-    let mut completed = HashMap::<usize, Option<RawBounds>>::new();
+    let mut completed = HashMap::<usize, Option<RawBounds>>::default();
     completed
         .try_reserve(graph.groups.len())
         .map_err(|_| AsciiError::AllocationFailed {
             phase: AsciiResourceLimitPhase::LayoutWork.as_str(),
         })?;
-    let mut visiting = HashSet::<usize>::new();
+    let mut visiting = HashSet::<usize>::default();
     visiting
         .try_reserve(graph.groups.len())
         .map_err(|_| AsciiError::AllocationFailed {

--- a/crates/merman-ascii/src/graph/layout/groups/direction.rs
+++ b/crates/merman-ascii/src/graph/layout/groups/direction.rs
@@ -73,7 +73,7 @@ fn flowchart_external_connections(
 fn include_group_endpoint_scope(
     topology: &GraphGroupTopology<'_>,
     endpoint: &str,
-    scope: &mut std::collections::HashSet<usize>,
+    scope: &mut rustc_hash::FxHashSet<usize>,
 ) -> Result<()> {
     let Some(GraphEndpointIndex::Group(group_index)) = topology.endpoint_index(endpoint) else {
         return Ok(());

--- a/crates/merman-ascii/src/graph/layout/groups/members.rs
+++ b/crates/merman-ascii/src/graph/layout/groups/members.rs
@@ -7,7 +7,7 @@ use crate::graph::topology::{GraphEndpointIndex, GraphGroupTopology};
 use crate::options::GraphLayoutPolicy;
 use crate::resource::{AsciiResourceLimitId, ResourceContext};
 use crate::safe_text::try_clone_layout_text;
-use std::collections::HashSet;
+use rustc_hash::FxHashSet as HashSet;
 
 pub(super) fn graph_endpoint_group_ids<'a>(
     graph: &'a AsciiGraph,
@@ -17,13 +17,13 @@ pub(super) fn graph_endpoint_group_ids<'a>(
     resources
         .charge_layout_work(resources.checked_work_add(graph.groups.len(), endpoint_count)?)?;
 
-    let mut group_ids = HashSet::new();
+    let mut group_ids = HashSet::default();
     group_ids
         .try_reserve(graph.groups.len())
         .map_err(|_| layout_work_allocation_failed())?;
     group_ids.extend(graph.groups.iter().map(|group| group.id.as_str()));
 
-    let mut endpoint_group_ids = HashSet::new();
+    let mut endpoint_group_ids = HashSet::default();
     endpoint_group_ids
         .try_reserve(graph.groups.len().min(endpoint_count))
         .map_err(|_| layout_work_allocation_failed())?;

--- a/crates/merman-ascii/src/graph/layout/groups/placement/local_direction.rs
+++ b/crates/merman-ascii/src/graph/layout/groups/placement/local_direction.rs
@@ -15,7 +15,7 @@ use crate::graph::topology::{GraphEndpointIndex, GraphGroupTopology};
 use crate::operation::AsciiExecution;
 use crate::resource::{AsciiResourceLimitId, ResourceContext};
 use merman_core::OperationPhase;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap as HashMap;
 
 pub(super) fn apply_subgraph_direction_overrides(
     context: &GroupPlacementContext<'_, '_>,
@@ -128,7 +128,7 @@ fn build_group_override_graph(
     let mut override_graph = AsciiGraph::new_for_diagram(graph.diagram_type(), direction);
     override_graph.root_policy = graph.root_policy;
 
-    let mut endpoint_to_member = HashMap::<GraphEndpointIndex, usize>::new();
+    let mut endpoint_to_member = HashMap::<GraphEndpointIndex, usize>::default();
     resources.charge_layout_work(members.len())?;
     let member_node_count = members.iter().try_fold(0usize, |total, member| {
         resources.checked_work_add(total, member.node_indices.len())
@@ -319,7 +319,7 @@ fn place_group_nodes(
     let ranked = super::super::super::grid::place_ranked_grid_nodes_without_group_adjustments(
         graph, direction, resources, execution,
     )?;
-    let mut placements = HashMap::new();
+    let mut placements = HashMap::default();
     placements.try_reserve(ranked.len()).map_err(|_| {
         crate::error::AsciiError::AllocationFailed {
             phase: crate::resource::AsciiResourceLimitPhase::LayoutWork.as_str(),

--- a/crates/merman-ascii/src/graph/layout/groups/side_constraints.rs
+++ b/crates/merman-ascii/src/graph/layout/groups/side_constraints.rs
@@ -8,7 +8,7 @@ use crate::graph::{
 use crate::options::GraphLayoutPolicy;
 use crate::resource::{AsciiResourceLimitId, ResourceContext};
 use crate::safe_text::try_clone_layout_text;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap as HashMap;
 
 pub(super) fn reserve_group_left_constraint_space(
     graph: &AsciiGraph,

--- a/crates/merman-ascii/src/graph/routing/cell.rs
+++ b/crates/merman-ascii/src/graph/routing/cell.rs
@@ -4,7 +4,7 @@ use super::super::surface::GraphSurface;
 use crate::canvas::CanvasColor;
 use crate::color::AsciiColorRole;
 use crate::error::{AsciiError, Result};
-use std::collections::HashMap;
+use rustc_hash::FxHashMap as HashMap;
 
 type Canvas<'surface> = dyn GraphSurface + 'surface;
 
@@ -282,7 +282,7 @@ mod tests {
     #[test]
     fn mixed_stroke_junction_is_rejected_without_overwriting_the_existing_route() {
         let mut canvas = RawCanvas::with_width_profile(1, 1, TerminalWidthProfile::Unicode);
-        let mut route_cells = RouteCells::new();
+        let mut route_cells = RouteCells::default();
         set_route_cell_with_paint(
             &mut canvas,
             &mut route_cells,

--- a/crates/merman-ascii/src/graph/routing/occupancy.rs
+++ b/crates/merman-ascii/src/graph/routing/occupancy.rs
@@ -11,7 +11,8 @@ use crate::error::{AsciiError, Result};
 use crate::operation::AsciiExecution;
 use crate::resource::{AsciiResourceLimitId, ResourceContext};
 use merman_core::{OperationControl, OperationPhase};
-use std::collections::{HashMap, HashSet, hash_map::Entry};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use std::collections::hash_map::Entry;
 
 mod labels;
 mod marker;
@@ -306,11 +307,11 @@ impl<'layout> SceneOccupancy<'layout> {
         }
 
         let mut scene = Self {
-            route_cells: HashMap::new(),
+            route_cells: HashMap::default(),
             route_bounds: Vec::new(),
-            terminal_claims: HashMap::new(),
-            markers: HashMap::new(),
-            labels: HashSet::new(),
+            terminal_claims: HashMap::default(),
+            markers: HashMap::default(),
+            labels: HashSet::default(),
             protected: Vec::new(),
             label_lane_radius,
             control: execution.cloned_control(),

--- a/crates/merman-ascii/src/graph/routing/path.rs
+++ b/crates/merman-ascii/src/graph/routing/path.rs
@@ -4,8 +4,9 @@ use crate::operation::AsciiExecution;
 use crate::resource::AsciiResourceLimitPhase;
 use crate::resource::ResourceContext;
 use merman_core::OperationPhase;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::cmp::Ordering;
-use std::collections::{BinaryHeap, HashMap, HashSet};
+use std::collections::BinaryHeap;
 use std::hash::Hash;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -282,8 +283,8 @@ fn find_grid_path(
     let max_y = resources.checked_grid_add(max_y, 6)?;
     let occupied = occupied_grid_cells(layouts, resources, execution)?;
     let mut open = BinaryHeap::new();
-    let mut cost_so_far = HashMap::new();
-    let mut came_from = HashMap::<GridCoord, GridCoord>::new();
+    let mut cost_so_far = HashMap::default();
+    let mut came_from = HashMap::<GridCoord, GridCoord>::default();
     open.try_reserve(1)
         .map_err(|_| layout_allocation_failed())?;
     try_reserve_hash_map(&mut cost_so_far, 1)?;
@@ -392,7 +393,7 @@ fn occupied_grid_cells(
 ) -> Result<HashSet<GridCoord>> {
     const NODE_GRID_FOOTPRINT: usize = 9;
     let capacity = resources.checked_work_mul(layouts.len(), NODE_GRID_FOOTPRINT)?;
-    let mut occupied = HashSet::new();
+    let mut occupied = HashSet::default();
     occupied
         .try_reserve(capacity)
         .map_err(|_| layout_allocation_failed())?;

--- a/crates/merman-ascii/src/graph/routing/plan.rs
+++ b/crates/merman-ascii/src/graph/routing/plan.rs
@@ -9,7 +9,7 @@ use crate::canvas::CanvasColor;
 use crate::color::{AsciiColorRole, AsciiRgb};
 use crate::error::{AsciiError, Result};
 use crate::resource::{AsciiResourceLimitPhase, ResourceContext};
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 mod boundary;
 mod candidates;
@@ -154,7 +154,7 @@ impl RoutePlan {
             anchors,
             start_marker: GraphEdgeMarker::Open,
             end_marker: GraphEdgeMarker::Open,
-            suppressed_cells: HashSet::new(),
+            suppressed_cells: HashSet::default(),
             min_canvas_extent: CanvasExtent::default(),
         }
     }
@@ -326,7 +326,7 @@ impl RoutePlan {
         let primary_candidate = self.terminal_candidate(endpoint, diagram_type)?;
         let primary = self.cells[primary_candidate.cell.0];
 
-        let mut coordinate_index = HashMap::<CanvasCoord, Option<PlannedCellId>>::new();
+        let mut coordinate_index = HashMap::<CanvasCoord, Option<PlannedCellId>>::default();
         coordinate_index
             .try_reserve(self.cells.len())
             .map_err(|_| AsciiError::AllocationFailed {
@@ -541,7 +541,7 @@ impl RoutePlan {
             anchors,
             start_marker: GraphEdgeMarker::Open,
             end_marker: GraphEdgeMarker::Open,
-            suppressed_cells: HashSet::new(),
+            suppressed_cells: HashSet::default(),
             min_canvas_extent: CanvasExtent { width, height },
         }
     }

--- a/crates/merman-ascii/src/graph/routing/tests.rs
+++ b/crates/merman-ascii/src/graph/routing/tests.rs
@@ -32,7 +32,7 @@ fn edge_style_is_applied_to_route_plan_cells_and_labels() {
     );
 
     let mut canvas = RawCanvas::with_width_profile(5, 1, TerminalWidthProfile::Unicode);
-    let mut route_cells = RouteCells::new();
+    let mut route_cells = RouteCells::default();
     let mut drawing = RouteDrawing::new(&mut canvas, &mut route_cells);
     let plan = plan.with_style(GraphEdgeStyle {
         line: Some(line),
@@ -88,7 +88,7 @@ fn one_long_route_body_observes_cancellation_between_cells() {
         labels: RoutedLabelCatalog::for_test(Vec::new()),
     };
     let mut canvas = RawCanvas::with_width_profile(ROUTE_LEN, 1, TerminalWidthProfile::Unicode);
-    let mut route_cells = RouteCells::new();
+    let mut route_cells = RouteCells::default();
     let policy = AsciiResourcePolicy::for_profile(ResourceProfile::UnboundedForTrustedInput);
     let control = OperationControl::new();
     // The route-level checkpoint and first cell checkpoint succeed. The next fixed-cadence cell
@@ -151,7 +151,7 @@ fn edge_arrow_style_falls_back_to_line_style() {
     );
 
     let mut canvas = RawCanvas::with_width_profile(1, 1, TerminalWidthProfile::Unicode);
-    let mut route_cells = RouteCells::new();
+    let mut route_cells = RouteCells::default();
     let mut drawing = RouteDrawing::new(&mut canvas, &mut route_cells);
 
     paint_route_plan(

--- a/crates/merman-ascii/src/graph/routing/tests/markers.rs
+++ b/crates/merman-ascii/src/graph/routing/tests/markers.rs
@@ -48,7 +48,7 @@ fn relocated_marker_suppresses_only_its_route_local_terminal_tail() {
     .unwrap();
 
     let mut local_canvas = RawCanvas::with_width_profile(3, 1, TerminalWidthProfile::Unicode);
-    let mut local_cells = RouteCells::new();
+    let mut local_cells = RouteCells::default();
     paint_route_plan(
         &mut RouteDrawing::new(&mut local_canvas, &mut local_cells),
         &routes[1].plan,
@@ -80,7 +80,7 @@ fn relocated_marker_suppresses_only_its_route_local_terminal_tail() {
     );
 
     let mut shared_canvas = RawCanvas::with_width_profile(3, 1, TerminalWidthProfile::Unicode);
-    let mut shared_cells = RouteCells::new();
+    let mut shared_cells = RouteCells::default();
     let mut drawing = RouteDrawing::new(&mut shared_canvas, &mut shared_cells);
     for route in &routes {
         route.paint_body(&mut drawing).unwrap();
@@ -126,7 +126,7 @@ fn relocated_marker_suppresses_a_three_cell_mixed_body_tail() {
         .unwrap();
 
     let mut canvas = RawCanvas::with_width_profile(5, 1, TerminalWidthProfile::Unicode);
-    let mut route_cells = RouteCells::new();
+    let mut route_cells = RouteCells::default();
     paint_route_plan(&mut RouteDrawing::new(&mut canvas, &mut route_cells), &plan).unwrap();
     assert_eq!(
         candidate.terminal_tail(),

--- a/crates/merman-ascii/src/graph/style.rs
+++ b/crates/merman-ascii/src/graph/style.rs
@@ -6,7 +6,7 @@ use crate::resource::{AsciiResourceLimitPhase, ResourceContext};
 use crate::style_color::{parse_border_color, parse_css_color};
 use merman_core::OperationPhase;
 use merman_core::diagrams::flowchart::{FlowchartModel, FlowchartRenderContext};
-use std::collections::HashMap;
+use rustc_hash::FxHashMap as HashMap;
 
 #[derive(Clone, Copy)]
 struct StyleTargets {
@@ -140,7 +140,7 @@ impl FlowchartStylePlan {
         nodes
             .try_reserve_exact(model.nodes.len())
             .map_err(|_| style_allocation_failed())?;
-        let mut direct_group_overlays = HashMap::new();
+        let mut direct_group_overlays = HashMap::default();
         if render_context.is_none() {
             let overlay_capacity = model.nodes.len().min(model.subgraphs.len());
             resources.charge_layout_work(overlay_capacity)?;

--- a/crates/merman-ascii/src/graph/topology.rs
+++ b/crates/merman-ascii/src/graph/topology.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::hash::Hash;
 
 use super::model::AsciiGraph;
@@ -32,21 +32,21 @@ impl<'a> GraphGroupTopology<'a> {
         )?;
         resources.charge_layout_work(construction_work)?;
 
-        let mut group_index_by_id = HashMap::new();
+        let mut group_index_by_id = HashMap::default();
         try_reserve_hash_map(&mut group_index_by_id, graph.groups.len())?;
         for (index, group) in graph.groups.iter().enumerate() {
             group_index_by_id.insert(group.id.as_str(), index);
         }
 
-        let mut node_index_by_id = HashMap::new();
+        let mut node_index_by_id = HashMap::default();
         try_reserve_hash_map(&mut node_index_by_id, graph.nodes.len())?;
         for (index, node) in graph.nodes.iter().enumerate() {
             node_index_by_id.insert(node.id.as_str(), index);
         }
 
-        let mut parent_index_by_group = HashMap::new();
+        let mut parent_index_by_group = HashMap::default();
         try_reserve_hash_map(&mut parent_index_by_group, graph.groups.len())?;
-        let mut direct_group_index_by_node = HashMap::new();
+        let mut direct_group_index_by_node = HashMap::default();
         try_reserve_hash_map(&mut direct_group_index_by_node, graph.nodes.len())?;
 
         for (group_index, group) in graph.groups.iter().enumerate() {
@@ -99,8 +99,8 @@ impl<'a> GraphGroupTopology<'a> {
         group_index: usize,
         resources: &mut ResourceContext,
     ) -> Result<Vec<usize>> {
-        let mut indices = HashSet::new();
-        let mut visited_groups = HashSet::new();
+        let mut indices = HashSet::default();
+        let mut visited_groups = HashSet::default();
         let mut stack = Vec::new();
         push_group_frame(&mut stack, group_index, 1, resources)?;
 
@@ -147,7 +147,7 @@ impl<'a> GraphGroupTopology<'a> {
         endpoint: &str,
         resources: &mut ResourceContext,
     ) -> Result<HashSet<usize>> {
-        let mut groups = HashSet::new();
+        let mut groups = HashSet::default();
         let mut stack = Vec::new();
         // A group endpoint is a compound node in its parent's scope; the group does not contain
         // itself. Nodes and groups both follow the same first-parent topology used by layout.
@@ -361,6 +361,6 @@ mod tests {
             .groups_containing_endpoint("child", &mut resources)
             .expect("group endpoint scope should be bounded");
 
-        assert_eq!(containing, HashSet::from([1]));
+        assert_eq!(containing, HashSet::from_iter([1]));
     }
 }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1030,6 +1030,7 @@ version = "0.8.0-alpha.6"
 dependencies = [
  "dugong",
  "merman-core",
+ "rustc-hash",
  "serde",
  "serde_json",
  "thiserror 2.0.19",

--- a/platforms/android/THIRD_PARTY_LICENSES/rust-cargo-dependencies.json
+++ b/platforms/android/THIRD_PARTY_LICENSES/rust-cargo-dependencies.json
@@ -54,7 +54,7 @@
     "version": "0.9.1",
     "command_profile": "artifact-profile-target-union",
     "offline": true,
-    "cargo_lock_sha256": "ae7cf8b44c86d3e3383eaddaea065d1feb430234734301e346163720130cf943",
+    "cargo_lock_sha256": "13703a41400a09cb9076292db2aefcccef37fc8e70ee0c76c29e8a165d10fa1c",
     "configuration_sha256": "50ee414d81334fe54e34465a8441d8ee5ec237518b06b3759c794056aa3e26a4",
     "artifact_bundle_sha256": "43d4943b94b5966eef594b0374c626b39163a2e72026f4b3f178255870d77c02"
   },

--- a/platforms/android/src/main/resources/META-INF/THIRD_PARTY_LICENSES/rust-cargo-dependencies.json
+++ b/platforms/android/src/main/resources/META-INF/THIRD_PARTY_LICENSES/rust-cargo-dependencies.json
@@ -54,7 +54,7 @@
     "version": "0.9.1",
     "command_profile": "artifact-profile-target-union",
     "offline": true,
-    "cargo_lock_sha256": "ae7cf8b44c86d3e3383eaddaea065d1feb430234734301e346163720130cf943",
+    "cargo_lock_sha256": "13703a41400a09cb9076292db2aefcccef37fc8e70ee0c76c29e8a165d10fa1c",
     "configuration_sha256": "50ee414d81334fe54e34465a8441d8ee5ec237518b06b3759c794056aa3e26a4",
     "artifact_bundle_sha256": "43d4943b94b5966eef594b0374c626b39163a2e72026f4b3f178255870d77c02"
   },

--- a/platforms/apple/THIRD_PARTY_LICENSES/rust-cargo-dependencies.json
+++ b/platforms/apple/THIRD_PARTY_LICENSES/rust-cargo-dependencies.json
@@ -73,7 +73,7 @@
     "version": "0.9.1",
     "command_profile": "artifact-profile-target-union",
     "offline": true,
-    "cargo_lock_sha256": "ae7cf8b44c86d3e3383eaddaea065d1feb430234734301e346163720130cf943",
+    "cargo_lock_sha256": "13703a41400a09cb9076292db2aefcccef37fc8e70ee0c76c29e8a165d10fa1c",
     "configuration_sha256": "50ee414d81334fe54e34465a8441d8ee5ec237518b06b3759c794056aa3e26a4",
     "artifact_bundle_sha256": "37bb31fbf2db27d56c5a2a18b2d484143fc96bab7c9689efe6ebd95bde59b28c"
   },

--- a/platforms/flutter/THIRD_PARTY_LICENSES/rust-cargo-dependencies.json
+++ b/platforms/flutter/THIRD_PARTY_LICENSES/rust-cargo-dependencies.json
@@ -175,7 +175,7 @@
     "version": "0.9.1",
     "command_profile": "artifact-profile-target-union",
     "offline": true,
-    "cargo_lock_sha256": "ae7cf8b44c86d3e3383eaddaea065d1feb430234734301e346163720130cf943",
+    "cargo_lock_sha256": "13703a41400a09cb9076292db2aefcccef37fc8e70ee0c76c29e8a165d10fa1c",
     "configuration_sha256": "50ee414d81334fe54e34465a8441d8ee5ec237518b06b3759c794056aa3e26a4",
     "artifact_bundle_sha256": "a8e26358b372a159cb52f7c7ba600510abd45f3dc678f84f66e3ee293a596f47"
   },

--- a/platforms/python/legal/rust-cargo-dependencies/aarch64-apple-darwin.json
+++ b/platforms/python/legal/rust-cargo-dependencies/aarch64-apple-darwin.json
@@ -55,7 +55,7 @@
     "version": "0.9.1",
     "command_profile": "artifact-profile-target",
     "offline": true,
-    "cargo_lock_sha256": "ae7cf8b44c86d3e3383eaddaea065d1feb430234734301e346163720130cf943",
+    "cargo_lock_sha256": "13703a41400a09cb9076292db2aefcccef37fc8e70ee0c76c29e8a165d10fa1c",
     "configuration_sha256": "50ee414d81334fe54e34465a8441d8ee5ec237518b06b3759c794056aa3e26a4",
     "artifact_bundle_sha256": "059315c305b1274945af934cfadcbb13ebb0add341357ec76da82efb2e901d90"
   },

--- a/platforms/python/legal/rust-cargo-dependencies/x86_64-pc-windows-msvc.json
+++ b/platforms/python/legal/rust-cargo-dependencies/x86_64-pc-windows-msvc.json
@@ -55,7 +55,7 @@
     "version": "0.9.1",
     "command_profile": "artifact-profile-target",
     "offline": true,
-    "cargo_lock_sha256": "ae7cf8b44c86d3e3383eaddaea065d1feb430234734301e346163720130cf943",
+    "cargo_lock_sha256": "13703a41400a09cb9076292db2aefcccef37fc8e70ee0c76c29e8a165d10fa1c",
     "configuration_sha256": "50ee414d81334fe54e34465a8441d8ee5ec237518b06b3759c794056aa3e26a4",
     "artifact_bundle_sha256": "6132778f9bad7b037d035b8d5da91bf34d7f80e154695abba3ba287941f60736"
   },

--- a/platforms/python/legal/rust-cargo-dependencies/x86_64-unknown-linux-gnu.json
+++ b/platforms/python/legal/rust-cargo-dependencies/x86_64-unknown-linux-gnu.json
@@ -55,7 +55,7 @@
     "version": "0.9.1",
     "command_profile": "artifact-profile-target",
     "offline": true,
-    "cargo_lock_sha256": "ae7cf8b44c86d3e3383eaddaea065d1feb430234734301e346163720130cf943",
+    "cargo_lock_sha256": "13703a41400a09cb9076292db2aefcccef37fc8e70ee0c76c29e8a165d10fa1c",
     "configuration_sha256": "50ee414d81334fe54e34465a8441d8ee5ec237518b06b3759c794056aa3e26a4",
     "artifact_bundle_sha256": "5a2edc547f30fc3d44c21c7b8f8a113f85d22abc13c59d9b3466062110ac982e"
   },

--- a/platforms/python/merman/THIRD_PARTY_LICENSES/rust-cargo-dependencies.json
+++ b/platforms/python/merman/THIRD_PARTY_LICENSES/rust-cargo-dependencies.json
@@ -63,7 +63,7 @@
     "version": "0.9.1",
     "command_profile": "artifact-profile-target-union",
     "offline": true,
-    "cargo_lock_sha256": "ae7cf8b44c86d3e3383eaddaea065d1feb430234734301e346163720130cf943",
+    "cargo_lock_sha256": "13703a41400a09cb9076292db2aefcccef37fc8e70ee0c76c29e8a165d10fa1c",
     "configuration_sha256": "50ee414d81334fe54e34465a8441d8ee5ec237518b06b3759c794056aa3e26a4",
     "artifact_bundle_sha256": "faa968e9eb96acadd4dcf8492f59ac264fd975be3685cc5ae236c98306c2754b"
   },

--- a/platforms/web/THIRD_PARTY_LICENSES/rust-cargo-dependencies.json
+++ b/platforms/web/THIRD_PARTY_LICENSES/rust-cargo-dependencies.json
@@ -5,7 +5,7 @@
     "version": "0.9.1",
     "command_profile": "workspace-all-features-runtime",
     "offline": true,
-    "cargo_lock_sha256": "ae7cf8b44c86d3e3383eaddaea065d1feb430234734301e346163720130cf943",
+    "cargo_lock_sha256": "13703a41400a09cb9076292db2aefcccef37fc8e70ee0c76c29e8a165d10fa1c",
     "configuration_sha256": "50ee414d81334fe54e34465a8441d8ee5ec237518b06b3759c794056aa3e26a4"
   },
   "licenses": [

--- a/platforms/web/legal/rust-cargo-dependencies/web-analysis.json
+++ b/platforms/web/legal/rust-cargo-dependencies/web-analysis.json
@@ -36,7 +36,7 @@
     "version": "0.9.1",
     "command_profile": "artifact-profile-runtime",
     "offline": true,
-    "cargo_lock_sha256": "ae7cf8b44c86d3e3383eaddaea065d1feb430234734301e346163720130cf943",
+    "cargo_lock_sha256": "13703a41400a09cb9076292db2aefcccef37fc8e70ee0c76c29e8a165d10fa1c",
     "configuration_sha256": "50ee414d81334fe54e34465a8441d8ee5ec237518b06b3759c794056aa3e26a4",
     "artifact_profile_sha256": "0938c4c85310fb3d012916ae15c9db49b116e4e488b2c0371f74f9d6f991a1ad"
   },

--- a/platforms/web/legal/rust-cargo-dependencies/web-ascii.json
+++ b/platforms/web/legal/rust-cargo-dependencies/web-ascii.json
@@ -36,7 +36,7 @@
     "version": "0.9.1",
     "command_profile": "artifact-profile-runtime",
     "offline": true,
-    "cargo_lock_sha256": "ae7cf8b44c86d3e3383eaddaea065d1feb430234734301e346163720130cf943",
+    "cargo_lock_sha256": "13703a41400a09cb9076292db2aefcccef37fc8e70ee0c76c29e8a165d10fa1c",
     "configuration_sha256": "50ee414d81334fe54e34465a8441d8ee5ec237518b06b3759c794056aa3e26a4",
     "artifact_profile_sha256": "a89c382151807edfdaea3e7a4ee67b5b89d7e20f7dbfe64b656aa5858e328037"
   },

--- a/platforms/web/legal/rust-cargo-dependencies/web-editor.json
+++ b/platforms/web/legal/rust-cargo-dependencies/web-editor.json
@@ -36,7 +36,7 @@
     "version": "0.9.1",
     "command_profile": "artifact-profile-runtime",
     "offline": true,
-    "cargo_lock_sha256": "ae7cf8b44c86d3e3383eaddaea065d1feb430234734301e346163720130cf943",
+    "cargo_lock_sha256": "13703a41400a09cb9076292db2aefcccef37fc8e70ee0c76c29e8a165d10fa1c",
     "configuration_sha256": "50ee414d81334fe54e34465a8441d8ee5ec237518b06b3759c794056aa3e26a4",
     "artifact_profile_sha256": "40ed32809ff00898cd9c49a8b9df98f373ccb0651f770d881f9a8891ed74c565"
   },

--- a/platforms/web/legal/rust-cargo-dependencies/web-full.json
+++ b/platforms/web/legal/rust-cargo-dependencies/web-full.json
@@ -42,7 +42,7 @@
     "version": "0.9.1",
     "command_profile": "artifact-profile-runtime",
     "offline": true,
-    "cargo_lock_sha256": "ae7cf8b44c86d3e3383eaddaea065d1feb430234734301e346163720130cf943",
+    "cargo_lock_sha256": "13703a41400a09cb9076292db2aefcccef37fc8e70ee0c76c29e8a165d10fa1c",
     "configuration_sha256": "50ee414d81334fe54e34465a8441d8ee5ec237518b06b3759c794056aa3e26a4",
     "artifact_profile_sha256": "3c7cfbd2829a4a0a797e87113656e16e58afb2f43f7a1d6d4d26ff0616a2936e"
   },

--- a/platforms/web/legal/rust-cargo-dependencies/web-render.json
+++ b/platforms/web/legal/rust-cargo-dependencies/web-render.json
@@ -39,7 +39,7 @@
     "version": "0.9.1",
     "command_profile": "artifact-profile-runtime",
     "offline": true,
-    "cargo_lock_sha256": "ae7cf8b44c86d3e3383eaddaea065d1feb430234734301e346163720130cf943",
+    "cargo_lock_sha256": "13703a41400a09cb9076292db2aefcccef37fc8e70ee0c76c29e8a165d10fa1c",
     "configuration_sha256": "50ee414d81334fe54e34465a8441d8ee5ec237518b06b3759c794056aa3e26a4",
     "artifact_profile_sha256": "40fdc2de531d02980abc495dd84d5d43f66cfc217a1b64e1790f22d62361b5d4"
   },

--- a/playground/public/THIRD_PARTY_LICENSES/rust-cargo-dependencies.json
+++ b/playground/public/THIRD_PARTY_LICENSES/rust-cargo-dependencies.json
@@ -5,7 +5,7 @@
     "version": "0.9.1",
     "command_profile": "workspace-all-features-runtime",
     "offline": true,
-    "cargo_lock_sha256": "ae7cf8b44c86d3e3383eaddaea065d1feb430234734301e346163720130cf943",
+    "cargo_lock_sha256": "13703a41400a09cb9076292db2aefcccef37fc8e70ee0c76c29e8a165d10fa1c",
     "configuration_sha256": "50ee414d81334fe54e34465a8441d8ee5ec237518b06b3759c794056aa3e26a4"
   },
   "licenses": [

--- a/tools/vscode-extension/THIRD_PARTY_LICENSES/rust-cargo-dependencies.json
+++ b/tools/vscode-extension/THIRD_PARTY_LICENSES/rust-cargo-dependencies.json
@@ -5,7 +5,7 @@
     "version": "0.9.1",
     "command_profile": "workspace-all-features-runtime",
     "offline": true,
-    "cargo_lock_sha256": "ae7cf8b44c86d3e3383eaddaea065d1feb430234734301e346163720130cf943",
+    "cargo_lock_sha256": "13703a41400a09cb9076292db2aefcccef37fc8e70ee0c76c29e8a165d10fa1c",
     "configuration_sha256": "50ee414d81334fe54e34465a8441d8ee5ec237518b06b3759c794056aa3e26a4"
   },
   "licenses": [


### PR DESCRIPTION
## Summary

Switch the hash maps and sets in `merman-ascii` module from std's default `RandomState` to `FxHashMap` and `FxHashSet` from `rustc-hash`.
The workspace already depends on `rustc-hash`, and both `merman-core` and the `dugong` layout engine already use `FxHashMap`; this brings `merman-ascii`, which performs a similar type of graph work, in line with that choice.

## Verification

- [x] `cargo fmt --all --check`
- [x] Relevant tests ran
- [x] Benchmark or report updated if this affects performance

## Performance / parity notes

**Benchmark or report**:

`cargo bench --bench ascii_pipeline` against `v0.8.0-alpha.6` (M1 Pro):

| Benchmark                         | Before    | After    | Change |
|-----------------------------------|-----------|----------|--------|
| ascii_end_to_end/flowchart_medium | 18.95 ms  | 9.42 ms  | −50%   |
| ascii_end_to_end/flowchart_large  | 183.41 ms | 83.74 ms | −54%   |

The other fixtures are unchanged within noise.
